### PR TITLE
Add access codes

### DIFF
--- a/src/main/java/alfio/config/DataSourceConfiguration.java
+++ b/src/main/java/alfio/config/DataSourceConfiguration.java
@@ -16,6 +16,7 @@
  */
 package alfio.config;
 
+import alfio.config.support.ArrayColumnMapper;
 import alfio.config.support.JSONColumnMapper;
 import alfio.config.support.PlatformProvider;
 import alfio.job.Jobs;
@@ -130,8 +131,10 @@ public class DataSourceConfiguration implements ResourceLoaderAware {
         return new QueryFactory(platform.getDialect(env), namedParameterJdbcTemplate)
             .addColumnMapperFactory(new ZonedDateTimeMapper.Factory())
             .addColumnMapperFactory(new JSONColumnMapper.Factory())
+            .addColumnMapperFactory(new ArrayColumnMapper.Factory())
             .addParameterConverters(new ZonedDateTimeMapper.Converter())
-            .addParameterConverters(new JSONColumnMapper.Converter());
+            .addParameterConverters(new JSONColumnMapper.Converter())
+            .addParameterConverters(new ArrayColumnMapper.Converter());
     }
 
     @Bean

--- a/src/main/java/alfio/config/support/ArrayColumnMapper.java
+++ b/src/main/java/alfio/config/support/ArrayColumnMapper.java
@@ -1,0 +1,99 @@
+/**
+ * This file is part of alf.io.
+ *
+ * alf.io is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * alf.io is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with alf.io.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package alfio.config.support;
+
+import alfio.model.support.Array;
+import ch.digitalfondue.npjt.mapper.ColumnMapper;
+import ch.digitalfondue.npjt.mapper.ColumnMapperFactory;
+import ch.digitalfondue.npjt.mapper.ParameterConverter;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+
+import java.lang.annotation.Annotation;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.List;
+
+public class ArrayColumnMapper extends ColumnMapper {
+
+    private static final int ORDER = Integer.MAX_VALUE - 30;
+
+    private ArrayColumnMapper(String name, Class<?> paramType) {
+        super(name, paramType);
+    }
+
+    @Override
+    public Object getObject(ResultSet rs) throws SQLException {
+        var array = rs.getArray(name);
+        if(array != null) {
+            return Arrays.asList((Object[]) array.getArray());
+        }
+        return null;
+    }
+
+    private static boolean hasAnnotation(Annotation[] annotations) {
+        return annotations != null
+            && Arrays.stream(annotations).anyMatch(annotation -> annotation.annotationType() == Array.class);
+    }
+
+    public static class Factory implements ColumnMapperFactory {
+        @Override
+        public ColumnMapper build(String name, Class<?> paramType) {
+            return new ArrayColumnMapper(name, paramType);
+        }
+
+        @Override
+        public int order() {
+            return ORDER;
+        }
+
+        @Override
+        public boolean accept(Class<?> paramType, Annotation[] annotations) {
+            return hasAnnotation(annotations);
+        }
+
+        @Override
+        public RowMapper<Object> getSingleColumnRowMapper(Class<Object> clazz) {
+            return (resultSet, rowNum) -> {
+                var array = resultSet.getArray(1);
+                if(array != null) {
+                    return Arrays.asList((Object[]) array.getArray());
+                }
+                return null;
+            };
+        }
+    }
+
+    public static class Converter implements ParameterConverter {
+        @Override
+        public boolean accept(Class<?> parameterType, Annotation[] annotations) {
+            return hasAnnotation(annotations) && List.class.isAssignableFrom(parameterType);
+        }
+
+        @Override
+        public void processParameter(String parameterName, Object arg, Class<?> parameterType, MapSqlParameterSource ps) {
+            Object array = arg != null ? ((List<?>) arg).toArray() : null;
+            ps.addValue(parameterName, array);
+        }
+
+        @Override
+        public int order() {
+            return ORDER;
+        }
+    }
+}

--- a/src/main/java/alfio/controller/api/admin/PromoCodeDiscountApiController.java
+++ b/src/main/java/alfio/controller/api/admin/PromoCodeDiscountApiController.java
@@ -18,7 +18,6 @@ package alfio.controller.api.admin;
 
 import alfio.manager.EventManager;
 import alfio.model.PromoCodeDiscount;
-import alfio.model.PromoCodeDiscount.DiscountType;
 import alfio.model.modification.PromoCodeDiscountModification;
 import alfio.model.modification.PromoCodeDiscountWithFormattedTime;
 import alfio.repository.EventRepository;
@@ -53,11 +52,11 @@ public class PromoCodeDiscountApiController {
         Integer organizationId = promoCode.getOrganizationId();
         ZoneId zoneId = zoneIdFromEventId(eventId, promoCode.getUtcOffset());
         
-        int discount = promoCode.getDiscountType() == DiscountType.FIXED_AMOUNT ? promoCode.getDiscountInCents() : promoCode.getDiscountAsPercent();
+        int discount = promoCode.getDiscountValue();
 
         eventManager.addPromoCode(promoCode.getPromoCode(), eventId, organizationId, promoCode.getStart().toZonedDateTime(zoneId),
             promoCode.getEnd().toZonedDateTime(zoneId), discount, promoCode.getDiscountType(), promoCode.getCategories(), promoCode.getMaxUsage(),
-            promoCode.getDescription(), promoCode.getEmailReference());
+            promoCode.getDescription(), promoCode.getEmailReference(), promoCode.getCodeType(), promoCode.getHiddenCategoryId());
     }
 
     @RequestMapping(value = "/promo-code/{promoCodeId}", method = POST)
@@ -66,7 +65,7 @@ public class PromoCodeDiscountApiController {
         ZoneId zoneId = zoneIdFromEventId(pcd.getEventId(), promoCode.getUtcOffset());
         eventManager.updatePromoCode(promoCodeId, promoCode.getStart().toZonedDateTime(zoneId),
             promoCode.getEnd().toZonedDateTime(zoneId), promoCode.getMaxUsage(), promoCode.getCategories(),
-            promoCode.getDescription(), promoCode.getEmailReference());
+            promoCode.getDescription(), promoCode.getEmailReference(), promoCode.getHiddenCategoryId());
     }
 
     private ZoneId zoneIdFromEventId(Integer eventId, Integer utcOffset) {

--- a/src/main/java/alfio/controller/api/v1/admin/EventApiV1Controller.java
+++ b/src/main/java/alfio/controller/api/v1/admin/EventApiV1Controller.java
@@ -19,11 +19,8 @@ package alfio.controller.api.v1.admin;
 import alfio.extension.ExtensionService;
 import alfio.manager.*;
 import alfio.manager.user.UserManager;
-import alfio.model.Event;
-import alfio.model.EventWithAdditionalInfo;
-import alfio.model.ExtensionSupport;
+import alfio.model.*;
 import alfio.model.ExtensionSupport.ExtensionMetadataValue;
-import alfio.model.TicketCategory;
 import alfio.model.api.v1.admin.EventCreationRequest;
 import alfio.model.group.Group;
 import alfio.model.modification.EventModification;
@@ -211,6 +208,8 @@ public class EventApiV1Controller {
                         Collections.emptyList(),
                         null,
                         null,
+                        null,
+                        PromoCodeDiscount.CodeType.DISCOUNT,
                         null
                     )
                 )

--- a/src/main/java/alfio/controller/decorator/SaleableAdditionalService.java
+++ b/src/main/java/alfio/controller/decorator/SaleableAdditionalService.java
@@ -88,7 +88,8 @@ public class SaleableAdditionalService implements PriceContainer {
 
     @Override
     public Optional<PromoCodeDiscount> getDiscount() {
-        return Optional.ofNullable(promoCodeDiscount).filter(x -> getType() != AdditionalService.AdditionalServiceType.DONATION);
+        return Optional.ofNullable(promoCodeDiscount)
+            .filter(x -> x.getCodeType() == PromoCodeDiscount.CodeType.DISCOUNT && getType() != AdditionalService.AdditionalServiceType.DONATION);
     }
 
     @Override
@@ -114,7 +115,8 @@ public class SaleableAdditionalService implements PriceContainer {
     }
 
     public boolean getSupportsDiscount() {
-        return getType() != AdditionalService.AdditionalServiceType.DONATION && isFixPrice() && promoCodeDiscount != null;
+        return getType() != AdditionalService.AdditionalServiceType.DONATION && isFixPrice()
+            && promoCodeDiscount != null && promoCodeDiscount.getCodeType() == PromoCodeDiscount.CodeType.DISCOUNT;
     }
 
     public boolean getUserDefinedPrice() {

--- a/src/main/java/alfio/controller/decorator/SaleableTicketCategory.java
+++ b/src/main/java/alfio/controller/decorator/SaleableTicketCategory.java
@@ -147,11 +147,11 @@ public class SaleableTicketCategory implements PriceContainer {
     }
 
     public boolean getSupportsDiscount() {
-        return promoCodeDiscount != null && getSaleable();
+        return getPromoCodeDiscount() != null && getSaleable();
     }
 
     public PromoCodeDiscount getPromoCodeDiscount() {
-        return promoCodeDiscount;
+        return (promoCodeDiscount == null || promoCodeDiscount.getCodeType() == PromoCodeDiscount.CodeType.DISCOUNT) ? promoCodeDiscount : null;
     }
 
     static BigDecimal getFinalPriceToDisplay(BigDecimal price, BigDecimal vat, VatStatus vatStatus) {

--- a/src/main/java/alfio/manager/AdminReservationManager.java
+++ b/src/main/java/alfio/manager/AdminReservationManager.java
@@ -454,7 +454,7 @@ public class AdminReservationManager {
             .stream()
             .limit(attendees.size())
             .collect(toList());
-        codes.forEach(c -> specialPriceRepository.updateStatus(c.getId(), SpecialPrice.Status.PENDING.toString(), specialPriceSessionId));
+        codes.forEach(c -> specialPriceRepository.updateStatus(c.getId(), SpecialPrice.Status.PENDING.toString(), specialPriceSessionId, null));
         return codes;
     }
 

--- a/src/main/java/alfio/manager/EventManager.java
+++ b/src/main/java/alfio/manager/EventManager.java
@@ -770,7 +770,9 @@ public class EventManager {
                              List<Integer> categoriesId,
                              Integer maxUsage,
                              String description,
-                             String emailReference) {
+                             String emailReference,
+                             PromoCodeDiscount.CodeType codeType,
+                             Integer hiddenCategoryId) {
 
         Validate.isTrue(promoCode.length() >= 7, "min length is 7 chars");
         Validate.isTrue((eventId != null && organizationId == null) || (eventId == null && organizationId != null), "eventId or organizationId must be not null");
@@ -787,6 +789,10 @@ public class EventManager {
             Validate.isTrue(discountAmount >= 0, "fixed discount amount cannot be less than zero");
         }
 
+        if(PromoCodeDiscount.CodeType.ACCESS == codeType) {
+            Validate.isTrue(hiddenCategoryId != null, "Hidden category is required");
+        }
+
         //
         categoriesId = Optional.ofNullable(categoriesId).orElse(Collections.emptyList()).stream().filter(Objects::nonNull).collect(toList());
         //
@@ -795,18 +801,19 @@ public class EventManager {
             organizationId = eventRepository.findOrganizationIdByEventId(eventId);
         }
 
-        promoCodeRepository.addPromoCode(promoCode, eventId, organizationId, start, end, discountAmount, discountType.toString(), Json.GSON.toJson(categoriesId), maxUsage, description, emailReference);
+        promoCodeRepository.addPromoCode(promoCode, eventId, organizationId, start, end, discountAmount, discountType.toString(), Json.GSON.toJson(categoriesId), maxUsage, description, emailReference, codeType, hiddenCategoryId);
     }
     
     public void deletePromoCode(int promoCodeId) {
         promoCodeRepository.deletePromoCode(promoCodeId);
     }
 
-    public void updatePromoCode(int promoCodeId, ZonedDateTime start, ZonedDateTime end, Integer maxUsage, List<Integer> categories, String description, String emailReference) {
+    public void updatePromoCode(int promoCodeId, ZonedDateTime start, ZonedDateTime end, Integer maxUsage, List<Integer> categories, String description, String emailReference, Integer hiddenCategoryId) {
         Validate.isTrue(StringUtils.length(description) < 1025, "Description can be maximum 1024 chars");
         Validate.isTrue(StringUtils.length(emailReference) < 257, "Description can be maximum 256 chars");
         String categoriesJson = CollectionUtils.isEmpty(categories) ? null : Json.toJson(categories);
-        promoCodeRepository.updateEventPromoCode(promoCodeId, start, end, maxUsage, categoriesJson, description, emailReference);
+
+        promoCodeRepository.updateEventPromoCode(promoCodeId, start, end, maxUsage, categoriesJson, description, emailReference, hiddenCategoryId);
     }
     
     public List<PromoCodeDiscountWithFormattedTime> findPromoCodesInEvent(int eventId) {

--- a/src/main/java/alfio/manager/EventManager.java
+++ b/src/main/java/alfio/manager/EventManager.java
@@ -801,7 +801,11 @@ public class EventManager {
             organizationId = eventRepository.findOrganizationIdByEventId(eventId);
         }
 
-        promoCodeRepository.addPromoCode(promoCode, eventId, organizationId, start, end, discountAmount, discountType.toString(), Json.GSON.toJson(categoriesId), maxUsage, description, emailReference, codeType, hiddenCategoryId);
+        if(codeType == PromoCodeDiscount.CodeType.ACCESS) {
+            discountType = DiscountType.NONE;
+        }
+
+        promoCodeRepository.addPromoCode(promoCode, eventId, organizationId, start, end, discountAmount, discountType, Json.GSON.toJson(categoriesId), maxUsage, description, emailReference, codeType, hiddenCategoryId);
     }
     
     public void deletePromoCode(int promoCodeId) {

--- a/src/main/java/alfio/manager/SpecialPriceTokenGenerator.java
+++ b/src/main/java/alfio/manager/SpecialPriceTokenGenerator.java
@@ -41,7 +41,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 @Log4j2
 @Transactional
-    public class SpecialPriceTokenGenerator {
+public class SpecialPriceTokenGenerator {
 
     private static final char[] ADMITTED_CHARACTERS = new char[]{
             'A', 'B', 'C', 'D', 'E', 'F',

--- a/src/main/java/alfio/manager/system/DataMigrator.java
+++ b/src/main/java/alfio/manager/system/DataMigrator.java
@@ -411,7 +411,7 @@ public class DataMigrator {
                     @Override
                     public Optional<PromoCodeDiscount> getDiscount() {
                         return Optional.ofNullable(ticket.get("discount_amount"))
-                            .map(amount -> new PromoCodeDiscount(0, "", eventId, null, null, null, (int) amount, PromoCodeDiscount.DiscountType.valueOf((String) ticket.get("discount_type")), "", null, null, null));
+                            .map(amount -> new PromoCodeDiscount(0, "", eventId, null, null, null, (int) amount, PromoCodeDiscount.DiscountType.valueOf((String) ticket.get("discount_type")), "", null, null, null, PromoCodeDiscount.CodeType.DISCOUNT, null));
                     }
                 });
             })

--- a/src/main/java/alfio/model/PromoCodeDiscount.java
+++ b/src/main/java/alfio/model/PromoCodeDiscount.java
@@ -33,6 +33,11 @@ import java.util.TreeSet;
 
 @Getter
 public class PromoCodeDiscount {
+
+    public enum CodeType {
+        DISCOUNT,
+        ACCESS
+    }
     
     public enum DiscountType {
         FIXED_AMOUNT, PERCENTAGE
@@ -50,19 +55,24 @@ public class PromoCodeDiscount {
     private final Integer maxUsage;
     private final String description;
     private final String emailReference;
+    private final CodeType codeType;
+    private final Integer hiddenCategoryId;
     
     public PromoCodeDiscount(@Column("id")int id, 
-            @Column("promo_code") String promoCode, 
-            @Column("event_id_fk") Integer eventId,
-            @Column("organization_id_fk") Integer organizationId,
-            @Column("valid_from") ZonedDateTime utcStart, 
-            @Column("valid_to") ZonedDateTime utcEnd, 
-            @Column("discount_amount") int discountAmount,
-            @Column("discount_type") DiscountType discountType,
-            @Column("categories") String categories,
-            @Column("max_usage") Integer maxUsage,
-            @Column("description") String description,
-            @Column("email_reference") String emailReference) {
+                             @Column("promo_code") String promoCode,
+                             @Column("event_id_fk") Integer eventId,
+                             @Column("organization_id_fk") Integer organizationId,
+                             @Column("valid_from") ZonedDateTime utcStart,
+                             @Column("valid_to") ZonedDateTime utcEnd,
+                             @Column("discount_amount") int discountAmount,
+                             @Column("discount_type") DiscountType discountType,
+                             @Column("categories") String categories,
+                             @Column("max_usage") Integer maxUsage,
+                             @Column("description") String description,
+                             @Column("email_reference") String emailReference,
+                             @Column("code_type") CodeType codeType,
+                             @Column("hidden_category_id") Integer hiddenCategoryId) {
+
         this.id = id;
         this.promoCode = promoCode;
         this.eventId = eventId;
@@ -80,6 +90,8 @@ public class PromoCodeDiscount {
         }
         this.description = description;
         this.emailReference = emailReference;
+        this.codeType = codeType;
+        this.hiddenCategoryId = hiddenCategoryId;
     }
     
     public boolean isCurrentlyValid(ZoneId eventZoneId, ZonedDateTime now) {

--- a/src/main/java/alfio/model/PromoCodeDiscount.java
+++ b/src/main/java/alfio/model/PromoCodeDiscount.java
@@ -40,7 +40,7 @@ public class PromoCodeDiscount {
     }
     
     public enum DiscountType {
-        FIXED_AMOUNT, PERCENTAGE
+        FIXED_AMOUNT, PERCENTAGE, NONE
     }
 
     private final int id;
@@ -112,7 +112,10 @@ public class PromoCodeDiscount {
     }
 
     public static Set<Integer> categoriesOrNull(PromoCodeDiscount code) {
-        Set<Integer> categories = code.getCategories();
-        return CollectionUtils.isEmpty(categories) ? null : categories;
+        if(code.codeType == CodeType.DISCOUNT) {
+            Set<Integer> categories = code.getCategories();
+            return CollectionUtils.isEmpty(categories) ? null : categories;
+        }
+        return Set.of(code.hiddenCategoryId);
     }
 }

--- a/src/main/java/alfio/model/SpecialPrice.java
+++ b/src/main/java/alfio/model/SpecialPrice.java
@@ -37,6 +37,7 @@ public class SpecialPrice {
     private final ZonedDateTime sentTimestamp;
     private final String recipientName;
     private final String recipientEmail;
+    private final Integer accessCodeId;
 
     public SpecialPrice(@Column("id") int id,
                         @Column("code") String code,
@@ -46,7 +47,8 @@ public class SpecialPrice {
                         @Column("session_id") String sessionIdentifier,
                         @Column("sent_ts") ZonedDateTime sentTimestamp,
                         @Column("recipient_name") String recipientName,
-                        @Column("recipient_email") String recipientEmail) {
+                        @Column("recipient_email") String recipientEmail,
+                        @Column("access_code_id_fk") Integer accessCodeId) {
         this.id = id;
         this.code = code;
         this.priceInCents = priceInCents;
@@ -56,6 +58,7 @@ public class SpecialPrice {
         this.sentTimestamp = sentTimestamp;
         this.recipientName = recipientName;
         this.recipientEmail = recipientEmail;
+        this.accessCodeId = accessCodeId;
     }
 
     public boolean notSent() {

--- a/src/main/java/alfio/model/modification/PromoCodeDiscountModification.java
+++ b/src/main/java/alfio/model/modification/PromoCodeDiscountModification.java
@@ -16,6 +16,7 @@
  */
 package alfio.model.modification;
 
