### PR TITLE
Move Dockerfile to root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN export ZULU_FOLDER=`ls /usr/lib/jvm/` \
     --add-modules jdk.scripting.nashorn,java.desktop,java.logging,java.sql,java.management,java.naming,jdk.unsupported \
     --output /jlinked
 
-FROM alpine:latest
+FROM alpine:3.8
 
 COPY --from=zulu /jlinked /opt/jdk/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,8 @@ RUN mkdir /home/alfio/app
 WORKDIR /home/alfio/app
 
 RUN mkdir logs
-COPY --chown=alfio WEB-INF WEB-INF
-COPY --chown=alfio resources resources
+COPY --chown=alfio src/main/webapp/WEB-INF    WEB-INF
+COPY --chown=alfio src/main/webapp/resources  resources
 
 ENV ALFIO_LOG_STDOUT_ONLY=true
 ENV ALFIO_JAVA_OPTS=""


### PR DESCRIPTION
This simplifies building the Docker image and is best practice AFAIK.

Also pins Alpine to the current latest to improve reproducibility.

Automatic builds can be enabled from a url [such as this one](https://cloud.docker.com/repository/docker/asymmetric/alf.io/builds/edit), by setting:

| Source Type | Source | Docker Tag | Dockerfile location | Build context | Autobuild | Build caching |
| --- | --- | --- | --- | --- | --- | --- |
| Tag | `/^[0-9.]+$/` | `{sourceref}` | `Dockerfile` | `/` | on | on |

See #584.