### PR TITLE
#430 delete category from ui

### DIFF
--- a/src/main/java/alfio/controller/api/admin/EventApiController.java
+++ b/src/main/java/alfio/controller/api/admin/EventApiController.java
@@ -267,6 +267,12 @@ public class EventApiController {
         return OK;
     }
 
+    @DeleteMapping("/events/{eventName}/category/{categoryId}")
+    public String deleteCategory(@PathVariable("eventName") String eventName, @PathVariable("categoryId") int categoryId, Principal principal) {
+        eventManager.deleteCategory(eventName, categoryId, principal.getName());
+        return OK;
+    }
+
     private static final List<String> FIXED_FIELDS = Arrays.asList("ID", "Creation", "Category", "Event", "Status", "OriginalPrice", "PaidPrice", "Discount", "VAT", "ReservationID", "Full Name", "First Name", "Last Name", "E-Mail", "Locked", "Language", "Confirmation", "Billing Address", "Payment ID", "Payment Method");
     private static final List<SerializablePair<String, String>> FIXED_PAIRS = FIXED_FIELDS.stream().map(f -> SerializablePair.of(f, f)).collect(toList());
     private static final List<String> ITALIAN_E_INVOICING_FIELDS = List.of("Fiscal Code", "Reference Type", "Addressee Code", "PEC");