+import alfio.model.PromoCodeDiscount;
 import alfio.model.PromoCodeDiscount.DiscountType;
 import alfio.util.MonetaryUtil;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -44,21 +45,26 @@ public class PromoCodeDiscountModification {
     private final Integer maxUsage;
     private final String description;
     private final String emailReference;
+    private final PromoCodeDiscount.CodeType codeType;
+    private final Integer hiddenCategoryId;
+
 
     @JsonCreator
     public PromoCodeDiscountModification(
-            @JsonProperty("organizationId") Integer organizationId,
-            @JsonProperty("eventId") Integer eventId,
-            @JsonProperty("promoCode") String promoCode,
-            @JsonProperty("start") DateTimeModification start,
-            @JsonProperty("end") DateTimeModification end,
-            @JsonProperty("discountAmount") BigDecimal discountAmount,
-            @JsonProperty("discountType") DiscountType discountType,
-            @JsonProperty("categories") List<Integer> categories,
-            @JsonProperty("utcOffset") Integer utcOffset,
-            @JsonProperty("maxUsage") Integer maxUsage,
-            @JsonProperty("description") String description,
-            @JsonProperty("emailReference") String emailReference) {
+        @JsonProperty("organizationId") Integer organizationId,
+        @JsonProperty("eventId") Integer eventId,
+        @JsonProperty("promoCode") String promoCode,
+        @JsonProperty("start") DateTimeModification start,
+        @JsonProperty("end") DateTimeModification end,
+        @JsonProperty("discountAmount") BigDecimal discountAmount,
+        @JsonProperty("discountType") DiscountType discountType,
+        @JsonProperty("categories") List<Integer> categories,
+        @JsonProperty("utcOffset") Integer utcOffset,
+        @JsonProperty("maxUsage") Integer maxUsage,
+        @JsonProperty("description") String description,
+        @JsonProperty("emailReference") String emailReference,
+        @JsonProperty("codeType") PromoCodeDiscount.CodeType codeType,
+        @JsonProperty("hiddenCategoryId") Integer hiddenCategoryId) {
 
         this.organizationId = organizationId;
         this.eventId = eventId;
@@ -72,13 +78,25 @@ public class PromoCodeDiscountModification {
         this.maxUsage = maxUsage;
         this.description = description;
         this.emailReference = emailReference;
+        this.codeType = Optional.ofNullable(codeType).orElse(PromoCodeDiscount.CodeType.DISCOUNT);
+        this.hiddenCategoryId = hiddenCategoryId;
     }
     
     public int getDiscountAsPercent() {
-        return discountAmount.intValue();
+        return Optional.ofNullable(discountAmount).map(BigDecimal::intValue).orElse(0);
     }
     
     public int getDiscountInCents() {
         return MonetaryUtil.unitToCents(discountAmount);
+    }
+
+    public int getDiscountValue() {
+        if(codeType != PromoCodeDiscount.CodeType.DISCOUNT) {
+            return 0;
+        }
+        if(discountType == DiscountType.PERCENTAGE) {
+            return getDiscountAsPercent();
+        }
+        return getDiscountInCents();
     }
 }

--- a/src/main/java/alfio/model/support/Array.java
+++ b/src/main/java/alfio/model/support/Array.java
@@ -1,0 +1,11 @@
+package alfio.model.support;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PARAMETER, ElementType.METHOD})
+public @interface Array {
+}

