### PR TITLE
Include additional items in the check-in response

### DIFF
--- a/src/main/java/alfio/manager/EventManager.java
+++ b/src/main/java/alfio/manager/EventManager.java
@@ -350,6 +350,31 @@ public class EventManager {
         }
     }
 
+    public EventModification.AdditionalService insertAdditionalService(Event event, EventModification.AdditionalService additionalService) {
+        int eventId = event.getId();
+        AffectedRowCountAndKey<Integer> result = additionalServiceRepository.insert(eventId,
+            Optional.ofNullable(additionalService.getPrice()).map(p -> MonetaryUtil.unitToCents(p, event.getCurrency())).orElse(0),
+            additionalService.isFixPrice(),
+            additionalService.getOrdinal(),
+            additionalService.getAvailableQuantity(),
+            additionalService.getMaxQtyPerOrder(),
+            additionalService.getInception().toZonedDateTime(event.getZoneId()),
+            additionalService.getExpiration().toZonedDateTime(event.getZoneId()),
+            additionalService.getVat(),
+            additionalService.getVatType(),
+            additionalService.getType(),
+            additionalService.getSupplementPolicy());
+        Validate.isTrue(result.getAffectedRowCount() == 1, "too many records updated");
+        int id = result.getKey();
+        Stream.concat(additionalService.getTitle().stream(), additionalService.getDescription().stream()).
+            forEach(t -> additionalServiceTextRepository.insert(id, t.getLocale(), t.getType(), t.getValue()));
+
+        return EventModification.AdditionalService.from(additionalServiceRepository.getById(result.getKey(), eventId))
+            .withText(additionalServiceTextRepository.findAllByAdditionalServiceId(result.getKey()))
+            .withZoneId(event.getZoneId())
+            .build();
+    }
+
     /**
      * This method has been modified to use the new Result<T> mechanism.
      * It will be replaced by {@link #insertCategory(Event, TicketCategoryModification, String)} in the next releases

--- a/src/main/java/alfio/manager/support/AdditionalServiceInfo.java
+++ b/src/main/java/alfio/manager/support/AdditionalServiceInfo.java
@@ -14,28 +14,18 @@
  * You should have received a copy of the GNU General Public License
  * along with alf.io.  If not, see <http://www.gnu.org/licenses/>.
  */
-package alfio.model;
+package alfio.manager.support;
 
+import alfio.model.TicketFieldValueForAdditionalService;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import lombok.experimental.Delegate;
 
+import java.util.List;
+
+@Getter
 @RequiredArgsConstructor
