### PR TITLE
add postgresql 11 to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,11 @@ matrix:
       env: PROFILE="-Dspring.profiles.active=travis -Ddbenv=PGSQL-TRAVIS -Dpgsql10"
       addons:
         postgresql: "10"
+    - name: postgresql 11
+      jdk: oraclejdk11
+      env: PROFILE="-Dspring.profiles.active=travis -Ddbenv=PGSQL-TRAVIS -Dpgsql10"
+      addons:
+        postgresql: "11"
 
 before_script:
   - psql -c 'create database alfio;' -U postgres


### PR DESCRIPTION
given that the README says that Prerequisite is _Postgresql version 9.6 or later_, and that the current version is 11 (and that is now available e.g. on Google Cloud, see https://cloud.google.com/blog/products/databases/enterprise-databases-managed-for-you), how about running ITs in CI against 11 as well? 