### PR TITLE
fix event creation default end date

### DIFF
--- a/src/main/webapp/resources/js/admin/directive/admin-directive.js
+++ b/src/main/webapp/resources/js/admin/directive/admin-directive.js
@@ -67,6 +67,8 @@
 
                 scope.startModelObj['date'] = startDate.format('YYYY-MM-DD');
                 scope.startModelObj['time'] = startDate.format('HH:mm');
+                scope.endModelObj['date'] = endDate.format('YYYY-MM-DD');
+                scope.endModelObj['time'] = endDate.format('HH:mm');
 
 
                 function updateDates(picker, override) {
@@ -111,7 +113,6 @@
                 element.on('hide.daterangepicker', function(ev, picker) {
                 	updateDates(picker, true);
                 });
-
             }
         };
     });


### PR DESCRIPTION
When you use the default event date range, you get an error on the ticket category date on submit.

This is due to a missing end date in the event model. This values are set in the date-range directive.