### PR TITLE
vat check fixes

### DIFF
--- a/src/main/java/alfio/controller/api/v2/user/ReservationApiV2Controller.java
+++ b/src/main/java/alfio/controller/api/v2/user/ReservationApiV2Controller.java
@@ -430,7 +430,7 @@ public class ReservationApiV2Controller {
         String country = contactAndTicketsForm.getVatCountryCode();
 
         // validate VAT presence if EU mode is enabled
-        if(vatChecker.isReverseChargeEnabledFor(event) && (country == null || (country != null && isEUCountry(country)))) {
+        if (vatChecker.isReverseChargeEnabledFor(event) && (country == null || isEUCountry(country))) {
             ValidationUtils.rejectIfEmptyOrWhitespace(bindingResult, "vatNr", "error.emptyField");
         }
 

--- a/src/main/java/alfio/controller/api/v2/user/ReservationApiV2Controller.java
+++ b/src/main/java/alfio/controller/api/v2/user/ReservationApiV2Controller.java
@@ -430,7 +430,7 @@ public class ReservationApiV2Controller {
         String country = contactAndTicketsForm.getVatCountryCode();
 
         // validate VAT presence if EU mode is enabled
-        if(vatChecker.isReverseChargeEnabledFor(event) && isEUCountry(country)) {
+        if(vatChecker.isReverseChargeEnabledFor(event) && (country == null || (country != null && isEUCountry(country)))) {
             ValidationUtils.rejectIfEmptyOrWhitespace(bindingResult, "vatNr", "error.emptyField");
         }
 
@@ -444,7 +444,7 @@ public class ReservationApiV2Controller {
 
             vatDetail.ifPresent(vatValidation -> {
                 if (!vatValidation.isValid()) {
-                    bindingResult.rejectValue("vatNr", "error.vat");
+                    bindingResult.rejectValue("vatNr", "error.STEP_2_INVALID_VAT");
                 } else {
                     var reservation = ticketReservationManager.findById(reservationId).orElseThrow();
                     var currencyCode = reservation.getCurrencyCode();

--- a/src/main/java/alfio/manager/EuVatChecker.java
+++ b/src/main/java/alfio/manager/EuVatChecker.java
@@ -33,10 +33,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.stereotype.Component;
 
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.function.BooleanSupplier;
@@ -147,7 +144,9 @@ public class EuVatChecker {
     }
 
     private static boolean reverseChargeEnabled(ConfigurationManager configurationManager, EventAndOrganizationId eventAndOrganizationId) {
-        return configurationManager.getFor(ConfigurationKeys.ENABLE_EU_VAT_DIRECTIVE, ConfigurationLevel.event(eventAndOrganizationId)).getValueAsBooleanOrDefault(false);
+        var res = configurationManager.getFor(Set.of(ConfigurationKeys.ENABLE_EU_VAT_DIRECTIVE, ConfigurationKeys.COUNTRY_OF_BUSINESS), ConfigurationLevel.event(eventAndOrganizationId));
+        return res.get(ConfigurationKeys.ENABLE_EU_VAT_DIRECTIVE).getValueAsBooleanOrDefault(false) &&
+            res.get(ConfigurationKeys.COUNTRY_OF_BUSINESS).isPresent();
     }
 
     static boolean validationEnabled(ConfigurationManager configurationManager, EventAndOrganizationId eventAndOrganizationId) {

--- a/src/test/java/alfio/manager/EuVatCheckerTest.java
+++ b/src/test/java/alfio/manager/EuVatCheckerTest.java
@@ -27,7 +27,9 @@ import ch.digitalfondue.vatchecker.EUVatChecker;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
@@ -51,6 +53,9 @@ public class EuVatCheckerTest {
             .thenReturn(buildConfReturn(ConfigurationKeys.EU_COUNTRIES_LIST, "IE"));
         when(configurationManager.getFor(eq(ConfigurationKeys.COUNTRY_OF_BUSINESS), any(ConfigurationLevel.class)))
             .thenReturn(buildConfReturn(ConfigurationKeys.COUNTRY_OF_BUSINESS, "IT"));
+        when(configurationManager.getFor(eq(Set.of(ConfigurationKeys.ENABLE_EU_VAT_DIRECTIVE, ConfigurationKeys.COUNTRY_OF_BUSINESS)), any()))
+            .thenReturn(Map.of(ConfigurationKeys.ENABLE_EU_VAT_DIRECTIVE, buildConfReturn(ConfigurationKeys.ENABLE_EU_VAT_DIRECTIVE, "true"),
+                ConfigurationKeys.COUNTRY_OF_BUSINESS, buildConfReturn(ConfigurationKeys.COUNTRY_OF_BUSINESS, "IT")));
     }
 
     private static ConfigurationManager.MaybeConfiguration buildConfReturn(ConfigurationKeys k, String value) {


### PR DESCRIPTION
1. better handling when submitted country is null. Currently, the server return a 500 error if the user does not select a country.


2. better handling when the event organizer has not set the country of business. Currently it launch a 500 (null pointer exception) if the organizer has set to enable the reverse charge but has not set the country of business.

3. use the correct error message
