### PR TITLE
fix coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,4 @@ before_script:
 script:
   - TERM=dumb ./gradlew build jacocoTestReport $PROFILE
 after_success:
-  ./gradlew -Djdk.tls.client.protocols="TLSv1,TLSv1.1,TLSv1.2" coveralls
+  ./gradlew coveralls

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,3 +10,5 @@ springSecurityConfigVersion=5.1.5.RELEASE
 log4jVersion=2.11.2
 jacksonVersion=2.9.9
 junitVersion=5.1.0
+
+systemProp.jdk.tls.client.protocols="TLSv1,TLSv1.1,TLSv1.2"


### PR DESCRIPTION
Currently, it seems that the coveralls plugin+gradle+jdk has some issues with tls1.3 and the currently used workaround stopped working.

Putting `systemProp.jdk.tls.client.protocols="TLSv1,TLSv1.1,TLSv1.2" `

in the gradle.properties seems to do the trick.