### PR TITLE
Show correct ticket price on invoices #661

### DIFF
--- a/src/main/resources/alfio/templates/invoice.ms
+++ b/src/main/resources/alfio/templates/invoice.ms
@@ -161,8 +161,8 @@
                 <tr>
                     <td class="text-center">{{amount}}</td>
                     <td>{{name}}</td>
-                    <td class="text-right">{{priceBeforeVat}}</td>
-                    <td class="text-right">{{subTotalBeforeVat}}</td>
+                    <td class="text-right">{{price}}</td>
+                    <td class="text-right">{{subTotal}}</td>
                 </tr>
         {{/orderSummary.summary}}
             </tbody>


### PR DESCRIPTION
This commit fixed the issue with invoices with discounts. The invoice now shows the original ticket price instead of the already discounted price to be consistent with the reservation summary and receipts.