--- a/src/main/java/alfio/model/support/Array.java
+++ b/src/main/java/alfio/model/support/Array.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of alf.io.
+ *
+ * alf.io is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * alf.io is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with alf.io.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package alfio.model.support;
 
 import java.lang.annotation.ElementType;

--- a/src/main/java/alfio/repository/PromoCodeDiscountRepository.java
+++ b/src/main/java/alfio/repository/PromoCodeDiscountRepository.java
@@ -52,7 +52,7 @@ public interface PromoCodeDiscountRepository {
                      @Bind("start") ZonedDateTime start,
                      @Bind("end") ZonedDateTime end,
                      @Bind("discountAmount") int discountAmount,
-                     @Bind("discountType") String discountType,
+                     @Bind("discountType") PromoCodeDiscount.DiscountType discountType,
                      @Bind("categories") String categories,
                      @Bind("maxUsage") Integer maxUsage,
                      @Bind("description") String description,

--- a/src/main/java/alfio/repository/PromoCodeDiscountRepository.java
+++ b/src/main/java/alfio/repository/PromoCodeDiscountRepository.java
@@ -44,8 +44,8 @@ public interface PromoCodeDiscountRepository {
     @Query("select * from promo_code where id = :id")
     Optional<PromoCodeDiscount> findOptionalById(@Bind("id") int id);
 
-    @Query("insert into promo_code(promo_code, event_id_fk, organization_id_fk, valid_from, valid_to, discount_amount, discount_type, categories, max_usage, description, email_reference) "
-        + " values (:promoCode, :eventId, :organizationId, :start, :end, :discountAmount, :discountType, :categories, :maxUsage, :description, :emailReference)")
+    @Query("insert into promo_code(promo_code, event_id_fk, organization_id_fk, valid_from, valid_to, discount_amount, discount_type, categories, max_usage, description, email_reference, code_type, hidden_category_id) "
+        + " values (:promoCode, :eventId, :organizationId, :start, :end, :discountAmount, :discountType, :categories, :maxUsage, :description, :emailReference, :codeType, :hiddenCategoryId)")
     int addPromoCode(@Bind("promoCode") String promoCode,
                      @Bind("eventId") Integer eventId,
                      @Bind("organizationId") int organizationId,
@@ -56,7 +56,9 @@ public interface PromoCodeDiscountRepository {
                      @Bind("categories") String categories,
                      @Bind("maxUsage") Integer maxUsage,
                      @Bind("description") String description,
-                     @Bind("emailReference") String emailReference);
+                     @Bind("emailReference") String emailReference,
+                     @Bind("codeType") PromoCodeDiscount.CodeType codeType,
+                     @Bind("hiddenCategoryId") Integer hiddenCategoryId);
 
     @Query("select * from promo_code where promo_code = :promoCode and ("
         +" event_id_fk = :eventId or "
@@ -75,12 +77,13 @@ public interface PromoCodeDiscountRepository {
     @Query("update promo_code set valid_to = :end where id = :id")
     int updateEventPromoCodeEnd(@Bind("id") int id, @Bind("end") ZonedDateTime end);
 
-    @Query("update promo_code set valid_from = :start, valid_to = :end, max_usage = :maxUsage, categories = :categories, description = :description, email_reference = :emailReference where id = :id")
+    @Query("update promo_code set valid_from = :start, valid_to = :end, max_usage = :maxUsage, categories = :categories, description = :description, email_reference = :emailReference, hidden_category_id = :hiddenCategoryId where id = :id")
     int updateEventPromoCode(@Bind("id") int id,
                              @Bind("start") ZonedDateTime start,
                              @Bind("end") ZonedDateTime end,
                              @Bind("maxUsage") Integer maxUsage,
                              @Bind("categories") String categories,
                              @Bind("description") String description,
-                             @Bind("emailReference") String emailReference);
+                             @Bind("emailReference") String emailReference,
+                             @Bind("hiddenCategoryId") Integer hiddenCategoryId);
 }

--- a/src/main/java/alfio/repository/TicketCategoryRepository.java
+++ b/src/main/java/alfio/repository/TicketCategoryRepository.java
@@ -127,4 +127,7 @@ public interface TicketCategoryRepository {
     default Map<Integer, TicketCategoryStatisticView> findStatisticsForEventIdByCategoryId(int eventId) {
         return findStatisticsForEventId(eventId).stream().collect(Collectors.toMap(TicketCategoryStatisticView::getId, Function.identity()));
     }
+
+    @Query("select access_restricted from ticket_category where id = :id")
+    Boolean isAccessRestricted(@Bind("id") Integer hiddenCategoryId);
 }

--- a/src/main/java/alfio/repository/TicketRepository.java
+++ b/src/main/java/alfio/repository/TicketRepository.java
@@ -20,6 +20,7 @@ import alfio.model.*;
 import ch.digitalfondue.npjt.Bind;
 import ch.digitalfondue.npjt.Query;
 import ch.digitalfondue.npjt.QueryRepository;
+import ch.digitalfondue.npjt.QueryType;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
@@ -94,7 +95,10 @@ public interface TicketRepository {
 
     @Query("update ticket set tickets_reservation_id = :reservationId, status = 'PENDING', category_id = :categoryId, user_language = :userLanguage, src_price_cts = :srcPriceCts where id in (:reservedForUpdate)")
     int reserveTickets(@Bind("reservationId") String reservationId, @Bind("reservedForUpdate") List<Integer> reservedForUpdate, @Bind("categoryId") int categoryId, @Bind("userLanguage") String userLanguage, @Bind("srcPriceCts") int srcPriceCts);
-    
+
+    @Query(type = QueryType.TEMPLATE, value = "update ticket set tickets_reservation_id = :reservationId, special_price_id_fk = :specialCodeId, user_language = :userLanguage, status = 'PENDING', src_price_cts = :srcPriceCts where id = :ticketId")
+    String batchReserveTicket();
+
     @Query("update ticket set tickets_reservation_id = :reservationId, special_price_id_fk = :specialCodeId, user_language = :userLanguage, status = 'PENDING', src_price_cts = :srcPriceCts where id = :ticketId")
     void reserveTicket(@Bind("reservationId")String transactionId, @Bind("ticketId") int ticketId, @Bind("specialCodeId") int specialCodeId, @Bind("userLanguage") String userLanguage, @Bind("srcPriceCts") int srcPriceCts);
 

--- a/src/main/resources/alfio/db/PGSQL/V202_2.0.0.11__ADD_PROMO_CODE_FOR_HIDDEN_CATEGORIES.sql
+++ b/src/main/resources/alfio/db/PGSQL/V202_2.0.0.11__ADD_PROMO_CODE_FOR_HIDDEN_CATEGORIES.sql
@@ -1,0 +1,22 @@
+--
+-- This file is part of alf.io.
+--
+-- alf.io is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- alf.io is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with alf.io.  If not, see <http://www.gnu.org/licenses/>.
+--
+
+alter table promo_code add column code_type varchar(255) not null default 'DISCOUNT';
+alter table promo_code add column hidden_category_id integer;
+alter table promo_code add constraint if_access_code_then_hidden_category_not_null
+    CHECK ( (code_type <> 'ACCESS' ) OR (hidden_category_id is not null) );
+-- alter table promo_code add FOREIGN KEY (hidden_category_id) REFERENCES ticket_category(id);

--- a/src/main/resources/alfio/db/PGSQL/V202_2.0.0.11__ADD_PROMO_CODE_FOR_HIDDEN_CATEGORIES.sql
+++ b/src/main/resources/alfio/db/PGSQL/V202_2.0.0.11__ADD_PROMO_CODE_FOR_HIDDEN_CATEGORIES.sql
@@ -19,4 +19,33 @@ alter table promo_code add column code_type varchar(255) not null default 'DISCO
 alter table promo_code add column hidden_category_id integer;
 alter table promo_code add constraint if_access_code_then_hidden_category_not_null
     CHECK ( (code_type <> 'ACCESS' ) OR (hidden_category_id is not null) );
--- alter table promo_code add FOREIGN KEY (hidden_category_id) REFERENCES ticket_category(id);
+alter table promo_code drop constraint "check_discount_type";
+alter table promo_code add constraint "check_discount_type" check (discount_type = 'FIXED_AMOUNT' OR discount_type = 'PERCENTAGE' or discount_type = 'NONE');
+
+alter table special_price add column access_code_id_fk integer;
+alter table special_price add constraint "access_code_promo_code_id" foreign key (access_code_id_fk) references promo_code(id);
+
+CREATE OR REPLACE FUNCTION trf_check_access_code_allocation()
+    RETURNS TRIGGER AS
+$body$
+DECLARE
+    r_count numeric;
+BEGIN
+    IF (NEW.access_code_id_fk is not null) THEN
+        -- serialize by locking all tokens for the current category
+        PERFORM * from special_price where ticket_category_id = NEW.ticket_category_id for update;
+        r_count = (select count(*) from special_price where access_code_id_fk = NEW.access_code_id_fk);
+        PERFORM max_usage from promo_code where id = NEW.access_code_id_fk and max_usage is not null and
+               max_usage < r_count;
+        IF FOUND THEN
+            raise EXCEPTION USING MESSAGE = ('Max usage exceeded. Tokens requested: ' || r_count);
+        END IF;
+    END IF;
+    RETURN NULL;
+END
+$body$
+    LANGUAGE plpgsql;
+
+CREATE TRIGGER tr_check_access_code_allocation
+    AFTER UPDATE ON special_price
+    FOR EACH ROW EXECUTE PROCEDURE trf_check_access_code_allocation();

--- a/src/main/webapp/WEB-INF/templates/event/ticket-category.ms
+++ b/src/main/webapp/WEB-INF/templates/event/ticket-category.ms
@@ -48,13 +48,7 @@
             {{#saleableAndLimitNotReached}}
                 <input name="reservation[{{-index}}].ticketCategoryId" value="{{id}}" type="hidden">
                 <select aria-labelledby="{{id}}-label" name="reservation[{{-index}}].amount" class="form-control text-align-center" placeholder="0" autocomplete="off" data-ticket-selector>
-                    {{#accessRestricted}}
-                        <option value="0">0</option>
-                        <option value="1">1</option>
-                    {{/accessRestricted}}
-                    {{^accessRestricted}}
                         {{#amountOfTickets}}<option value="{{this}}">{{this}}</option>{{/amountOfTickets}}
-                    {{/accessRestricted}}
                 </select>
             {{/saleableAndLimitNotReached}}
             {{^saleableAndLimitNotReached}}

--- a/src/main/webapp/resources/js/admin/feature/promo-codes/edit-date-promo-code-modal.html
+++ b/src/main/webapp/resources/js/admin/feature/promo-codes/edit-date-promo-code-modal.html
@@ -4,8 +4,13 @@
 <form name="promoCodeForm" data-ng-submit="update(promocode)" novalidate data-error-sensitive>
     <div class="modal-body">
         <div class="form-group" bs-form-error="promocode.dateString">
-            <label for="date">Validity range <span ng-if="!forEvent">(Note: these dates are in your current timezone)</span><span ng-if="forEvent">(Note: these dates will use the timezone from the event)</span></label>
-            <input type="text" data-date-range data-start-model="promocode.start" min-date="true" data-end-model="promocode.end" data-ng-model="promocode.dateString" name="date" id="date" class="form-control" required />
+            <label for="date">Validity range <span ng-if="!forEvent">(Note: these dates are in your current timezone)</span></label>
+            <div class="input-group">
+                <input type="text" data-date-range data-start-model="promocode.start" min-date="true" data-end-model="promocode.end" data-ng-model="promocode.dateString" name="date" id="date" class="form-control" required />
+                <div class="input-group-addon" ng-if="forEvent">
+                    <span>{{event.timeZone}}</span>
+                </div>
+            </div>
             <field-error data-form-obj="promocode" data-field-obj="promocode.dateString" data-show-existing-errors="showExistingErrors"></field-error>
         </div>
         <div class="form-group" bs-form-error="promocode.maxUsage">
@@ -13,7 +18,7 @@
             <input type="number" data-ng-model="promocode.maxUsage" name="maxUsage" id="maxUsage" class="form-control">
             <field-error data-form-obj="promocode" data-field-obj="promocode.maxUsage" data-show-existing-errors="showExistingErrors"></field-error>
         </div>
-        <div class="form-group">
+        <div class="form-group" ng-if="forEvent && promocode.codeType == 'DISCOUNT'">
             <label>Restrict to categories</label>
             <ul class="list-unstyled">
                 <li ng-repeat="category in validCategories"><label><input type="checkbox" ng-model="category.selected"> {{::category.name}}</label></li>
@@ -33,9 +38,11 @@
     </div>
 
     <div class="modal-footer">
-        <div>
-            <button type="submit" class="btn btn-primary" data-ng-disabled="promoCodeForm.$waiting || promoCodeForm.$invalid">Save</button>
-            <button type="button" class="btn btn-default" data-ng-disabled="promoCodeForm.$waiting" data-ng-click="cancel()">Cancel</button>
+        <div class="col-md-4 col-md-push-8 col-xs-12">
+            <button type="submit" class="btn btn-lg btn-warning btn-block" data-ng-disabled="promoCodeForm.$waiting || promoCodeForm.$invalid" style="margin-bottom: 10px">Save</button>
+        </div>
+        <div class="col-md-4 col-md-pull-4 col-xs-12">
+            <button type="button" class="btn btn-lg btn-default btn-block" data-ng-disabled="promoCodeForm.$waiting" data-ng-click="cancel()" style="margin-bottom: 10px">Cancel</button>
         </div>
     </div>
 </form>

--- a/src/main/webapp/resources/js/admin/feature/promo-codes/edit-promo-code-modal.html
+++ b/src/main/webapp/resources/js/admin/feature/promo-codes/edit-promo-code-modal.html
@@ -3,34 +3,45 @@
 </div>
 <form name="promoCodeForm" data-ng-submit="update(promoCodeForm, promocode)" novalidate data-error-sensitive>
     <div class="modal-body">
+        <div class="col-xs-12 col-md-8 col-md-offset-2" ng-if="restrictedCategories && restrictedCategories.length > 0">
+            <div class="form-group">
+                <label class="control-label">Code type</label>
+                <div>
+                    <div class="radio-inline">
+                        <label>
+                            <input type="radio" name="codeType" data-ng-model="promocode.codeType" data-ng-value="'DISCOUNT'" required>
+                            Discount Code
+                        </label>
+                    </div>
+                    <div class="radio-inline">
+                        <label>
+                            <input type="radio" name="codeType" data-ng-model="promocode.codeType" data-ng-value="'ACCESS'" required>
+                            Access hidden Category
+                        </label>
+                    </div>
+                </div>
+            </div>
+        </div>
         <div class="col-sm-12 col-md-8 col-md-offset-2">
             <div class="form-group" bs-form-error="promocode.promoCode">
-                <label for="promoCode">{{promoCodeDescription}} code name (min length is 7 characters)</label>
+                <label for="promoCode">name (min length is 7 characters)</label>
                 <input type="text" id="promoCode" data-ng-model="promocode.promoCode" class="form-control to-uppercase" required minlength="7"/>
                 <field-error data-form-obj="promocode" data-field-obj="promocode.promoCode" data-show-existing-errors="showExistingErrors"></field-error>
             </div>
-            
-            
+
+
             <div class="form-group" bs-form-error="promocode.dateString">
-                <label for="date">Validity range <span ng-if="!forEvent">(Note: these dates are in your current timezone)</span><span ng-if="forEvent">(Note: these dates will use the timezone from the event)</span></label>
-                <input type="text" data-date-range data-start-model="promocode.start" min-date="true" data-end-model="promocode.end" data-ng-model="promocode.dateString" name="date" id="date" class="form-control" required />
+                <label for="date">Validity range <span ng-if="!forEvent">(Note: these dates are in your current timezone)</span></label>
+                <div class="input-group">
+                    <input type="text" data-date-range data-start-model="promocode.start" min-date="true" data-end-model="promocode.end" data-ng-model="promocode.dateString" name="date" id="date" class="form-control" required />
+                    <div class="input-group-addon" ng-if="forEvent">
+                        <span>{{event.timeZone}}</span>
+                    </div>
+                </div>
                 <field-error data-form-obj="promocode" data-field-obj="promocode.dateString" data-show-existing-errors="showExistingErrors"></field-error>
             </div>
 
-            <div class="form-group" ng-if="forEvent">
-                <label>Restrict to categories</label>
-                <ul>
-                    <li ng-repeat="category in validCategories"><label><input type="checkbox" ng-true-value="{{::category.id}}" ng-false-value="null" ng-model="promocode.categories[$index]"> {{::category.name}}</label></li>
-                </ul>
-            </div>
-
-            <div class="form-group" bs-form-error="promocode.maxUsage">
-                <label for="maxUsage">Limit usage to</label>
-                <input type="number" data-ng-model="promocode.maxUsage" name="maxUsage" id="maxUsage" class="form-control">
-                <field-error data-form-obj="promocode" data-field-obj="promocode.maxUsage" data-show-existing-errors="showExistingErrors"></field-error>
-            </div>
-
-            <div class="form-group">
+            <div class="form-group" ng-if="promocode.codeType == 'DISCOUNT'">
                 <label class="control-label">Discount type</label>
                 <div>
                     <div class="radio-inline">
@@ -47,8 +58,8 @@
                     </div>
                 </div>
             </div>
-                    
-            <div class="form-group" bs-form-error="promocode.discountAmount">
+
+            <div class="form-group" bs-form-error="promocode.discountAmount" ng-if="promocode.codeType == 'DISCOUNT'">
                 <label for="promoCode">Discount amount</label>
                 <div class="input-group">
                     <input type="number" id="discountAmount" data-ng-model="promocode.discountAmount" class="form-control" min="0" required/>
@@ -59,6 +70,28 @@
                 </div>
                 <field-error data-form-obj="discountAmount" data-field-obj="promocode.discountAmount" data-show-existing-errors="showExistingErrors"></field-error>
             </div>
+
+
+            <div class="form-group" ng-if="forEvent && promocode.codeType == 'DISCOUNT'">
+                <label>Restrict to categories</label>
+                <ul class="list-unstyled">
+                    <li ng-repeat="category in validCategories"><label><input type="checkbox" ng-true-value="{{::category.id}}" ng-false-value="null" ng-model="promocode.categories[$index]"> {{::category.name}}</label></li>
+                </ul>
+            </div>
+
+            <div class="form-group" ng-if="forEvent && promocode.codeType == 'ACCESS'">
+                <label>Gives access to category:</label>
+                <ul class="list-unstyled">
+                    <li ng-repeat="category in restrictedCategories"><label><input type="radio" ng-model="promocode.hiddenCategoryId" name="hiddenCategory" ng-value="category.id" required> {{::category.name}}</label></li>
+                </ul>
+            </div>
+
+            <div class="form-group" bs-form-error="promocode.maxUsage">
+                <label for="maxUsage">Limit usage to</label>
+                <input type="number" data-ng-model="promocode.maxUsage" name="maxUsage" id="maxUsage" class="form-control">
+                <field-error data-form-obj="promocode" data-field-obj="promocode.maxUsage" data-show-existing-errors="showExistingErrors"></field-error>
+            </div>
+
             <div class="form-group">
                 <label for="description">Description</label>
                 <input class="form-control" id="description" ng-model="promocode.description" name="description" maxlength="1024">
@@ -74,9 +107,11 @@
     </div>
 
     <div class="modal-footer">
-        <div>
-            <button type="submit" class="btn btn-success" data-ng-disabled="promoCodeForm.$waiting || promoCodeForm.$invalid" data-ng-click="ok(formObj)">Save</button>
-            <button type="button" class="btn btn-default" data-ng-disabled="promoCodeForm.$waiting" data-ng-click="cancel()">Cancel</button>
+        <div class="col-md-4 col-md-push-8 col-xs-12">
+            <button type="submit" class="btn btn-lg btn-warning btn-block" data-ng-disabled="promoCodeForm.$waiting || promoCodeForm.$invalid" data-ng-click="ok(formObj)" style="margin-bottom: 10px">Save</button>
+        </div>
+        <div class="col-md-4 col-md-pull-4 col-xs-12">
+            <button type="button" class="btn btn-lg btn-default btn-block" data-ng-disabled="promoCodeForm.$waiting" data-ng-click="cancel()" style="margin-bottom: 10px">Cancel</button>
         </div>
     </div>
 </form>

--- a/src/main/webapp/resources/js/admin/feature/promo-codes/promo-codes.html
+++ b/src/main/webapp/resources/js/admin/feature/promo-codes/promo-codes.html
@@ -10,6 +10,7 @@
         <table class="table" data-ng-if="$ctrl.promocodes.length > 0">
             <thead>
             <tr>
+                <th ng-if="$ctrl.forEvent">&nbsp;</th>
                 <th>Code</th>
                 <th width="2%">#</th>
                 <th width="2%">Max</th>
@@ -24,22 +25,28 @@
             </thead>
             <tbody>
             <tr data-ng-repeat="promocode in $ctrl.promocodes" data-ng-class="{'text-muted': promocode.expired}">
+                <td ng-if="$ctrl.forEvent"><i class="fa" data-ng-class="{'fa-percent': promocode.codeType === 'DISCOUNT', 'fa-unlock': promocode.codeType === 'ACCESS'}"></i></td>
                 <td>{{::promocode.promoCode}} <span data-ng-if="promocode.expired">(Expired)</span></td>
                 <td class="text-right">{{promocode.useCount}}</td>
                 <td class="text-right">{{promocode.maxUsage}}</td>
                 <td>{{::promocode.formattedStart | formatDate}}</td>
                 <td>{{::promocode.formattedEnd | formatDate}}</td>
                 <td>
-                    <span data-ng-if="promocode.discountType === 'PERCENTAGE'">-{{::promocode.discountAmount}}%</span>
-                    <span data-ng-if="promocode.discountType === 'FIXED_AMOUNT'">-{{::promocode.formattedDiscountAmount | currency : ($ctrl.event.currency || "")}}</span>
+                    <span data-ng-if="promocode.codeType !== 'DISCOUNT'">&nbsp;</span>
+                    <span data-ng-if="promocode.codeType === 'DISCOUNT' && promocode.discountType === 'PERCENTAGE'">-{{::promocode.discountAmount}}%</span>
+                    <span data-ng-if="promocode.codeType === 'DISCOUNT' && promocode.discountType === 'FIXED_AMOUNT'">-{{::promocode.formattedDiscountAmount | currency : ($ctrl.event.currency || "")}}</span>
                 </td>
-                <td ng-if="$ctrl.forEvent"><div ng-if="promocode.categories.length > 0"><p ng-repeat="categoryId in promocode.categories">{{::$ctrl.ticketCategoriesById[categoryId].name}}</p></div><div class="text-muted" ng-if="promocode.categories.length == 0 || promocode.categories == null">Apply to all</div></td>
+                <td ng-if="$ctrl.forEvent">
+                    <div ng-if="promocode.categories.length > 0"><p ng-repeat="categoryId in promocode.categories">{{::$ctrl.ticketCategoriesById[categoryId].name}}</p></div>
+                    <div ng-if="promocode.hiddenCategoryId">{{::$ctrl.ticketCategoriesById[promocode.hiddenCategoryId].name}}</div>
+                    <div class="text-muted" ng-if="promocode.codeType === 'DISCOUNT' && (promocode.categories == null || promocode.categories.length == 0)">Apply to all</div>
+                </td>
                 <td ng-bind="promocode.description"></td>
                 <td ng-bind="promocode.emailReference"></td>
                 <td>
-                    <button class="btn btn-sm btn-default" ng-click="$ctrl.changeDate(promocode)"><i class="fa fa-edit"></i> Edit Settings</button>
-                    <button data-ng-hide="promocode.expired" class="btn btn-sm btn-default" data-ng-click="$ctrl.disablePromocode(promocode)"><i class="fa fa-remove"></i> Disable</button>
-                    <button data-ng-show="promocode.useCount === 0" class="btn btn-sm btn-default" data-ng-click="$ctrl.deletePromocode(promocode)"><i class="fa fa-trash"></i> Delete</button>
+                    <button class="btn btn-xs btn-default" ng-click="$ctrl.changeDate(promocode)"><i class="fa fa-edit"></i> Edit Settings</button>
+                    <button data-ng-hide="promocode.expired" class="btn btn-xs btn-default" data-ng-click="$ctrl.disablePromocode(promocode)"><i class="fa fa-remove"></i> Disable</button>
+                    <button data-ng-show="promocode.useCount === 0" class="btn btn-xs btn-default" data-ng-click="$ctrl.deletePromocode(promocode)"><i class="fa fa-trash"></i> Delete</button>
                 </td>
             </tr>
             </tbody>

--- a/src/main/webapp/resources/js/admin/feature/promo-codes/promo-codes.js
+++ b/src/main/webapp/resources/js/admin/feature/promo-codes/promo-codes.js
@@ -24,7 +24,7 @@
 
         ctrl.$onInit = function() {
             loadData();
-        }
+        };
 
         function loadData() {
             var loader = ctrl.forEvent ? function () {return PromoCodeService.list(ctrl.event.id)} : function() {return PromoCodeService.listOrganization(ctrl.organizationId)};
@@ -88,6 +88,7 @@
                 controller: function($scope) {
                     $scope.cancel = function() {$scope.$dismiss('canceled');};
                     $scope.forEvent = ctrl.forEvent;
+                    $scope.event = ctrl.event;
                     var start = moment(promocode.formattedStart);
                     var end = moment(promocode.formattedEnd);
                     $scope.promoCodeDescription = ctrl.promoCodeDescription;
@@ -96,7 +97,9 @@
                         end: {date: end.format('YYYY-MM-DD'), time: end.format('HH:mm')},
                         maxUsage: promocode.maxUsage,
                         description: promocode.description,
-                        emailReference: promocode.emailReference
+                        emailReference: promocode.emailReference,
+                        codeType: promocode.codeType,
+                        hiddenCategoryId: promocode.hiddenCategoryId
                     };
                     $scope.validCategories = _.map(ctrl.event.ticketCategories, function(c) {
                         var c1 = angular.copy(c, {});
@@ -165,7 +168,11 @@
 
                     if(forEvent) {
                         $scope.validCategories = _.filter(event.ticketCategories, function(tc) {
-                            return !tc.expired;
+                            return !tc.expired && !tc.accessRestricted;
+                        });
+
+                        $scope.restrictedCategories = _.filter(event.ticketCategories, function(tc) {
+                            return !tc.expired && tc.accessRestricted;
                         });
                     }
 
@@ -174,7 +181,9 @@
                         discountType :'PERCENTAGE',
                         start : {date: now.format('YYYY-MM-DD'), time: now.format('HH:mm')},
                         end: {date: eventBegin.format('YYYY-MM-DD'), time: eventBegin.format('HH:mm')},
-                        categories:[]
+                        categories:[],
+                        codeType: 'DISCOUNT',
+                        hiddenCategoryId: null
                     };
 
                     $scope.addCategory = function addCategory(index, value) {

--- a/src/test/java/alfio/controller/ReservationFlowIntegrationTest.java
+++ b/src/test/java/alfio/controller/ReservationFlowIntegrationTest.java
@@ -221,7 +221,7 @@ public class ReservationFlowIntegrationTest extends BaseIntegrationTest {
         invoiceReceiptController = new InvoiceReceiptController(eventRepository, ticketReservationManager, fileUploadManager, templateManager, configurationManager, extensionManager);
 
         //promo code at event level
-        eventManager.addPromoCode(PROMO_CODE, event.getId(), null, ZonedDateTime.now().minusDays(2), event.getEnd().plusDays(2), 10, PromoCodeDiscount.DiscountType.PERCENTAGE, null, 3, "description", "test@test.ch");
+        eventManager.addPromoCode(PROMO_CODE, event.getId(), null, ZonedDateTime.now().minusDays(2), event.getEnd().plusDays(2), 10, PromoCodeDiscount.DiscountType.PERCENTAGE, null, 3, "description", "test@test.ch", PromoCodeDiscount.CodeType.DISCOUNT, null);
     }
 
     private static final String PROMO_CODE = "MYPROMOCODE";

--- a/src/test/java/alfio/manager/SpecialPriceManagerTest.java
+++ b/src/test/java/alfio/manager/SpecialPriceManagerTest.java
@@ -72,7 +72,7 @@ public class SpecialPriceManagerTest {
         i18nManager = mock(I18nManager.class);
         configurationManager = mock(ConfigurationManager.class);
 
-        List<SpecialPrice> specialPrices = asList(new SpecialPrice(0, "123", 0, 0, "FREE", null, null, null, null), new SpecialPrice(0, "456", 0, 0, "FREE", null, null, null, null));
+        List<SpecialPrice> specialPrices = asList(new SpecialPrice(0, "123", 0, 0, "FREE", null, null, null, null, null), new SpecialPrice(0, "456", 0, 0, "FREE", null, null, null, null, null));
         when(i18nManager.getEventLanguages(anyInt())).thenReturn(Collections.singletonList(ContentLanguage.ITALIAN));
         when(messageSource.getMessage(anyString(), any(), any())).thenReturn("text");
         when(eventManager.getSingleEvent(anyString(), anyString())).thenReturn(event);

--- a/src/test/java/alfio/manager/TicketReservationManagerIntegrationTest.java
+++ b/src/test/java/alfio/manager/TicketReservationManagerIntegrationTest.java
@@ -232,10 +232,10 @@ public class TicketReservationManagerIntegrationTest extends BaseIntegrationTest
         TicketCategory unbounded = ticketCategoryRepository.findByEventId(event.getId()).stream().filter(t -> !t.isBounded()).findFirst().orElseThrow(IllegalStateException::new);
 
         //promo code at event level
-        eventManager.addPromoCode("MYPROMOCODE", event.getId(), null, event.getBegin(), event.getEnd(), 10, PromoCodeDiscount.DiscountType.PERCENTAGE, null, 3, "description", "email@reference.ch");
+        eventManager.addPromoCode("MYPROMOCODE", event.getId(), null, event.getBegin(), event.getEnd(), 10, PromoCodeDiscount.DiscountType.PERCENTAGE, null, 3, "description", "email@reference.ch", PromoCodeDiscount.CodeType.DISCOUNT, null);
 
         //promo code at organization level
-        eventManager.addPromoCode("MYFIXEDPROMO", null, event.getOrganizationId(), event.getBegin(), event.getEnd(), 5, PromoCodeDiscount.DiscountType.FIXED_AMOUNT, null, null,"description", "email@reference.ch");
+        eventManager.addPromoCode("MYFIXEDPROMO", null, event.getOrganizationId(), event.getBegin(), event.getEnd(), 5, PromoCodeDiscount.DiscountType.FIXED_AMOUNT, null, null,"description", "email@reference.ch", PromoCodeDiscount.CodeType.DISCOUNT, null);
 
         TicketReservationModification tr = new TicketReservationModification();
         tr.setAmount(3);

--- a/src/test/java/alfio/manager/TicketReservationManagerUnitTest.java
+++ b/src/test/java/alfio/manager/TicketReservationManagerUnitTest.java
@@ -25,6 +25,7 @@ import alfio.util.TemplateManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.MessageSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.transaction.PlatformTransactionManager;
 
 import java.math.BigDecimal;
@@ -134,7 +135,8 @@ public class TicketReservationManagerUnitTest {
             extensionManager,
             mock(TicketSearchRepository.class),
             groupManager,
-            billingDocumentRepository);
+            billingDocumentRepository,
+            mock(NamedParameterJdbcTemplate.class));
 
     }
 


### PR DESCRIPTION
Add the ability to define access codes for hidden categories.

An access codes works like a "carnet" of access tokens, allowing the user to buy/register multiple tickets for an hidden category at once. Maximum allowed quantity can be specified.

The typical use case for this is a conference organizer, who distributes free tickets to sponsors. 