### PR TITLE
refactor geoapi params, avoid one level of transformation

### DIFF
--- a/src/main/java/alfio/controller/api/admin/LocationApiController.java
+++ b/src/main/java/alfio/controller/api/admin/LocationApiController.java
@@ -71,24 +71,20 @@ public class LocationApiController {
     public String getMapImage(
         @RequestParam(name = "lat", required = false) String lat,
         @RequestParam(name = "lng", required = false) String lng) {
-        Map<ConfigurationKeys, Optional<String>> geoInfoConfiguration = getGeoConf();
-        return LocationDescriptor.getMapUrl(lat, lng, geoInfoConfiguration);
+        return LocationDescriptor.getMapUrl(lat, lng, getGeoConf());
     }
 
-    private Map<ConfigurationKeys, Optional<String>> getGeoConf() {
+    private Map<ConfigurationKeys, ConfigurationManager.MaybeConfiguration> getGeoConf() {
         var keys = Set.of(MAPS_PROVIDER, MAPS_CLIENT_API_KEY, MAPS_HERE_APP_ID, MAPS_HERE_APP_CODE);
-        var conf = configurationManager.getFor(keys, ConfigurationLevel.system());
-        var res = new EnumMap<ConfigurationKeys, Optional<String>>(ConfigurationKeys.class);
-        conf.forEach((k,v) -> res.put(k, v.getValue()));
-        return res;
+        return configurationManager.getFor(keys, ConfigurationLevel.system());
     }
 
     @GetMapping("/location/map-provider-client-api-key")
     public ProviderAndKeys getGeoInfoProviderAndKeys() {
-        Map<ConfigurationKeys, Optional<String>> geoInfoConfiguration = getGeoConf();
+        var geoInfoConfiguration = getGeoConf();
         ConfigurationKeys.GeoInfoProvider provider = LocationDescriptor.getProvider(geoInfoConfiguration);
         Map<ConfigurationKeys, String> apiKeys = new EnumMap<>(ConfigurationKeys.class);
-        geoInfoConfiguration.forEach((k,v) -> v.ifPresent(value -> apiKeys.put(k, value)));
+        geoInfoConfiguration.forEach((k,v) -> v.getValue().ifPresent(value -> apiKeys.put(k, value)));
         return new ProviderAndKeys(provider, apiKeys);
     }
 

--- a/src/main/java/alfio/controller/api/v2/user/EventApiV2Controller.java
+++ b/src/main/java/alfio/controller/api/v2/user/EventApiV2Controller.java
@@ -165,13 +165,7 @@ public class EventApiV2Controller {
                     COUNTRY_OF_BUSINESS
                 ), ConfigurationLevel.event(event));
 
-                var geoInfoConfiguration = Map.of(
-                    MAPS_PROVIDER, configurationsValues.get(MAPS_PROVIDER).getValue(),
-                    MAPS_CLIENT_API_KEY, configurationsValues.get(MAPS_CLIENT_API_KEY).getValue(),
-                    MAPS_HERE_APP_ID, configurationsValues.get(MAPS_HERE_APP_ID).getValue(),
-                    MAPS_HERE_APP_CODE, configurationsValues.get(MAPS_HERE_APP_CODE).getValue());
-
-                var ld = LocationDescriptor.fromGeoData(event.getLatLong(), TimeZone.getTimeZone(event.getTimeZone()), geoInfoConfiguration);
+                var locationDescriptor = LocationDescriptor.fromGeoData(event.getLatLong(), TimeZone.getTimeZone(event.getTimeZone()), configurationsValues);
 
                 Map<PaymentMethod, PaymentProxyWithParameters> availablePaymentMethods = new EnumMap<>(PaymentMethod.class);
 
@@ -236,7 +230,7 @@ public class EventApiV2Controller {
                 var analyticsConf = AnalyticsConfiguration.build(configurationsValues, session);
                 //
 
-                return new ResponseEntity<>(new EventWithAdditionalInfo(event, ld.getMapUrl(), organization, descriptions, availablePaymentMethods,
+                return new ResponseEntity<>(new EventWithAdditionalInfo(event, locationDescriptor.getMapUrl(), organization, descriptions, availablePaymentMethods,
                     bankAccount, bankAccountOwner,
                     formattedBeginDate, formattedBeginTime,
                     formattedEndDate, formattedEndTime,

--- a/src/main/java/alfio/manager/system/ConfigurationManager.java
+++ b/src/main/java/alfio/manager/system/ConfigurationManager.java
@@ -562,6 +562,10 @@ public class ConfigurationManager {
             return configuration.isPresent();
         }
 
+        public boolean isEmpty() {
+            return configuration.isEmpty();
+        }
+
         public Optional<String> getValue() {
             return configuration.map(ConfigurationKeyValuePathLevel::getValue);
         }

--- a/src/test/java/alfio/model/modification/support/LocationDescriptorTest.java
+++ b/src/test/java/alfio/model/modification/support/LocationDescriptorTest.java
@@ -16,6 +16,8 @@
  */
 package alfio.model.modification.support;
 
+import alfio.manager.system.ConfigurationManager;
+import alfio.model.system.ConfigurationKeyValuePathLevel;
 import alfio.model.system.ConfigurationKeys;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Test;
@@ -32,26 +34,30 @@ public class LocationDescriptorTest {
     private final TimeZone timeZone = TimeZone.getDefault();
     private Function<String, LocationDescriptor> locationDescriptorBuilder = (mapUrl) -> new LocationDescriptor(timeZone.getID(), latitude, longitude, mapUrl);
 
+
+    private static ConfigurationManager.MaybeConfiguration buildMaybeConf(ConfigurationKeys k, String val) {
+        return new ConfigurationManager.MaybeConfiguration(k, new ConfigurationKeyValuePathLevel(k.name(), val, null));
+    }
+
     @Test
     public void testLocationDescriptorGoogle() {
-        Map<ConfigurationKeys, Optional<String>> geoInfo = Collections.singletonMap(ConfigurationKeys.MAPS_CLIENT_API_KEY, Optional.of("mapKey"));
+        var geoInfo = Map.of(ConfigurationKeys.MAPS_CLIENT_API_KEY, buildMaybeConf(ConfigurationKeys.MAPS_CLIENT_API_KEY, "mapKey"));
         final LocationDescriptor expected = locationDescriptorBuilder.apply("https://maps.googleapis.com/maps/api/staticmap?center=latitude,longitude&key=mapKey&zoom=16&size=400x400&markers=color:blue%7Clabel:E%7Clatitude,longitude");
         assertEquals(expected, LocationDescriptor.fromGeoData(Pair.of(latitude, longitude), timeZone, geoInfo));
     }
 
     @Test
     public void testLocationDescriptorNone() {
-        Map<ConfigurationKeys, Optional<String>> geoInfo = Collections.emptyMap();
+        Map<ConfigurationKeys, ConfigurationManager.MaybeConfiguration> geoInfo = Collections.emptyMap();
         final LocationDescriptor expected = locationDescriptorBuilder.apply("");
         assertEquals(expected, LocationDescriptor.fromGeoData(Pair.of(latitude, longitude), timeZone, geoInfo));
     }
 
     @Test
     public void testLocationDescriptorGoogleWithTypeSet() {
-        Map<ConfigurationKeys, Optional<String>> geoInfo = new HashMap<>();
-
-        geoInfo.put(ConfigurationKeys.MAPS_PROVIDER, Optional.of(ConfigurationKeys.GeoInfoProvider.GOOGLE.name()));
-        geoInfo.put(ConfigurationKeys.MAPS_CLIENT_API_KEY, Optional.of("mapKey"));
+        var geoInfo = Map.of(
+            ConfigurationKeys.MAPS_PROVIDER, buildMaybeConf(ConfigurationKeys.MAPS_PROVIDER, ConfigurationKeys.GeoInfoProvider.GOOGLE.name()),
+            ConfigurationKeys.MAPS_CLIENT_API_KEY, buildMaybeConf(ConfigurationKeys.MAPS_CLIENT_API_KEY, "mapKey"));
 
         final LocationDescriptor expected = locationDescriptorBuilder.apply("https://maps.googleapis.com/maps/api/staticmap?center=latitude,longitude&key=mapKey&zoom=16&size=400x400&markers=color:blue%7Clabel:E%7Clatitude,longitude");
         assertEquals(expected, LocationDescriptor.fromGeoData(Pair.of(latitude, longitude), timeZone, geoInfo));
@@ -59,10 +65,11 @@ public class LocationDescriptorTest {
 
     @Test
     public void testLocationDescriptorHEREWithTypeSet() {
-        Map<ConfigurationKeys, Optional<String>> geoInfo = new HashMap<>();
-        geoInfo.put(ConfigurationKeys.MAPS_PROVIDER, Optional.of(ConfigurationKeys.GeoInfoProvider.HERE.name()));
-        geoInfo.put(ConfigurationKeys.MAPS_HERE_APP_ID, Optional.of("appId"));
-        geoInfo.put(ConfigurationKeys.MAPS_HERE_APP_CODE, Optional.of("appCode"));
+        var geoInfo = Map.of(
+            ConfigurationKeys.MAPS_PROVIDER, buildMaybeConf(ConfigurationKeys.MAPS_PROVIDER, ConfigurationKeys.GeoInfoProvider.HERE.name()),
+            ConfigurationKeys.MAPS_HERE_APP_ID, buildMaybeConf(ConfigurationKeys.MAPS_HERE_APP_ID, "appId"),
+            ConfigurationKeys.MAPS_HERE_APP_CODE, buildMaybeConf(ConfigurationKeys.MAPS_HERE_APP_CODE, "appCode")
+        );
 
         final LocationDescriptor expected = locationDescriptorBuilder.apply("https://image.maps.api.here.com/mia/1.6/mapview?c=latitude,longitude&z=16&w=400&h=400&poi=latitude,longitude&app_id=appId&app_code=appCode");
         assertEquals(expected, LocationDescriptor.fromGeoData(Pair.of(latitude, longitude), timeZone, geoInfo));
@@ -70,8 +77,7 @@ public class LocationDescriptorTest {
 
     @Test
     public void testLocationDescriptorNONEWithTypeSet() {
-        Map<ConfigurationKeys, Optional<String>> geoInfo = new HashMap<>();
-        geoInfo.put(ConfigurationKeys.MAPS_PROVIDER, Optional.of(ConfigurationKeys.GeoInfoProvider.NONE.name()));
+        var geoInfo = Map.of(ConfigurationKeys.MAPS_PROVIDER, buildMaybeConf(ConfigurationKeys.MAPS_PROVIDER, ConfigurationKeys.GeoInfoProvider.NONE.name()));
         final LocationDescriptor expected = locationDescriptorBuilder.apply("");
         assertEquals(expected, LocationDescriptor.fromGeoData(Pair.of(latitude, longitude), timeZone, geoInfo));
     }


### PR DESCRIPTION
avoid creating useless data structure support for handling the geoapi. Use directly the results from  configurationManager.getFor