--- a/src/main/java/alfio/manager/EventManager.java
+++ b/src/main/java/alfio/manager/EventManager.java
@@ -149,7 +149,7 @@ public class EventManager {
     }
 
     public List<TicketCategory> loadTicketCategories(EventAndOrganizationId event) {
-        return ticketCategoryRepository.findByEventId(event.getId());
+        return ticketCategoryRepository.findAllTicketCategories(event.getId());
     }
 
     public Organization loadOrganizer(EventAndOrganizationId event, String username) {
@@ -320,7 +320,7 @@ public class EventManager {
         int eventId = original.getId();
         int seatsDifference = em.getAvailableSeats() - eventRepository.countExistingTickets(original.getId());
         if(seatsDifference < 0) {
-            int allocatedSeats = ticketCategoryRepository.findByEventId(original.getId()).stream()
+            int allocatedSeats = ticketCategoryRepository.findAllTicketCategories(original.getId()).stream()
                     .filter(TicketCategory::isBounded)
                     .mapToInt(TicketCategory::getMaxTickets)
                     .sum();
@@ -498,7 +498,7 @@ public class EventManager {
         //FIXME: the date should be inserted as ZonedDateTime !
         Date creationDate = Date.from(creation.toInstant());
 
-        List<TicketCategory> categories = ticketCategoryRepository.findByEventId(event.getId());
+        List<TicketCategory> categories = ticketCategoryRepository.findAllTicketCategories(event.getId());
         Stream<MapSqlParameterSource> boundedTickets = categories.stream()
                 .filter(IS_CATEGORY_BOUNDED)
                 .flatMap(tc -> generateTicketsForCategory(tc, event, creationDate, 0));
@@ -754,7 +754,7 @@ public class EventManager {
     public boolean toggleTicketLocking(String eventName, int categoryId, int ticketId, String username) {
         EventAndOrganizationId event = getEventAndOrganizationId(eventName, username);
         checkOwnership(event, username, event.getOrganizationId());
-        var existingCategory = ticketCategoryRepository.findByEventId(event.getId()).stream().filter(tc -> tc.getId() == categoryId).findFirst();
+        var existingCategory = ticketCategoryRepository.findAllTicketCategories(event.getId()).stream().filter(tc -> tc.getId() == categoryId).findFirst();
         if(existingCategory.isPresent()) {
             Ticket ticket = ticketRepository.findById(ticketId, categoryId);
             Validate.isTrue(ticketRepository.toggleTicketLocking(ticketId, categoryId, !ticket.getLockedAssignment()) == 1, "unwanted result from ticket locking");

--- a/src/main/java/alfio/manager/EventStatisticsManager.java
+++ b/src/main/java/alfio/manager/EventStatisticsManager.java
@@ -109,7 +109,7 @@ public class EventStatisticsManager {
     }
 
     private List<TicketCategory> loadTicketCategories(EventAndOrganizationId event) {
-        return ticketCategoryRepository.findByEventId(event.getId());
+        return ticketCategoryRepository.findAllTicketCategories(event.getId());
     }
 
     private Event getEventAndCheckOwnership(String eventName, String username) {

--- a/src/main/java/alfio/manager/TicketReservationManager.java
+++ b/src/main/java/alfio/manager/TicketReservationManager.java
@@ -1733,7 +1733,7 @@ public class TicketReservationManager {
     }
 
     public int revertTicketsToFreeIfAccessRestricted(int eventId) {
-        List<Integer> restrictedCategories = ticketCategoryRepository.findByEventId(eventId).stream()
+        List<Integer> restrictedCategories = ticketCategoryRepository.findAllTicketCategories(eventId).stream()
             .filter(TicketCategory::isAccessRestricted)
             .map(TicketCategory::getId)
             .collect(toList());

--- a/src/main/java/alfio/manager/WaitingQueueManager.java
+++ b/src/main/java/alfio/manager/WaitingQueueManager.java
@@ -108,7 +108,7 @@ public class WaitingQueueManager {
 
     private WaitingQueueSubscription.Type getSubscriptionType(Event event) {
         ZonedDateTime now = ZonedDateTime.now(event.getZoneId());
-        return ticketCategoryRepository.findByEventId(event.getId()).stream()
+        return ticketCategoryRepository.findAllTicketCategories(event.getId()).stream()
                 .filter(tc -> !tc.isAccessRestricted())
                 .filter(tc -> now.isAfter(tc.getInception(event.getZoneId())))
                 .findFirst()

--- a/src/main/java/alfio/manager/system/DataMigrator.java
+++ b/src/main/java/alfio/manager/system/DataMigrator.java
@@ -225,7 +225,7 @@ public class DataMigrator {
     }
 
     void fixCategoriesSize(EventAndOrganizationId event) {
-        ticketCategoryRepository.findByEventId(event.getId()).stream()
+        ticketCategoryRepository.findAllTicketCategories(event.getId()).stream()
             .filter(TicketCategory::isBounded)
             .forEach(tc -> {
                 Integer result = jdbc.queryForObject("select count(*) from ticket where event_id = :eventId and category_id = :categoryId and status <> 'INVALIDATED'", new MapSqlParameterSource("eventId", tc.getEventId()).addValue("categoryId", tc.getId()), Integer.class);

--- a/src/main/java/alfio/repository/TicketCategoryRepository.java
+++ b/src/main/java/alfio/repository/TicketCategoryRepository.java
@@ -75,11 +75,8 @@ public interface TicketCategoryRepository {
     @Query("select * from ticket_category_with_currency where event_id = :eventId  and tc_status = 'ACTIVE' order by inception asc, expiration asc, id asc")
     List<TicketCategory> findAllTicketCategories(@Bind("eventId") int eventId);
     
-    @Query("select * from ticket_category_with_currency where event_id = :eventId and tc_status = 'ACTIVE'")
-    List<TicketCategory> findByEventId(@Bind("eventId") int eventId);
-
     default Map<Integer, TicketCategory> findByEventIdAsMap(int eventId) {
-        return findByEventId(eventId).stream().collect(Collectors.toMap(TicketCategory::getId, Function.identity()));
+        return findAllTicketCategories(eventId).stream().collect(Collectors.toMap(TicketCategory::getId, Function.identity()));
     }
     
     @Query("select count(*) from ticket_category_with_currency where event_id = :eventId and access_restricted = true")
@@ -112,7 +109,7 @@ public interface TicketCategoryRepository {
     int fixDates(@Bind("id") int id, @Bind("inception") ZonedDateTime inception, @Bind("expiration") ZonedDateTime expiration);
 
     default int getTicketAllocation(int eventId) {
-        return findByEventId(eventId).stream()
+        return findAllTicketCategories(eventId).stream()
             .filter(TicketCategory::isBounded)
             .mapToInt(TicketCategory::getMaxTickets)
             .sum();

--- a/src/main/java/alfio/repository/TicketCategoryRepository.java
+++ b/src/main/java/alfio/repository/TicketCategoryRepository.java
@@ -75,7 +75,7 @@ public interface TicketCategoryRepository {
     @Query("select * from ticket_category_with_currency where event_id = :eventId  and tc_status = 'ACTIVE' order by inception asc, expiration asc, id asc")
     List<TicketCategory> findAllTicketCategories(@Bind("eventId") int eventId);
     
-    @Query("select * from ticket_category_with_currency where event_id = :eventId")
+    @Query("select * from ticket_category_with_currency where event_id = :eventId and tc_status = 'ACTIVE'")
     List<TicketCategory> findByEventId(@Bind("eventId") int eventId);
 
     default Map<Integer, TicketCategory> findByEventIdAsMap(int eventId) {
@@ -130,4 +130,7 @@ public interface TicketCategoryRepository {
 
     @Query("select access_restricted from ticket_category where id = :id")
     Boolean isAccessRestricted(@Bind("id") Integer hiddenCategoryId);
+
+    @Query("update ticket_category set tc_status = 'NOT_ACTIVE' from (select count(*) cnt from ticket where category_id = :categoryId and status in ('PENDING', 'ACQUIRED', 'CHECKED_IN')) tkts where id = :categoryId and tkts.cnt = 0")
+    int deleteCategoryIfEmpty(@Bind("categoryId") int categoryId);
 }

--- a/src/main/webapp/resources/angular-templates/admin/partials/event/detail.html
+++ b/src/main/webapp/resources/angular-templates/admin/partials/event/detail.html
@@ -83,6 +83,7 @@
                                             <i class="fa fa-envelope-o"></i> send invitations
                                         </a>
                                         <a class="btn btn-sm btn-default" data-ng-click="openConfiguration(event, ticketCategory)"><i class="fa fa-wrench"></i> options</a>
+                                        <a class="btn btn-sm btn-danger" ng-if="canBeDeleted(ticketCategory)" ng-click="deleteCategory(ticketCategory, event)"><i class="fa fa-trash"></i> delete</a>
                                     </div>
                                 </div>
                             </div>
@@ -95,7 +96,7 @@
                         </div>
                         <div class="row form-inline text-danger" data-ng-if="ticketCategory.containingOrphans">
                             <div class="col-xs-12" data-ng-form="moveTickets">
-                                <i class="fa fa-warning"></i> This category contains orphan (not sold) tickets. Move them to another category:
+                                <i class="fa fa-warning"></i> This category contains reserved tickets that cannot be sold anymore. Move them to another category:
                                 <select class="form-control input-sm" data-ng-model="targetCategoryId" required data-ng-options="category.id as category.name for category in validCategories"></select>
                                 <button class="btn btn-sm btn-warning" data-ng-click="moveOrphans(ticketCategory, targetCategoryId, event.id)">apply</button>
                                 <button data-ng-if="event.containingUnboundedCategories" class="btn btn-sm btn-warning" data-ng-click="unbindTickets(event, ticketCategory)">Assign to dynamic categories</button>

--- a/src/main/webapp/resources/angular-templates/admin/partials/event/fragment/delete-category-modal.html
+++ b/src/main/webapp/resources/angular-templates/admin/partials/event/fragment/delete-category-modal.html
@@ -1,0 +1,21 @@
+<div class="modal-header">
+    <h3>Delete Ticket Category "{{category.name}}"</h3>
+</div>
+
+
+<form name="addFieldForm" ng-submit="deleteCategory()">
+	<div class="modal-body">
+        <h5>
+            Are you sure you want to delete the ticket category "{{category.name}}"?
+        </h5>
+	</div>
+
+	<div class="modal-footer">
+        <div class="col-md-4 col-md-push-8 col-xs-12">
+            <button type="submit" class="btn btn-lg btn-danger btn-block">Confirm deletion</button>
+        </div>
+        <div class="col-md-4 col-md-pull-4 col-xs-12">
+            <button type="button" class="btn btn-lg btn-default btn-block" data-ng-click="cancel()">Cancel</button>
+        </div>
+	</div>
+</form>

--- a/src/main/webapp/resources/js/admin/ng-app/admin-application.js
+++ b/src/main/webapp/resources/js/admin/ng-app/admin-application.js
@@ -868,13 +868,11 @@
         };
 
         $scope.deleteCategory = function(category, event) {
-            if($window.confirm('Do you really want to delete '+category.name+'?')) {
-                EventService.deleteCategory(category, event).success(function(result) {
-                    if(result === 'OK') {
-                        loadData();
-                    }
-                });
-            }
+            EventService.deleteCategory(category, event).then(function(result) {
+                if(result === 'OK') {
+                    loadData();
+                }
+            });
         };
 
         $scope.moveOrphans = function(srcCategory, targetCategoryId, eventId) {

--- a/src/main/webapp/resources/js/admin/ng-app/admin-application.js
+++ b/src/main/webapp/resources/js/admin/ng-app/admin-application.js
@@ -816,8 +816,6 @@
                     }
 
                 });
-            GroupService.loadActiveLinks($state.params.eventName).then(function(confResult) {
-            });
         });
         $scope.allocationStrategyRadioClass = 'radio';
         $scope.evaluateCategoryStatusClass = function(index, category) {
@@ -863,6 +861,20 @@
 
         $scope.isReady = function(token) {
             return token.status === 'WAITING';
+        };
+
+        $scope.canBeDeleted = function(category) {
+            return category.checkedInTickets + category.soldTickets + category.pendingTickets === 0
+        };
+
+        $scope.deleteCategory = function(category, event) {
+            if($window.confirm('Do you really want to delete '+category.name+'?')) {
+                EventService.deleteCategory(category, event).success(function(result) {
+                    if(result === 'OK') {
+                        loadData();
+                    }
+                });
+            }
         };
 
         $scope.moveOrphans = function(srcCategory, targetCategoryId, eventId) {

--- a/src/main/webapp/resources/js/admin/service/service.js
+++ b/src/main/webapp/resources/js/admin/service/service.js
@@ -110,7 +110,27 @@
                 }).error(HttpErrorHandler.handle);
             },
             deleteCategory: function(category, event) {
-                return $http['delete']('/admin/api/events/'+event.shortName+'/category/'+category.id).error(HttpErrorHandler.handle);
+
+                var modal = $uibModal.open({
+                    size:'md',
+                    templateUrl: '/resources/angular-templates/admin/partials/event/fragment/delete-category-modal.html',
+                    backdrop: 'static',
+                    controller: function($scope) {
+                        $scope.cancel = function() {
+                            modal.dismiss('canceled');
+                        };
+
+                        $scope.deleteCategory = function() {
+                            $http['delete']('/admin/api/events/'+event.shortName+'/category/'+category.id)
+                                .error(HttpErrorHandler.handle)
+                                .then(function() {
+                                    modal.close('OK');
+                                });
+                        };
+                        $scope.category = category;
+                    }
+                });
+                return modal.result;
             },
             unbindTickets: function(event, category) {
                 return $http['put']('/admin/api/events/'+event.shortName+'/category/'+category.id+'/unbind-tickets').error(HttpErrorHandler.handle);

--- a/src/main/webapp/resources/js/admin/service/service.js
+++ b/src/main/webapp/resources/js/admin/service/service.js
@@ -109,6 +109,9 @@
                     eventId: eventId
                 }).error(HttpErrorHandler.handle);
             },
+            deleteCategory: function(category, event) {
+                return $http['delete']('/admin/api/events/'+event.shortName+'/category/'+category.id).error(HttpErrorHandler.handle);
+            },
             unbindTickets: function(event, category) {
                 return $http['put']('/admin/api/events/'+event.shortName+'/category/'+category.id+'/unbind-tickets').error(HttpErrorHandler.handle);
             },

--- a/src/test/java/alfio/controller/api/v1/EventApiV1IntegrationTest.java
+++ b/src/test/java/alfio/controller/api/v1/EventApiV1IntegrationTest.java
@@ -46,9 +46,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.io.IOException;
 import java.math.BigDecimal;
-import java.net.URISyntaxException;
 import java.security.Principal;
 import java.time.LocalDateTime;
 import java.util.Arrays;
@@ -169,7 +167,7 @@ public class EventApiV1IntegrationTest extends BaseIntegrationTest {
 
         String shortName = controller.create(eventCreationRequest,mockPrincipal).getBody();
         Event event = eventManager.getSingleEvent(shortName,username);
-        List<TicketCategory> tickets = ticketCategoryRepository.findByEventId(event.getId());
+        List<TicketCategory> tickets = ticketCategoryRepository.findAllTicketCategories(event.getId());
 
 
 

--- a/src/test/java/alfio/controller/api/v2/user/ReservationFlowIntegrationTest.java
+++ b/src/test/java/alfio/controller/api/v2/user/ReservationFlowIntegrationTest.java
@@ -65,7 +65,6 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -228,7 +227,7 @@ public class ReservationFlowIntegrationTest extends BaseIntegrationTest {
         //promo code at event level
         eventManager.addPromoCode(PROMO_CODE, event.getId(), null, ZonedDateTime.now().minusDays(2), event.getEnd().plusDays(2), 10, PromoCodeDiscount.DiscountType.PERCENTAGE, null, 3, "description", "test@test.ch", PromoCodeDiscount.CodeType.DISCOUNT, null);
 
-        hiddenCategoryId = ticketCategoryRepository.findByEventId(event.getId()).stream().filter(t -> t.isAccessRestricted()).collect(Collectors.toList()).get(0).getId();
+        hiddenCategoryId = ticketCategoryRepository.findAllTicketCategories(event.getId()).stream().filter(TicketCategory::isAccessRestricted).collect(Collectors.toList()).get(0).getId();
 
         eventManager.addPromoCode(HIDDEN_CODE, event.getId(), null, ZonedDateTime.now().minusDays(2), event.getEnd().plusDays(2), 0, PromoCodeDiscount.DiscountType.NONE, null, null, "hidden", "test@test.ch", PromoCodeDiscount.CodeType.ACCESS, hiddenCategoryId);
 

--- a/src/test/java/alfio/manager/AdminReservationManagerIntegrationTest.java
+++ b/src/test/java/alfio/manager/AdminReservationManagerIntegrationTest.java
@@ -189,9 +189,9 @@ public class AdminReservationManagerIntegrationTest extends BaseIntegrationTest 
         assertEquals(attendees, ticketRepository.findPendingTicketsInCategories(Collections.singletonList(categoryId)).size());
         TicketCategory categoryModified = ticketCategoryRepository.getByIdAndActive(categoryId, event.getId());
         assertEquals(categoryModified.getMaxTickets(), attendees);
-        ticketCategoryRepository.findByEventId(event.getId()).forEach(tc -> assertTrue(specialPriceRepository.findAllByCategoryId(tc.getId()).stream().allMatch(sp -> sp.getStatus() == SpecialPrice.Status.PENDING)));
+        ticketCategoryRepository.findAllTicketCategories(event.getId()).forEach(tc -> assertTrue(specialPriceRepository.findAllByCategoryId(tc.getId()).stream().allMatch(sp -> sp.getStatus() == SpecialPrice.Status.PENDING)));
         adminReservationManager.confirmReservation(event.getShortName(), data.getLeft().getId(), username, EMPTY);
-        ticketCategoryRepository.findByEventId(event.getId()).forEach(tc -> assertTrue(specialPriceRepository.findAllByCategoryId(tc.getId()).stream().allMatch(sp -> sp.getStatus() == SpecialPrice.Status.TAKEN)));
+        ticketCategoryRepository.findAllTicketCategories(event.getId()).forEach(tc -> assertTrue(specialPriceRepository.findAllByCategoryId(tc.getId()).stream().allMatch(sp -> sp.getStatus() == SpecialPrice.Status.TAKEN)));
         assertFalse(ticketRepository.findAllReservationsConfirmedButNotAssignedForUpdate(event.getId()).contains(data.getLeft().getId()));
     }
 
@@ -208,7 +208,7 @@ public class AdminReservationManagerIntegrationTest extends BaseIntegrationTest 
         DateTimeModification expiration = DateTimeModification.fromZonedDateTime(ZonedDateTime.now().plusDays(1));
         CustomerData customerData = new CustomerData("Integration", "Test", "integration-test@test.ch", "Billing Address", "reference", "en", "1234", "CH", null);
 
-        TicketCategory existingCategory = ticketCategoryRepository.findByEventId(event.getId()).get(0);
+        TicketCategory existingCategory = ticketCategoryRepository.findAllTicketCategories(event.getId()).get(0);
 
 
         Category resExistingCategory = new Category(existingCategory.getId(), "", existingCategory.getPrice());
@@ -235,9 +235,9 @@ public class AdminReservationManagerIntegrationTest extends BaseIntegrationTest 
         assertEquals(ticketRepository.findTicketsInReservation(reservationId).stream().findFirst().get().getId(),
             ticketRepository.findFirstTicketInReservation(reservationId).get().getId());
 
-        ticketCategoryRepository.findByEventId(event.getId()).forEach(tc -> assertTrue(specialPriceRepository.findAllByCategoryId(tc.getId()).stream().allMatch(sp -> sp.getStatus() == SpecialPrice.Status.PENDING)));
+        ticketCategoryRepository.findAllTicketCategories(event.getId()).forEach(tc -> assertTrue(specialPriceRepository.findAllByCategoryId(tc.getId()).stream().allMatch(sp -> sp.getStatus() == SpecialPrice.Status.PENDING)));
         adminReservationManager.confirmReservation(event.getShortName(), data.getLeft().getId(), username, EMPTY);
-        ticketCategoryRepository.findByEventId(event.getId()).forEach(tc -> assertTrue(specialPriceRepository.findAllByCategoryId(tc.getId()).stream().allMatch(sp -> sp.getStatus() == SpecialPrice.Status.TAKEN)));
+        ticketCategoryRepository.findAllTicketCategories(event.getId()).forEach(tc -> assertTrue(specialPriceRepository.findAllByCategoryId(tc.getId()).stream().allMatch(sp -> sp.getStatus() == SpecialPrice.Status.TAKEN)));
         assertFalse(ticketRepository.findAllReservationsConfirmedButNotAssignedForUpdate(event.getId()).contains(data.getLeft().getId()));
     }
 
@@ -256,7 +256,7 @@ public class AdminReservationManagerIntegrationTest extends BaseIntegrationTest 
         assertEquals(TicketReservation.TicketReservationStatus.COMPLETE, triple.getLeft().getStatus());
         triple.getMiddle().forEach(t -> assertEquals(Ticket.TicketStatus.ACQUIRED, t.getStatus()));
         assertTrue(emailMessageRepository.findByEventId(triple.getRight().getId(), 0, 50, null).isEmpty());
-        ticketCategoryRepository.findByEventId(triple.getRight().getId()).forEach(tc -> assertTrue(specialPriceRepository.findAllByCategoryId(tc.getId()).stream().allMatch(sp -> sp.getStatus() == SpecialPrice.Status.TAKEN)));
+        ticketCategoryRepository.findAllTicketCategories(triple.getRight().getId()).forEach(tc -> assertTrue(specialPriceRepository.findAllByCategoryId(tc.getId()).stream().allMatch(sp -> sp.getStatus() == SpecialPrice.Status.TAKEN)));
         assertFalse(ticketRepository.findAllReservationsConfirmedButNotAssignedForUpdate(triple.getRight().getId()).contains(triple.getLeft().getId()));
     }
 
@@ -276,7 +276,7 @@ public class AdminReservationManagerIntegrationTest extends BaseIntegrationTest 
         assertEquals(TicketReservation.TicketReservationStatus.COMPLETE, triple.getLeft().getStatus());
         triple.getMiddle().forEach(t -> assertEquals(Ticket.TicketStatus.ACQUIRED, t.getStatus()));
         assertEquals(attendees + 2, emailMessageRepository.findByEventId(triple.getRight().getId(), 0, 50, null).size());
-        ticketCategoryRepository.findByEventId(triple.getRight().getId()).forEach(tc -> assertTrue(specialPriceRepository.findAllByCategoryId(tc.getId()).stream().allMatch(sp -> sp.getStatus() == SpecialPrice.Status.TAKEN)));
+        ticketCategoryRepository.findAllTicketCategories(triple.getRight().getId()).forEach(tc -> assertTrue(specialPriceRepository.findAllByCategoryId(tc.getId()).stream().allMatch(sp -> sp.getStatus() == SpecialPrice.Status.TAKEN)));
         assertFalse(ticketRepository.findAllReservationsConfirmedButNotAssignedForUpdate(triple.getRight().getId()).contains(triple.getLeft().getId()));
     }
 
@@ -290,7 +290,7 @@ public class AdminReservationManagerIntegrationTest extends BaseIntegrationTest 
         DateTimeModification expiration = DateTimeModification.fromZonedDateTime(ZonedDateTime.now().plusDays(1));
         CustomerData customerData = new CustomerData("Integration", "Test", "integration-test@test.ch", "Billing Address", "reference", "en", "1234", "CH", null);
         Iterator<Integer> attendeesIterator = attendeesNr.iterator();
-        List<TicketCategory> existingCategories = ticketCategoryRepository.findByEventId(event.getId());
+        List<TicketCategory> existingCategories = ticketCategoryRepository.findAllTicketCategories(event.getId());
         List<Attendee> allAttendees = new ArrayList<>();
         List<TicketsInfo> ticketsInfoList = existingCategories.stream()
             .map(existingCategory -> {
@@ -349,7 +349,7 @@ public class AdminReservationManagerIntegrationTest extends BaseIntegrationTest 
                 assertEquals(data.getLeft().getId(), ticket.getTicketsReservationId());
             }
         }
-        ticketCategoryRepository.findByEventId(modified.getId()).forEach(tc -> assertTrue(specialPriceRepository.findAllByCategoryId(tc.getId()).stream().allMatch(sp -> sp.getStatus() == SpecialPrice.Status.PENDING)));
+        ticketCategoryRepository.findAllTicketCategories(modified.getId()).forEach(tc -> assertTrue(specialPriceRepository.findAllByCategoryId(tc.getId()).stream().allMatch(sp -> sp.getStatus() == SpecialPrice.Status.PENDING)));
         assertFalse(ticketRepository.findAllReservationsConfirmedButNotAssignedForUpdate(event.getId()).contains(data.getLeft().getId()));
     }
 

--- a/src/test/java/alfio/manager/EventManagerCategoriesTest.java
+++ b/src/test/java/alfio/manager/EventManagerCategoriesTest.java
@@ -66,7 +66,7 @@ public class EventManagerCategoriesTest {
     @DisplayName("create tickets for the unbounded category")
     void createTicketsForUnboundedCategory() {
         List<TicketCategory> categories = generateCategoryStream().limit(3).collect(Collectors.toList());
-        when(ticketCategoryRepository.findByEventId(eq(eventId))).thenReturn(categories);
+        when(ticketCategoryRepository.findAllTicketCategories(eq(eventId))).thenReturn(categories);
         MapSqlParameterSource[] parameterSources = eventManager.prepareTicketsBulkInsertParameters(ZonedDateTime.now(), event, availableSeats, Ticket.TicketStatus.FREE);
         assertNotNull(parameterSources);
         assertEquals(availableSeats, parameterSources.length);
@@ -77,7 +77,7 @@ public class EventManagerCategoriesTest {
     @DisplayName("create tickets for the unbounded categories")
     void createTicketsForUnboundedCategories() {
         List<TicketCategory> categories = generateCategoryStream().limit(6).collect(Collectors.toList());
-        when(ticketCategoryRepository.findByEventId(eq(eventId))).thenReturn(categories);
+        when(ticketCategoryRepository.findAllTicketCategories(eq(eventId))).thenReturn(categories);
         MapSqlParameterSource[] parameterSources = eventManager.prepareTicketsBulkInsertParameters(ZonedDateTime.now(), event, availableSeats, Ticket.TicketStatus.FREE);
         assertNotNull(parameterSources);
         assertEquals(availableSeats, parameterSources.length);
@@ -88,7 +88,7 @@ public class EventManagerCategoriesTest {
     @DisplayName("create tickets only for the bounded categories")
     void createTicketsOnlyForBounded() {
         List<TicketCategory> categories = generateCategoryStream().limit(2).collect(Collectors.toList());
-        when(ticketCategoryRepository.findByEventId(eq(eventId))).thenReturn(categories);
+        when(ticketCategoryRepository.findAllTicketCategories(eq(eventId))).thenReturn(categories);
         MapSqlParameterSource[] parameterSources = eventManager.prepareTicketsBulkInsertParameters(ZonedDateTime.now(), event, availableSeats, Ticket.TicketStatus.FREE);
         assertNotNull(parameterSources);
         assertEquals(availableSeats, parameterSources.length);

--- a/src/test/java/alfio/manager/EventManagerIntegrationTest.java
+++ b/src/test/java/alfio/manager/EventManagerIntegrationTest.java
@@ -134,7 +134,7 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
         assertFalse(tickets.isEmpty());
         assertEquals(AVAILABLE_SEATS, tickets.size());
         assertEquals(AVAILABLE_SEATS, tickets.stream().filter(t -> t.getCategoryId() == null).count());
-        List<TicketCategory> ticketCategories = ticketCategoryRepository.findByEventId(event.getId());
+        List<TicketCategory> ticketCategories = ticketCategoryRepository.findAllTicketCategories(event.getId());
         assertEquals(1, ticketCategories.size());
         assertEquals(0, ticketCategories.get(0).getMaxTickets());
     }
@@ -370,7 +370,7 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
                         DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null));
         Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = pair.getKey();
-        TicketCategory category = ticketCategoryRepository.findByEventId(event.getId()).get(0);
+        TicketCategory category = ticketCategoryRepository.findAllTicketCategories(event.getId()).get(0);
         TicketCategoryModification tcm = new TicketCategoryModification(category.getId(), "default", 20,
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
@@ -453,7 +453,7 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
         Event event = pair.getLeft();
         String username = pair.getRight();
         assertEquals(Integer.valueOf(AVAILABLE_SEATS), ticketRepository.countFreeTicketsForUnbounded(event.getId()));
-        TicketCategory category = ticketCategoryRepository.findByEventId(event.getId()).get(0);
+        TicketCategory category = ticketCategoryRepository.findAllTicketCategories(event.getId()).get(0);
         Map<String, String> categoryDescription = ticketCategoryDescriptionRepository.descriptionForTicketCategory(category.getId());
         TicketCategoryModification tcm = new TicketCategoryModification(category.getId(), category.getName(), AVAILABLE_SEATS,
             DateTimeModification.fromZonedDateTime(category.getUtcInception()),
@@ -476,7 +476,7 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
         String username = pair.getRight();
         assertEquals(Integer.valueOf(0), ticketRepository.countFreeTicketsForUnbounded(event.getId()));
 
-        TicketCategory category = ticketCategoryRepository.findByEventId(event.getId()).get(0);
+        TicketCategory category = ticketCategoryRepository.findAllTicketCategories(event.getId()).get(0);
         Map<String, String> categoryDescription = ticketCategoryDescriptionRepository.descriptionForTicketCategory(category.getId());
 
         TicketCategoryModification tcm = new TicketCategoryModification(category.getId(), category.getName(), AVAILABLE_SEATS,
@@ -503,7 +503,7 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
         Event event = pair.getLeft();
         String username = pair.getRight();
 
-        TicketCategory category = ticketCategoryRepository.findByEventId(event.getId()).get(0);
+        TicketCategory category = ticketCategoryRepository.findAllTicketCategories(event.getId()).get(0);
         Map<String, String> categoryDescription = ticketCategoryDescriptionRepository.descriptionForTicketCategory(category.getId());
 
         TicketCategoryModification tcm = new TicketCategoryModification(category.getId(), category.getName(), 10,
@@ -525,7 +525,7 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
         Event event = pair.getLeft();
         String username = pair.getRight();
 
-        TicketCategory category = ticketCategoryRepository.findByEventId(event.getId()).get(0);
+        TicketCategory category = ticketCategoryRepository.findAllTicketCategories(event.getId()).get(0);
         Map<String, String> categoryDescription = ticketCategoryDescriptionRepository.descriptionForTicketCategory(category.getId());
 
         List<Integer> tickets = ticketRepository.selectTicketInCategoryForUpdate(event.getId(), category.getId(), 1, Collections.singletonList(Ticket.TicketStatus.FREE.name()));
@@ -553,7 +553,7 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
         Event event = pair.getLeft();
         String username = pair.getRight();
 
-        TicketCategory category = ticketCategoryRepository.findByEventId(event.getId()).get(0);
+        TicketCategory category = ticketCategoryRepository.findAllTicketCategories(event.getId()).get(0);
         Map<String, String> categoryDescription = ticketCategoryDescriptionRepository.descriptionForTicketCategory(category.getId());
 
         TicketCategoryModification tcm = new TicketCategoryModification(category.getId(), category.getName(), 11,
@@ -578,7 +578,7 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
         Event event = pair.getLeft();
         String username = pair.getRight();
 
-        TicketCategory category = ticketCategoryRepository.findByEventId(event.getId()).get(0);
+        TicketCategory category = ticketCategoryRepository.findAllTicketCategories(event.getId()).get(0);
         Map<String, String> categoryDescription = ticketCategoryDescriptionRepository.descriptionForTicketCategory(category.getId());
 
         TicketCategoryModification tcm = new TicketCategoryModification(category.getId(), category.getName(), 9,
@@ -608,7 +608,7 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
         Event event = pair.getLeft();
         String username = pair.getRight();
 
-        TicketCategory category = ticketCategoryRepository.findByEventId(event.getId()).get(0);
+        TicketCategory category = ticketCategoryRepository.findAllTicketCategories(event.getId()).get(0);
         Map<String, String> categoryDescription = ticketCategoryDescriptionRepository.descriptionForTicketCategory(category.getId());
 
         specialPriceTokenGenerator.generatePendingCodesForCategory(category.getId());
@@ -680,7 +680,7 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
         assertEquals(Integer.valueOf(AVAILABLE_SEATS), ticketRepository.countFreeTicketsForUnbounded(event.getId()));
         TicketReservationModification trm = new TicketReservationModification();
         trm.setAmount(1);
-        trm.setTicketCategoryId(ticketCategoryRepository.findByEventId(event.getId()).get(0).getId());
+        trm.setTicketCategoryId(ticketCategoryRepository.findAllTicketCategories(event.getId()).get(0).getId());
         TicketReservationWithOptionalCodeModification reservation = new TicketReservationWithOptionalCodeModification(trm, Optional.empty());
         ticketReservationManager.createTicketReservation(event, Collections.singletonList(reservation), Collections.emptyList(),
             DateUtils.addDays(new Date(), 1), Optional.empty(), Locale.ENGLISH, false);

--- a/src/test/java/alfio/manager/TicketReservationManagerIntegrationTest.java
+++ b/src/test/java/alfio/manager/TicketReservationManagerIntegrationTest.java
@@ -116,7 +116,7 @@ public class TicketReservationManagerIntegrationTest extends BaseIntegrationTest
 
         TicketReservationModification tr = new TicketReservationModification();
         tr.setAmount(2);
-        TicketCategory category = ticketCategoryRepository.findByEventId(event.getId()).get(0);
+        TicketCategory category = ticketCategoryRepository.findAllTicketCategories(event.getId()).get(0);
         tr.setTicketCategoryId(category.getId());
         TicketReservationWithOptionalCodeModification mod = new TicketReservationWithOptionalCodeModification(tr, Optional.empty());
         ticketReservationManager.createTicketReservation(event, Collections.singletonList(mod), Collections.emptyList(), DateUtils.addDays(new Date(), 1), Optional.empty(), Locale.ENGLISH, false);
@@ -142,8 +142,8 @@ public class TicketReservationManagerIntegrationTest extends BaseIntegrationTest
         Pair<Event, String> eventAndUsername = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = eventAndUsername.getKey();
 
-        TicketCategory bounded = ticketCategoryRepository.findByEventId(event.getId()).stream().filter(TicketCategory::isBounded).findFirst().orElseThrow(IllegalStateException::new);
-        TicketCategory unbounded = ticketCategoryRepository.findByEventId(event.getId()).stream().filter(t -> !t.isBounded()).findFirst().orElseThrow(IllegalStateException::new);
+        TicketCategory bounded = ticketCategoryRepository.findAllTicketCategories(event.getId()).stream().filter(TicketCategory::isBounded).findFirst().orElseThrow(IllegalStateException::new);
+        TicketCategory unbounded = ticketCategoryRepository.findAllTicketCategories(event.getId()).stream().filter(t -> !t.isBounded()).findFirst().orElseThrow(IllegalStateException::new);
 
         assertEquals(0, eventStatisticsManager.loadModifiedTickets(event.getId(), bounded.getId(), 0, null).size());
         assertEquals(Integer.valueOf(0), eventStatisticsManager.countModifiedTicket(event.getId(), bounded.getId(), null));
@@ -234,7 +234,7 @@ public class TicketReservationManagerIntegrationTest extends BaseIntegrationTest
                 DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null));
         Event event = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository).getKey();
 
-        TicketCategory unbounded = ticketCategoryRepository.findByEventId(event.getId()).stream().filter(t -> !t.isBounded()).findFirst().orElseThrow(IllegalStateException::new);
+        TicketCategory unbounded = ticketCategoryRepository.findAllTicketCategories(event.getId()).stream().filter(t -> !t.isBounded()).findFirst().orElseThrow(IllegalStateException::new);
 
         //promo code at event level
         eventManager.addPromoCode("MYPROMOCODE", event.getId(), null, event.getBegin(), event.getEnd(), 10, PromoCodeDiscount.DiscountType.PERCENTAGE, null, 3, "description", "email@reference.ch", PromoCodeDiscount.CodeType.DISCOUNT, null);
@@ -310,7 +310,7 @@ public class TicketReservationManagerIntegrationTest extends BaseIntegrationTest
         var firstAsKey = additionalServiceRepository.insert(event.getId(), 1000, true, 1, 100, 1, ZonedDateTime.now().minusHours(1), ZonedDateTime.now().plusHours(1), BigDecimal.TEN, AdditionalService.VatType.INHERITED, AdditionalService.AdditionalServiceType.SUPPLEMENT, AdditionalService.SupplementPolicy.OPTIONAL_UNLIMITED_AMOUNT);
         var secondAsKey = additionalServiceRepository.insert(event.getId(), 500, true, 2, 100, 1, ZonedDateTime.now().minusHours(1), ZonedDateTime.now().plusHours(1), BigDecimal.TEN, AdditionalService.VatType.INHERITED, AdditionalService.AdditionalServiceType.DONATION, AdditionalService.SupplementPolicy.OPTIONAL_UNLIMITED_AMOUNT);
 
-        TicketCategory unbounded = ticketCategoryRepository.findByEventId(event.getId()).stream().filter(t -> !t.isBounded()).findFirst().orElseThrow(IllegalStateException::new);
+        TicketCategory unbounded = ticketCategoryRepository.findAllTicketCategories(event.getId()).stream().filter(t -> !t.isBounded()).findFirst().orElseThrow(IllegalStateException::new);
 
         //promo code at event level
         eventManager.addPromoCode("MYPROMOCODE", event.getId(), null, event.getBegin(), event.getEnd(), 10, PromoCodeDiscount.DiscountType.PERCENTAGE, null, 3, "description", "email@reference.ch", PromoCodeDiscount.CodeType.DISCOUNT, null);
@@ -353,7 +353,7 @@ public class TicketReservationManagerIntegrationTest extends BaseIntegrationTest
                 DESCRIPTION, BigDecimal.TEN, true, "", true, null, null, null, null, null));
         Event event = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository).getKey();
 
-        TicketCategory category = ticketCategoryRepository.findByEventId(event.getId()).stream().filter(TicketCategory::isAccessRestricted).findFirst().orElseThrow();
+        TicketCategory category = ticketCategoryRepository.findAllTicketCategories(event.getId()).stream().filter(TicketCategory::isAccessRestricted).findFirst().orElseThrow();
 
         specialPriceTokenGenerator.generatePendingCodesForCategory(category.getId());
 
@@ -427,7 +427,7 @@ public class TicketReservationManagerIntegrationTest extends BaseIntegrationTest
             BigDecimal.TEN, AdditionalService.VatType.INHERITED, Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), AdditionalService.AdditionalServiceType.SUPPLEMENT, AdditionalService.SupplementPolicy.OPTIONAL_UNLIMITED_AMOUNT));
         Event event = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository, additionalServices).getKey();
 
-        TicketCategory unbounded = ticketCategoryRepository.findByEventId(event.getId()).stream().filter(t -> !t.isBounded()).findFirst().orElseThrow(IllegalStateException::new);
+        TicketCategory unbounded = ticketCategoryRepository.findAllTicketCategories(event.getId()).stream().filter(t -> !t.isBounded()).findFirst().orElseThrow(IllegalStateException::new);
 
         TicketReservationModification tr = new TicketReservationModification();
         tr.setAmount(3);
@@ -469,7 +469,7 @@ public class TicketReservationManagerIntegrationTest extends BaseIntegrationTest
                 DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null));
         Event event = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository).getKey();
 
-        TicketCategory unbounded = ticketCategoryRepository.findByEventId(event.getId()).stream().filter(t -> !t.isBounded()).findFirst().orElseThrow(IllegalStateException::new);
+        TicketCategory unbounded = ticketCategoryRepository.findAllTicketCategories(event.getId()).stream().filter(t -> !t.isBounded()).findFirst().orElseThrow(IllegalStateException::new);
 
         TicketReservationModification tr = new TicketReservationModification();
         tr.setAmount(AVAILABLE_SEATS + 1);
@@ -488,7 +488,7 @@ public class TicketReservationManagerIntegrationTest extends BaseIntegrationTest
                 DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null));
         Event event = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository).getKey();
 
-        TicketCategory unbounded = ticketCategoryRepository.findByEventId(event.getId()).get(0);
+        TicketCategory unbounded = ticketCategoryRepository.findAllTicketCategories(event.getId()).get(0);
 
         TicketReservationModification tr = new TicketReservationModification();
         tr.setAmount(AVAILABLE_SEATS / 2 + 1);
@@ -526,7 +526,7 @@ public class TicketReservationManagerIntegrationTest extends BaseIntegrationTest
         Pair<Event, String> eventAndUsername = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = eventAndUsername.getKey();
 
-        TicketCategory bounded = ticketCategoryRepository.findByEventId(event.getId()).stream().filter(TicketCategory::isBounded).findFirst().orElseThrow(IllegalStateException::new);
+        TicketCategory bounded = ticketCategoryRepository.findAllTicketCategories(event.getId()).stream().filter(TicketCategory::isBounded).findFirst().orElseThrow(IllegalStateException::new);
 
 
         TicketReservationModification tr = new TicketReservationModification();
@@ -564,7 +564,7 @@ public class TicketReservationManagerIntegrationTest extends BaseIntegrationTest
         Pair<Event, String> eventAndUsername = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = eventAndUsername.getKey();
 
-        TicketCategory bounded = ticketCategoryRepository.findByEventId(event.getId()).stream().filter(TicketCategory::isBounded).findFirst().orElseThrow(IllegalStateException::new);
+        TicketCategory bounded = ticketCategoryRepository.findAllTicketCategories(event.getId()).stream().filter(TicketCategory::isBounded).findFirst().orElseThrow(IllegalStateException::new);
 
 
         TicketReservationModification tr = new TicketReservationModification();

--- a/src/test/java/alfio/manager/WaitingQueueManagerIntegrationTest.java
+++ b/src/test/java/alfio/manager/WaitingQueueManagerIntegrationTest.java
@@ -166,7 +166,7 @@ public class WaitingQueueManagerIntegrationTest extends BaseIntegrationTest {
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null));
         Event event = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository).getKey();
