### PR TITLE
#713 always escape raw html in markdown description

### DIFF
--- a/src/main/java/alfio/controller/api/admin/UtilsApiController.java
+++ b/src/main/java/alfio/controller/api/admin/UtilsApiController.java
@@ -24,7 +24,6 @@ import alfio.util.MustacheCustomTag;
 import alfio.util.Wrappers;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.commons.text.StringEscapeUtils;
 import org.joda.money.CurrencyUnit;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -79,7 +78,7 @@ public class UtilsApiController {
     
     @GetMapping("/render-commonmark")
     public String renderCommonmark(@RequestParam("text") String input) {
-        return MustacheCustomTag.renderToCommonmark(StringEscapeUtils.escapeHtml4(input));
+        return MustacheCustomTag.renderToHtmlCommonmarkEscaped(input);
     }
 
     @GetMapping("/alfio/info")

--- a/src/main/java/alfio/controller/api/v2/user/EventApiV2Controller.java
+++ b/src/main/java/alfio/controller/api/v2/user/EventApiV2Controller.java
@@ -258,7 +258,7 @@ public class EventApiV2Controller {
 
         var res = new HashMap<String, String>();
         in.forEach((k, v) -> {
-            res.put(k, MustacheCustomTag.renderToCommonmark(v));
+            res.put(k, MustacheCustomTag.renderToHtmlCommonmarkEscaped(v));
         });
         return res;
     }

--- a/src/main/java/alfio/util/MustacheCustomTag.java
+++ b/src/main/java/alfio/util/MustacheCustomTag.java
@@ -20,6 +20,7 @@ import alfio.controller.api.support.TicketHelper;
 import com.samskivert.mustache.Mustache;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.text.StringEscapeUtils;
 import org.commonmark.Extension;
 import org.commonmark.ext.gfm.tables.TablesExtension;
 import org.commonmark.node.Node;
@@ -134,8 +135,8 @@ public class MustacheCustomTag {
     private static final HtmlRenderer COMMONMARK_RENDERER = HtmlRenderer.builder().extensions(COMMONMARK_EXTENSIONS).build();
     private static final TextContentRenderer COMMONMARK_TEXT_RENDERER = TextContentRenderer.builder().extensions(COMMONMARK_EXTENSIONS).build();
 
-    public static String renderToCommonmark(String input) {
-        Node document = COMMONMARK_PARSER.parse(input);
+    public static String renderToHtmlCommonmarkEscaped(String input) {
+        Node document = COMMONMARK_PARSER.parse(StringEscapeUtils.escapeHtml4(input));
         return COMMONMARK_RENDERER.render(document);
     }
 


### PR DESCRIPTION
see #713 more coherence with the resulting preview from the admin.
