### PR TITLE
WaitingQueueManager.getSubscriptionType: ignore restricted categories

### DIFF
--- a/src/main/java/alfio/manager/WaitingQueueManager.java
+++ b/src/main/java/alfio/manager/WaitingQueueManager.java
@@ -110,6 +110,7 @@ public class WaitingQueueManager {
     private WaitingQueueSubscription.Type getSubscriptionType(Event event) {
         ZonedDateTime now = ZonedDateTime.now(event.getZoneId());
         return ticketCategoryRepository.findByEventId(event.getId()).stream()
+                .filter(tc -> !tc.isAccessRestricted())
                 .filter(tc -> now.isAfter(tc.getInception(event.getZoneId())))
                 .findFirst()
                 .map(tc -> WaitingQueueSubscription.Type.SOLD_OUT)


### PR DESCRIPTION
or else this check will fail in the following scenario:

- 1 hidden category available
- 1 category available in the future

-> waiting list is enabled, but submitting will fail because the type is SOLD_OUT and does not match