### PR TITLE
Added explicit cast to avoid type mismatch error

### DIFF
--- a/src/main/java/alfio/controller/api/v2/user/EventApiV2Controller.java
+++ b/src/main/java/alfio/controller/api/v2/user/EventApiV2Controller.java
@@ -439,7 +439,7 @@ public class EventApiV2Controller {
             });
 
             if (bindingResult.hasErrors()) {
-                return new ResponseEntity<>(ValidatedResponse.toResponse(bindingResult, null), getCorsHeaders(), HttpStatus.UNPROCESSABLE_ENTITY);
+                return new ResponseEntity<>(ValidatedResponse.toResponse(bindingResult, (String) null), getCorsHeaders(), HttpStatus.UNPROCESSABLE_ENTITY);
             } else {
                 var reservationIdentifier = reservationIdRes.orElseThrow(IllegalStateException::new);
                 return ResponseEntity.ok(new ValidatedResponse<>(ValidationResult.success(), reservationIdentifier));


### PR DESCRIPTION
ECJ complains about type mismatch:

`cannot convert from Optional<Object> to Optional<ResponseEntity<ValidatedResponse<String>>>`