-        TicketCategory unbounded = ticketCategoryRepository.findByEventId(event.getId()).get(0);
+        TicketCategory unbounded = ticketCategoryRepository.findAllTicketCategories(event.getId()).get(0);
 
         TicketReservationModification tr = new TicketReservationModification();
         tr.setAmount(AVAILABLE_SEATS);
@@ -197,7 +197,7 @@ public class WaitingQueueManagerIntegrationTest extends BaseIntegrationTest {
 
         Event event = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository).getKey();
 
-        TicketCategory unbounded = ticketCategoryRepository.findByEventId(event.getId()).get(0);
+        TicketCategory unbounded = ticketCategoryRepository.findAllTicketCategories(event.getId()).get(0);
 
         TicketReservationModification tr = new TicketReservationModification();
         tr.setAmount(AVAILABLE_SEATS - 1);
@@ -257,7 +257,7 @@ public class WaitingQueueManagerIntegrationTest extends BaseIntegrationTest {
 
         Event event = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository).getKey();
 
-        TicketCategory bounded = ticketCategoryRepository.findByEventId(event.getId()).get(0);
+        TicketCategory bounded = ticketCategoryRepository.findAllTicketCategories(event.getId()).get(0);
 
         TicketReservationModification tr = new TicketReservationModification();
         tr.setAmount(AVAILABLE_SEATS - 1);