-public class TicketWithCategory implements TicketInfoContainer {
-
-    @Delegate
-    private final Ticket ticket;
-    private final TicketCategory category;
-
-    public String getCategoryName() {
-        return category != null ? category.getName() : null;
-    }
-
-    public TicketCategory getCategory() {
-        return category;
-    }
-
-    protected Ticket getTicket() {
-        return ticket;
-    }
-
+public class AdditionalServiceInfo {
+    private final String name;
+    private final int count;
+    private final List<TicketFieldValueForAdditionalService> fields;
 }

--- a/src/main/java/alfio/manager/support/SuccessfulCheckIn.java
+++ b/src/main/java/alfio/manager/support/SuccessfulCheckIn.java
@@ -14,28 +14,23 @@
  * You should have received a copy of the GNU General Public License
  * along with alf.io.  If not, see <http://www.gnu.org/licenses/>.
  */
-package alfio.model;
+package alfio.manager.support;
 
-import lombok.RequiredArgsConstructor;
-import lombok.experimental.Delegate;
+import alfio.model.TicketWithCategory;
 
-@RequiredArgsConstructor
-public class TicketWithCategory implements TicketInfoContainer {
+import java.util.List;
 
-    @Delegate
-    private final Ticket ticket;
-    private final TicketCategory category;
+import static alfio.manager.support.CheckInStatus.SUCCESS;
 
-    public String getCategoryName() {
-        return category != null ? category.getName() : null;
+public class SuccessfulCheckIn extends TicketAndCheckInResult {
+    private final List<AdditionalServiceInfo> additionalServices;
+
+    public SuccessfulCheckIn(TicketWithCategory ticket, List<AdditionalServiceInfo> additionalServices) {
+        super(ticket, new DefaultCheckInResult(SUCCESS, "success"));
+        this.additionalServices = additionalServices;
     }
 
-    public TicketCategory getCategory() {
-        return category;
+    public List<AdditionalServiceInfo> getAdditionalServices() {
+        return additionalServices;
     }
-
-    protected Ticket getTicket() {
-        return ticket;
-    }
-
 }

--- a/src/main/java/alfio/model/FullTicketInfo.java
+++ b/src/main/java/alfio/model/FullTicketInfo.java
@@ -27,7 +27,7 @@ import java.time.ZonedDateTime;
 import java.util.Date;
 
 @Getter
-public class FullTicketInfo {
+public class FullTicketInfo implements TicketInfoContainer {
 
     @Delegate
     private final Ticket ticket;

--- a/src/main/java/alfio/model/Ticket.java
+++ b/src/main/java/alfio/model/Ticket.java
@@ -31,7 +31,7 @@ import java.util.Optional;
 import java.util.Set;
 
 @Getter
-public class Ticket {
+public class Ticket implements TicketInfoContainer {
 
     public enum TicketStatus {
         FREE, PENDING, TO_BE_PAID, ACQUIRED, CANCELLED, CHECKED_IN, EXPIRED, INVALIDATED, RELEASED, PRE_RESERVED
@@ -101,6 +101,7 @@ public class Ticket {
         this.currencyCode = currencyCode;
     }
     
+    @Override
     public boolean getAssigned() {
         return (StringUtils.isNotBlank(fullName) || (StringUtils.isNotBlank(firstName) && StringUtils.isNotBlank(lastName))) && StringUtils.isNotBlank(email);
     }
@@ -129,6 +130,7 @@ public class Ticket {
         return SOLD_STATUSES.contains(status);
     }
 
+    @Override
     public boolean isCheckedIn() {
         return status == TicketStatus.CHECKED_IN;
     }

--- a/src/main/java/alfio/model/TicketInfoContainer.java
+++ b/src/main/java/alfio/model/TicketInfoContainer.java
@@ -16,26 +16,24 @@
  */
 package alfio.model;
 
-import lombok.RequiredArgsConstructor;
-import lombok.experimental.Delegate;
+public interface TicketInfoContainer {
+    boolean getAssigned();
 
-@RequiredArgsConstructor
-public class TicketWithCategory implements TicketInfoContainer {
+    boolean isCheckedIn();
 
-    @Delegate
-    private final Ticket ticket;
-    private final TicketCategory category;
+    int getId();
 
-    public String getCategoryName() {
-        return category != null ? category.getName() : null;
-    }
+    String getUuid();
 
-    public TicketCategory getCategory() {
-        return category;
-    }
+    int getEventId();
 
-    protected Ticket getTicket() {
-        return ticket;
-    }
+    String getTicketsReservationId();
 
+    String getFirstName();
+
+    String getLastName();
+
+    String getEmail();
+
+    String getUserLanguage();
 }

--- a/src/main/java/alfio/repository/TicketRepository.java
+++ b/src/main/java/alfio/repository/TicketRepository.java
@@ -139,6 +139,9 @@ public interface TicketRepository {
     @Query("select * from ticket where tickets_reservation_id = :reservationId order by category_id asc, uuid asc LIMIT 1 OFFSET 0")
     Optional<Ticket> findFirstTicketInReservation(@Bind("reservationId") String reservationId);
 
+    @Query("select id from ticket where tickets_reservation_id = :reservationId order by category_id asc, uuid asc LIMIT 1 OFFSET 0")
+    Optional<Integer> findFirstTicketIdInReservation(@Bind("reservationId") String reservationId);
+
     @Query("select count(*) from ticket where tickets_reservation_id = :reservationId ")
     Integer countTicketsInReservation(@Bind("reservationId") String reservationId);
     

--- a/src/main/java/alfio/repository/TicketRepository.java
+++ b/src/main/java/alfio/repository/TicketRepository.java
@@ -34,6 +34,7 @@ public interface TicketRepository {
     String FREE = "FREE";
     String RELEASED = "RELEASED";
     String REVERT_TO_FREE = "update ticket set status = 'FREE' where status = 'RELEASED' and event_id = :eventId";
+    String SORT_TICKETS = "order by category_id asc, uuid asc";
 
 
     //TODO: refactor, try to move the MapSqlParameterSource inside the default method!
@@ -130,16 +131,16 @@ public interface TicketRepository {
     @Query("update ticket set category_id = null where event_id = :eventId and category_id = :categoryId and id in (:ticketIds)")
     int unbindTicketsFromCategory(@Bind("eventId") int eventId, @Bind("categoryId") int categoryId, @Bind("ticketIds") List<Integer> ids);
 
-    @Query("select * from ticket where tickets_reservation_id = :reservationId order by category_id asc, uuid asc")
+    @Query("select * from ticket where tickets_reservation_id = :reservationId " + SORT_TICKETS)
     List<Ticket> findTicketsInReservation(@Bind("reservationId") String reservationId);
 
-    @Query("select id from ticket where tickets_reservation_id = :reservationId order by category_id asc, uuid asc")
+    @Query("select id from ticket where tickets_reservation_id = :reservationId " + SORT_TICKETS)
     List<Integer> findTicketIdsInReservation(@Bind("reservationId") String reservationId);
 
-    @Query("select * from ticket where tickets_reservation_id = :reservationId order by category_id asc, uuid asc LIMIT 1 OFFSET 0")
+    @Query("select * from ticket where tickets_reservation_id = :reservationId " + SORT_TICKETS + " LIMIT 1 OFFSET 0")
     Optional<Ticket> findFirstTicketInReservation(@Bind("reservationId") String reservationId);
 
-    @Query("select id from ticket where tickets_reservation_id = :reservationId order by category_id asc, uuid asc LIMIT 1 OFFSET 0")
+    @Query("select id from ticket where tickets_reservation_id = :reservationId " + SORT_TICKETS + " LIMIT 1 OFFSET 0")
     Optional<Integer> findFirstTicketIdInReservation(@Bind("reservationId") String reservationId);
 
     @Query("select count(*) from ticket where tickets_reservation_id = :reservationId ")

--- a/src/test/java/alfio/manager/CheckInManagerIntegrationTest.java
+++ b/src/test/java/alfio/manager/CheckInManagerIntegrationTest.java
@@ -1,0 +1,138 @@
+/**
+ * This file is part of alf.io.
+ *
+ * alf.io is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * alf.io is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with alf.io.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package alfio.manager;
+
+import alfio.TestConfiguration;
+import alfio.config.DataSourceConfiguration;
+import alfio.config.Initializer;
+import alfio.manager.payment.PaymentSpecification;
+import alfio.manager.support.PaymentResult;
+import alfio.manager.user.UserManager;
+import alfio.model.*;
+import alfio.model.modification.*;
+import alfio.model.transaction.PaymentProxy;
+import alfio.repository.EventRepository;
+import alfio.repository.TicketCategoryRepository;
+import alfio.repository.TicketRepository;
+import alfio.repository.system.ConfigurationRepository;
+import alfio.repository.user.OrganizationRepository;
+import alfio.test.util.IntegrationTestUtil;
+import org.apache.commons.lang3.time.DateUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZonedDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static alfio.test.util.IntegrationTestUtil.*;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = {DataSourceConfiguration.class, TestConfiguration.class})
+@ActiveProfiles({Initializer.PROFILE_DEV, Initializer.PROFILE_DISABLE_JOBS, Initializer.PROFILE_INTEGRATION_TEST})
+@Transactional
+public class CheckInManagerIntegrationTest {
+
+    @Autowired
+    private CheckInManager checkInManager;
+    @Autowired
+    private ConfigurationRepository configurationRepository;
+    @Autowired
+    private UserManager userManager;
+    @Autowired
+    private OrganizationRepository organizationRepository;
+    @Autowired
+    private EventManager eventManager;
+    @Autowired
+    private EventRepository eventRepository;
+    @Autowired
+    private TicketCategoryRepository ticketCategoryRepository;
+    @Autowired
+    private TicketReservationManager ticketReservationManager;
+    @Autowired
+    private TicketRepository ticketRepository;
+
+    @Test
+    public void testReturnOnlyOnce() {
+        IntegrationTestUtil.ensureMinimalConfiguration(configurationRepository);
+        List<TicketCategoryModification> categories = List.of(
+            new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
+                new DateTimeModification(LocalDate.now().minusDays(1), LocalTime.now()),
+                new DateTimeModification(LocalDate.now().plusDays(1), LocalTime.now()),
+                DESCRIPTION, BigDecimal.TEN, false,
+                "", false, null, null, null, null, null, 0, null)
+        );
+        Pair<Event, String> eventAndUser = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
+        var event = eventAndUser.getLeft();
+        var additionalServiceRequest = new EventModification.AdditionalService(
+            null,
+            BigDecimal.ONE,
+            true,
+            1,
+            100,
+            2,
+            DateTimeModification.fromZonedDateTime(ZonedDateTime.now().minusDays(1)),
+            DateTimeModification.fromZonedDateTime(ZonedDateTime.now().plusDays(1)),
+            BigDecimal.ZERO,
+            AdditionalService.VatType.INHERITED,
+            List.of(),
+            List.of(new EventModification.AdditionalServiceText(null, "en", "bla", AdditionalServiceText.TextType.TITLE)),
+            List.of(new EventModification.AdditionalServiceText(null, "en", "blabla", AdditionalServiceText.TextType.DESCRIPTION)),
+            AdditionalService.AdditionalServiceType.SUPPLEMENT,
+            AdditionalService.SupplementPolicy.OPTIONAL_UNLIMITED_AMOUNT
+        );
+        var additionalService = eventManager.insertAdditionalService(event, additionalServiceRequest);
+        var category = ticketCategoryRepository.findAllTicketCategories(event.getId()).get(0);
+        TicketReservationModification tr = new TicketReservationModification();
+        tr.setAmount(AVAILABLE_SEATS);
+        tr.setTicketCategoryId(category.getId());
+
+        var tickets = new TicketReservationWithOptionalCodeModification(tr, Optional.empty());
+        var additionalServices = new AdditionalServiceReservationModification();
+        additionalServices.setAdditionalServiceId(additionalService.getId());
+        additionalServices.setQuantity(1);
+
+        var additionalServicesModification = new ASReservationWithOptionalCodeModification(additionalServices, Optional.empty());
+        String reservationId = ticketReservationManager.createTicketReservation(event, List.of(tickets), List.of(additionalServicesModification), DateUtils.addDays(new Date(), 1), Optional.empty(), Locale.ENGLISH, false);
+        TotalPrice reservationCost = ticketReservationManager.totalReservationCostWithVAT(reservationId);
+        PaymentSpecification specification = new PaymentSpecification(reservationId, null, reservationCost.getPriceWithVAT(),
+            event, "email@example.com", new CustomerName("full name", "full", "name", event.mustUseFirstAndLastName()),
+            "billing address", null, Locale.ENGLISH, true, false, null, "IT", "123456", PriceContainer.VatStatus.INCLUDED, true, false);
+        PaymentResult result = ticketReservationManager.performPayment(specification, reservationCost, Optional.of(PaymentProxy.OFFLINE));
+        assertTrue(result.isSuccessful());
+        ticketReservationManager.confirmOfflinePayment(event, reservationId, eventAndUser.getRight());
+
+        var returnedAdditionalServices = ticketReservationManager.findTicketsInReservation(reservationId).stream()
+            .filter(ticket -> !checkInManager.getAdditionalServicesForTicket(ticket).isEmpty())
+            .collect(Collectors.toList());
+        //
+        assertEquals(1, returnedAdditionalServices.size());
+        assertEquals((int) ticketRepository.findFirstTicketIdInReservation(reservationId).orElseThrow(), returnedAdditionalServices.get(0).getId());
+
+    }
+
+}


### PR DESCRIPTION
We need to display additional items (e.g. T-Shirts) on the mobile app and check-in stations upon check-in, so that the operator can distribute them accordingly.
Given the current model limitations, we'll return the additional items only for the first ticket in the reservation.
