### PR TITLE
Detect if Flyway should avoid to check if the actual schema is non-empty

### DIFF
--- a/src/main/java/alfio/config/DataSourceConfiguration.java
+++ b/src/main/java/alfio/config/DataSourceConfiguration.java
@@ -58,6 +58,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.text.ParseException;
 import java.util.EnumSet;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 
@@ -142,10 +143,14 @@ public class DataSourceConfiguration implements ResourceLoaderAware {
         migration.setOutOfOrder(true);
 
         migration.setLocations("alfio/db/" + sqlDialect + "/");
+
+        Optional<String> baselineOnMigrate = Optional.ofNullable(env.getProperty("flyway.baseline-on-migrate"));
+        baselineOnMigrate.ifPresent(s -> migration.setBaselineOnMigrate(Boolean.valueOf(s)));
+
         migration.migrate();
         return migration;
     }
-    
+
     @Bean
     public PasswordEncoder getPasswordEncoder() {
          return new BCryptPasswordEncoder();


### PR DESCRIPTION
Fix the [issue that do not enable Flyway skip the validation of the database schema if there are existing tables on it](https://github.com/alfio-event/alf.io/issues/558)