@@ -320,7 +320,7 @@ public class WaitingQueueManagerIntegrationTest extends BaseIntegrationTest {
 
         Event event = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository).getKey();
 
-        List<TicketCategory> ticketCategories = ticketCategoryRepository.findByEventId(event.getId());
+        List<TicketCategory> ticketCategories = ticketCategoryRepository.findAllTicketCategories(event.getId());
         TicketCategory first = ticketCategories.get(0);
         TicketCategory second = ticketCategories.get(1);
 
@@ -395,7 +395,7 @@ public class WaitingQueueManagerIntegrationTest extends BaseIntegrationTest {
         configurationManager.saveSystemConfiguration(ConfigurationKeys.ENABLE_WAITING_QUEUE, "true");
         Pair<Event, String> eventAndUsername = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = eventAndUsername.getKey();
-        List<TicketCategory> ticketCategories = ticketCategoryRepository.findByEventId(event.getId());
+        List<TicketCategory> ticketCategories = ticketCategoryRepository.findAllTicketCategories(event.getId());
         TicketCategory first = ticketCategories.stream().filter(tc -> !tc.isAccessRestricted()).findFirst().orElseThrow(IllegalStateException::new);
         reserveTickets(event, first, 2);
         assertTrue(waitingQueueManager.subscribe(event, customerJohnDoe(event), "john@doe.com", null, Locale.ENGLISH));
@@ -430,7 +430,7 @@ public class WaitingQueueManagerIntegrationTest extends BaseIntegrationTest {
         configurationManager.saveSystemConfiguration(ConfigurationKeys.ENABLE_WAITING_QUEUE, "true");
         Pair<Event, String> eventAndUsername = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = eventAndUsername.getKey();
-        List<TicketCategory> ticketCategories = ticketCategoryRepository.findByEventId(event.getId());
+        List<TicketCategory> ticketCategories = ticketCategoryRepository.findAllTicketCategories(event.getId());
         TicketCategory first = ticketCategories.stream().filter(tc -> !tc.isAccessRestricted()).findFirst().orElseThrow(IllegalStateException::new);
         String reservationId = reserveTickets(event, first, 2);
         assertTrue(waitingQueueManager.subscribe(event, customerJohnDoe(event), "john@doe.com", null, Locale.ENGLISH));

--- a/src/test/java/alfio/manager/system/DataMigratorIntegrationTest.java
+++ b/src/test/java/alfio/manager/system/DataMigratorIntegrationTest.java
@@ -323,7 +323,7 @@ public class DataMigratorIntegrationTest extends BaseIntegrationTest {
                 DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null));
         Pair<Event, String> eventUsername = initEvent(categories);
         Event event = eventUsername.getKey();
-        TicketCategory firstCategory = ticketCategoryRepository.findByEventId(event.getId()).stream().filter(TicketCategory::isBounded).findFirst().orElseThrow(IllegalStateException::new);
+        TicketCategory firstCategory = ticketCategoryRepository.findAllTicketCategories(event.getId()).stream().filter(TicketCategory::isBounded).findFirst().orElseThrow(IllegalStateException::new);
         int firstCategoryID = firstCategory.getId();
         ticketCategoryRepository.updateSeatsAvailability(firstCategoryID, AVAILABLE_SEATS + 1);
         dataMigrator.fixCategoriesSize(event);
@@ -355,6 +355,6 @@ public class DataMigratorIntegrationTest extends BaseIntegrationTest {
         String uuid = ticketsInReservation.get(0).getUuid();
         assertTrue(ticketsInReservation.stream().allMatch(t -> t.getStatus() == Ticket.TicketStatus.PENDING));
         dataMigrator.fixStuckTickets(event.getId());
-        assertTrue(ticketRepository.findByUUID(uuid).getStatus() == Ticket.TicketStatus.RELEASED);
+        assertSame(ticketRepository.findByUUID(uuid).getStatus(), Ticket.TicketStatus.RELEASED);
     }
 }


### PR DESCRIPTION
Added the ability to delete a ticket category from the UI.
Categories can be deleted if they do not contain pending or confirmed tickets.

fix #430 