### PR TITLE
Configure badge colors for event

### DIFF
--- a/src/main/java/alfio/controller/api/admin/ConfigurationApiController.java
+++ b/src/main/java/alfio/controller/api/admin/ConfigurationApiController.java
@@ -26,6 +26,7 @@ import alfio.model.user.Organization;
 import lombok.Data;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
@@ -82,10 +83,15 @@ public class ConfigurationApiController {
     }
 
     @GetMapping("/events/{eventId}/single/{key}")
-    public String getSingleConfigForEvent(@PathVariable("eventId") int eventId,
-                                   @PathVariable("key") String key,
-                                   Principal principal) {
-        return configurationManager.getSingleConfigForEvent(eventId, key, principal.getName());
+    public ResponseEntity<String> getSingleConfigForEvent(@PathVariable("eventId") int eventId,
+                                                         @PathVariable("key") String key,
+                                                         Principal principal) {
+
+        String singleConfigForEvent = configurationManager.getSingleConfigForEvent(eventId, key, principal.getName());
+        if(singleConfigForEvent == null) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.ok(singleConfigForEvent);
     }
 
     @PostMapping(value = "/organizations/{organizationId}/events/{eventId}/update")

--- a/src/main/java/alfio/manager/AdminReservationManager.java
+++ b/src/main/java/alfio/manager/AdminReservationManager.java
@@ -509,7 +509,7 @@ public class AdminReservationManager {
         int tickets = attendees.size();
         TicketCategoryModification tcm = new TicketCategoryModification(category.getExistingCategoryId(), category.getName(), tickets,
             inception, reservation.getExpiration(), Collections.emptyMap(), category.getPrice(), true, "",
-            true, null, null, null, null, null, 0, null);
+            true, null, null, null, null, null, 0, null, null);
         int notAllocated = getNotAllocatedTickets(event);
         int missingTickets = Math.max(tickets - notAllocated, 0);
         Event modified = increaseSeatsIfNeeded(ti, event, missingTickets, event);
@@ -551,7 +551,7 @@ public class AdminReservationManager {
                 fromZonedDateTime(existing.getValidCheckInTo(modified.getZoneId())),
                 fromZonedDateTime(existing.getTicketValidityStart(modified.getZoneId())),
                 fromZonedDateTime(existing.getTicketValidityEnd(modified.getZoneId())), 0,
-                existing.getTicketCheckInStrategy());
+                existing.getTicketCheckInStrategy(), null);
             return eventManager.updateCategory(existingCategoryId, modified, tcm, username, true);
         }
         return Result.success(existing);

--- a/src/main/java/alfio/manager/CheckInManager.java
+++ b/src/main/java/alfio/manager/CheckInManager.java
@@ -22,6 +22,7 @@ import alfio.manager.system.ConfigurationManager;
 import alfio.model.*;
 import alfio.model.Ticket.TicketStatus;
 import alfio.model.audit.ScanAudit;
+import alfio.model.support.CheckInOutputColorConfiguration;
 import alfio.model.transaction.PaymentProxy;
 import alfio.repository.*;
 import alfio.repository.audit.ScanAuditRepository;
@@ -60,6 +61,7 @@ import java.util.stream.Collectors;
 import static alfio.manager.support.CheckInStatus.*;
 import static alfio.model.Audit.EventType.*;
 import static alfio.model.system.ConfigurationKeys.*;
+import static alfio.util.Wrappers.optionally;
 import static java.util.stream.Collectors.toMap;
 import static org.apache.commons.lang3.StringUtils.trimToEmpty;
 
@@ -139,10 +141,11 @@ public class CheckInManager {
         var checkInStatus = descriptor.getResult().getStatus();
         if(checkInStatus == OK_READY_TO_BE_CHECKED_IN) {
             checkIn(ticketIdentifier);
+            TicketWithCategory ticket = descriptor.getTicket();
             scanAuditRepository.insert(ticketIdentifier, eventId, ZonedDateTime.now(), user, SUCCESS, ScanAudit.Operation.SCAN);
-            auditingRepository.insert(descriptor.getTicket().getTicketsReservationId(), userRepository.findIdByUserName(user).orElse(null), eventId, CHECK_IN, new Date(), Audit.EntityType.TICKET, Integer.toString(descriptor.getTicket().getId()));
+            auditingRepository.insert(ticket.getTicketsReservationId(), userRepository.findIdByUserName(user).orElse(null), eventId, CHECK_IN, new Date(), Audit.EntityType.TICKET, Integer.toString(descriptor.getTicket().getId()));
             // return also additional items, if any
-            return new SuccessfulCheckIn(descriptor.getTicket(), getAdditionalServicesForTicket(descriptor.getTicket()));
+            return new SuccessfulCheckIn(ticket, getAdditionalServicesForTicket(ticket), loadBoxColor(ticket));
         } else if(checkInStatus == BADGE_SCAN_ALREADY_DONE || checkInStatus == OK_READY_FOR_BADGE_SCAN) {
             var auditingStatus = checkInStatus == OK_READY_FOR_BADGE_SCAN ? BADGE_SCAN_SUCCESS : checkInStatus;
             scanAuditRepository.insert(ticketIdentifier, eventId, ZonedDateTime.now(), user, auditingStatus, ScanAudit.Operation.SCAN);
@@ -359,6 +362,7 @@ public class CheckInManager {
             String eventKey = event.getPrivateKey();
 
             Function<FullTicketInfo, String> hashedHMAC = ticket -> DigestUtils.sha256Hex(ticket.hmacTicketInfo(eventKey));
+            var outputColorConfiguration = getOutputColorConfiguration(event);
 
             Function<FullTicketInfo, String> encryptedBody = ticket -> {
                 Map<String, String> info = new HashMap<>();
@@ -369,6 +373,10 @@ public class CheckInManager {
                 info.put("status", ticket.getStatus().toString());
                 info.put("uuid", ticket.getUuid());
                 info.put("category", ticket.getTicketCategory().getName());
+                if(outputColorConfiguration != null) {
+                    info.put("boxColor", detectBoxColor(outputColorConfiguration, ticket));
+                }
+
                 if (!additionalFields.isEmpty()) {
                     Map<String, String> fields = new HashMap<>();
                     fields.put("company", trimToEmpty(ticket.getBillingDetails().getCompanyName()));
@@ -422,6 +430,28 @@ public class CheckInManager {
                 .collect(toMap(hashedHMAC, encryptedBody));
 
         }).orElseGet(Collections::emptyMap);
+    }
+
+    private CheckInOutputColorConfiguration getOutputColorConfiguration(EventAndOrganizationId event) {
+        return configurationManager.getFor(CHECK_IN_COLOR_CONFIGURATION, ConfigurationLevel.event(event)).getValue()
+            .flatMap(str -> optionally(() -> Json.fromJson(str, CheckInOutputColorConfiguration.class)))
+            .orElse(null);
+    }
+
+    private String loadBoxColor(TicketInfoContainer ticket) {
+        var eventAndOrganizationId = eventRepository.findEventAndOrganizationIdById(ticket.getEventId());
+        return detectBoxColor(getOutputColorConfiguration(eventAndOrganizationId), ticket);
+    }
+
+    private String detectBoxColor(CheckInOutputColorConfiguration outputColorConfiguration, TicketInfoContainer ticket) {
+        if(outputColorConfiguration == null) {
+            return null;
+        }
+        return outputColorConfiguration.getConfigurations().stream()
+            .filter(cc -> cc.getCategories().contains(ticket.getCategoryId()))
+            .map(CheckInOutputColorConfiguration.ColorConfiguration::getColorName)
+            .findFirst()
+            .orElse(outputColorConfiguration.getDefaultColorName());
     }
 
     List<AdditionalServiceInfo> getAdditionalServicesForTicket(TicketInfoContainer ticket) {

--- a/src/main/java/alfio/manager/support/SuccessfulCheckIn.java
+++ b/src/main/java/alfio/manager/support/SuccessfulCheckIn.java
@@ -24,13 +24,21 @@ import static alfio.manager.support.CheckInStatus.SUCCESS;
 
 public class SuccessfulCheckIn extends TicketAndCheckInResult {
     private final List<AdditionalServiceInfo> additionalServices;
+    private final String boxColor;
 
-    public SuccessfulCheckIn(TicketWithCategory ticket, List<AdditionalServiceInfo> additionalServices) {
+    public SuccessfulCheckIn(TicketWithCategory ticket,
+                             List<AdditionalServiceInfo> additionalServices,
+                             String boxColor) {
         super(ticket, new DefaultCheckInResult(SUCCESS, "success"));
         this.additionalServices = additionalServices;
+        this.boxColor = boxColor;
     }
 
     public List<AdditionalServiceInfo> getAdditionalServices() {
         return additionalServices;
+    }
+
+    public String getBoxColor() {
+        return boxColor;
     }
 }

--- a/src/main/java/alfio/model/TicketInfoContainer.java
+++ b/src/main/java/alfio/model/TicketInfoContainer.java
@@ -36,4 +36,6 @@ public interface TicketInfoContainer {
     String getEmail();
 
     String getUserLanguage();
+
+    Integer getCategoryId();
 }

--- a/src/main/java/alfio/model/api/v1/admin/EventCreationRequest.java
+++ b/src/main/java/alfio/model/api/v1/admin/EventCreationRequest.java
@@ -238,8 +238,8 @@ public class EventCreationRequest{
                 customValidityOpt.flatMap(x -> Optional.ofNullable(x.validityStart)).map(x -> new DateTimeModification(x.toLocalDate(),x.toLocalTime())).orElse(null),
                 customValidityOpt.flatMap(x -> Optional.ofNullable(x.validityEnd)).map(x -> new DateTimeModification(x.toLocalDate(),x.toLocalTime())).orElse(null),
                 0,
-                null
-            );
+                null,
+                null);
         }
     }
 

--- a/src/main/java/alfio/model/modification/TicketCategoryModification.java
+++ b/src/main/java/alfio/model/modification/TicketCategoryModification.java
@@ -16,9 +16,7 @@
  */
 package alfio.model.modification;
 
-import alfio.model.TicketCategory;
 import alfio.model.TicketCategory.TicketCheckInStrategy;
-import alfio.util.MonetaryUtil;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
@@ -48,6 +46,7 @@ public class TicketCategoryModification {
     private final DateTimeModification ticketValidityEnd;
     private final int ordinal;
     private final TicketCheckInStrategy ticketCheckInStrategy;
+    private final String badgeColor;
 
     @JsonCreator
     public TicketCategoryModification(@JsonProperty("id") Integer id,
@@ -66,7 +65,8 @@ public class TicketCategoryModification {
                                       @JsonProperty("ticketValidityStart") DateTimeModification ticketValidityStart,
                                       @JsonProperty("ticketValidityEnd") DateTimeModification ticketValidityEnd,
                                       @JsonProperty("ordinal") Integer ordinal,
-                                      @JsonProperty("ticketCheckInStrategy") TicketCheckInStrategy ticketCheckInStrategy) {
+                                      @JsonProperty("ticketCheckInStrategy") TicketCheckInStrategy ticketCheckInStrategy,
+                                      @JsonProperty("badgeColor") String badgeColor) {
         this.id = id;
         this.name = name;
         this.maxTickets = maxTickets;
@@ -84,6 +84,7 @@ public class TicketCategoryModification {
         this.ticketValidityEnd = ticketValidityEnd;
         this.ordinal = ordinal != null ? ordinal : 0;
         this.ticketCheckInStrategy = ticketCheckInStrategy;
+        this.badgeColor = badgeColor;
     }
 
 }

--- a/src/main/java/alfio/model/support/CheckInOutputColorConfiguration.java
+++ b/src/main/java/alfio/model/support/CheckInOutputColorConfiguration.java
@@ -1,0 +1,50 @@
+/**
+ * This file is part of alf.io.
+ *
+ * alf.io is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * alf.io is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with alf.io.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package alfio.model.support;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.Optional;
+
+@Getter
+public class CheckInOutputColorConfiguration {
+    private final String defaultColorName;
+    private final List<ColorConfiguration> configurations;
+
+    @JsonCreator
+    public CheckInOutputColorConfiguration(@JsonProperty("defaultColorName") String defaultColorName,
+                                           @JsonProperty("configurations") List<ColorConfiguration> configurations) {
+        this.defaultColorName = defaultColorName;
+        this.configurations = configurations;
+    }
+
+    @Getter
+    public static class ColorConfiguration {
+        private final String colorName;
+        private final List<Integer> categories;
+
+        private ColorConfiguration(@JsonProperty("colorName") String colorName,
+                                   @JsonProperty("categories") List<Integer> categories) {
+            this.colorName = colorName;
+            this.categories = Optional.ofNullable(categories).orElse(List.of());
+        }
+    }
+}
+

--- a/src/main/java/alfio/model/support/CheckInOutputColorConfiguration.java
+++ b/src/main/java/alfio/model/support/CheckInOutputColorConfiguration.java
@@ -40,7 +40,7 @@ public class CheckInOutputColorConfiguration {
         private final String colorName;
         private final List<Integer> categories;
 
-        private ColorConfiguration(@JsonProperty("colorName") String colorName,
+        public ColorConfiguration(@JsonProperty("colorName") String colorName,
                                    @JsonProperty("categories") List<Integer> categories) {
             this.colorName = colorName;
             this.categories = Optional.ofNullable(categories).orElse(List.of());

--- a/src/main/java/alfio/model/system/ConfigurationKeys.java
+++ b/src/main/java/alfio/model/system/ConfigurationKeys.java
@@ -199,6 +199,7 @@ public enum ConfigurationKeys {
     OFFLINE_CHECKIN_ENABLED("Offline Check-in enabled (default:true)", false, SettingCategory.ALFIO_PI, ComponentType.BOOLEAN, false, EnumSet.of(EVENT)),
     LABEL_PRINTING_ENABLED("Label Printing enabled (default:true)", false, SettingCategory.ALFIO_PI, ComponentType.BOOLEAN, false, EnumSet.of(EVENT)),
     LABEL_LAYOUT("Label layout", false, SettingCategory.ALFIO_PI, ComponentType.TEXTAREA, false, EnumSet.of(EVENT)),
+    CHECK_IN_COLOR_CONFIGURATION("Categories color configuration", false, SettingCategory.ALFIO_PI, ComponentType.TEXTAREA, false, EnumSet.of(EVENT)),
     //
 
     //

--- a/src/main/webapp/resources/angular-templates/admin/partials/configuration/event.html
+++ b/src/main/webapp/resources/angular-templates/admin/partials/configuration/event.html
@@ -208,7 +208,7 @@
             </div>
 
             <div class="page-header" data-ng-if="eventConf.payment || eventConf.paymentPaypal || eventConf.paymentStripe || eventConf.paymentMollie || eventConf.paymentOffline">
-                <h2>Alf.io PI settings</h2>
+                <h2>Check-in settings</h2>
             </div>
             <div data-ng-if="eventConf.alfioPi" class="panel panel-default">
                 <div class="panel-heading">
@@ -220,6 +220,26 @@
                     </div>
                     <div data-ng-repeat="setting in eventConf.alfioPiOptions">
                         <setting data-obj="setting" data-display-delete-if-needed="true" data-delete-handler="eventConf.delete(config)"></setting>
+                    </div>
+                    <div ng-if="eventConf.isLabelPrintingEnabled()" class="hidden-xs hidden-sm">
+                        <label-template config="eventConf.labelLayout" data-delete-handler="eventConf.delete(config)"></label-template>
+                    </div>
+                    <div class="hidden-xs hidden-sm row">
+                        <div class="col-md-6"><setting data-obj="eventConf.colorConfiguration" data-display-delete-if-needed="true" data-delete-handler="eventConf.delete(config)"></setting></div>
+                        <div class="col-md-6">
+                            <div class="row">
+                                <div class="col-md-8 col-md-push-2">
+                                    <h5>example:</h5>
+                                    <pre>{
+  "defaultColorName": "success",
+  "configurations": [{
+      "colorName": "info",
+      "categories": [1]
+  }]
+}</pre>
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/main/webapp/resources/angular-templates/admin/partials/event/fragment/edit-category.html
+++ b/src/main/webapp/resources/angular-templates/admin/partials/event/fragment/edit-category.html
@@ -240,8 +240,17 @@
     <div class="col-xs-12">
         <div class="form-group">
             <label for="ticketCheckInStrategy" class="control-label">Multi-day check-in</label>
-            <select name="ticketCheckInStrategy" data-ng-model="ticketCheckInStrategy" class="form-control" id="ticketCheckInStrategy" ng-options="type.code as type.description for type in ticketCheckInStrategies"></select>
+            <select name="ticketCheckInStrategy" data-ng-model="ticketCategory.ticketCheckInStrategy" class="form-control" id="ticketCheckInStrategy" ng-options="type.code as type.description for type in ticketCheckInStrategies"></select>
             <p class="help-block">Attendees must do the first check-in by using their ticket. Then, if you print their badge using Alf.io, you can request them to repeat the check-in every morning, by using their badge</p>
+        </div>
+    </div>
+</div>
+<div class="row">
+    <div class="col-xs-12">
+        <div class="form-group">
+            <label for="badgeColor" class="control-label">Badge color</label>
+            <select name="badgeColor" data-ng-model="ticketCategory.badgeColor" class="form-control" id="badgeColor" ng-options="type.code as type.description for type in badgeColors"></select>
+            <p class="help-block">Make this category stand out at check-in. If set, the color will be used from our mobile app and check-in stations to match the color of the badge upon successful scan. This will help your crew to handle this category properly.</p>
         </div>
     </div>
 </div>

--- a/src/main/webapp/resources/css/admin.css
+++ b/src/main/webapp/resources/css/admin.css
@@ -778,3 +778,41 @@ span.path {
     background-color: transparent;
     border: 0;
 }
+
+div.preformatted {
+    word-wrap: break-word;
+    white-space: pre-wrap;
+}
+
+.pi-primary {
+    background-color: #007bff;
+    color: #007bff;
+}
+.pi-secondary {
+    background-color: #6c757d;
+    color: #6c757d;
+}
+.pi-success {
+    background-color: #28a745;
+    color: #28a745;
+}
+.pi-danger {
+    background-color: #dc3545;
+    color: #dc3545;
+}
+.pi-warning {
+    background-color: #ffc107;
+    color: #ffc107;
+}
+.pi-info {
+    background-color: #17a2b8;
+    color: #17a2b8;
+}
+.pi-light {
+    background-color: #f8f9fa;
+    color: #f8f9fa;
+}
+.pi-dark {
+    background-color: #343a40;
+    color: #343a40;
+}

--- a/src/main/webapp/resources/js/admin/directive/admin-directive.js
+++ b/src/main/webapp/resources/js/admin/directive/admin-directive.js
@@ -581,6 +581,24 @@
             restrict: 'E',
             templateUrl: '/resources/angular-templates/admin/partials/event/fragment/edit-category.html',
             controller: function($scope, ConfigurationService) {
+
+                ConfigurationService.loadSingleConfigForEvent($scope.event.id, 'CHECK_IN_COLOR_CONFIGURATION').then(function(result) {
+                    var data = {};
+                    if(result.data && result.data.length > 0) {
+                        try {
+                            data = JSON.parse(result.data);
+                        } catch(e) {
+                            console.error("cannot deserialize JSON", e);
+                        }
+                    }
+                    if(data && data.configurations) {
+                        var configurations = data.configurations.filter(function(c) { return c.categories.filter(function(tc) { return tc.id === $scope.ticketCategory}); });
+                        if(configurations.length > 0) {
+                            $scope.ticketCategory['badgeColor'] = configurations[0].colorName;
+                        }
+                    }
+                });
+
                 $scope.buildPrefix = function(index, name) {
                     return angular.isDefined(index) ? index + "-" + name : name;
                 };
@@ -692,6 +710,16 @@
                         code: 'ONCE_PER_DAY',
                         description: 'Attendees check in the first day using their ticket, then the following day(s) using their badge'
                     }
+                ];
+                $scope.badgeColors = [
+                    { code: 'primary', description: 'blue' },
+                    { code: 'secondary', description: 'gray' },
+                    { code: 'success', description: 'green' },
+                    { code: 'danger', description: 'red' },
+                    { code: 'warning', description: 'yellow' },
+                    { code: 'info', description: 'cyan'},
+                    { code: 'light', description: 'white' },
+                    { code: 'dark', description: 'black' }
                 ];
                 $scope.checkInStrategiesVisible = eventEndDate.endOf('day').diff(eventStartDate.startOf('day'), 'days') > 0;
                 $scope.ticketCheckInStrategy = $scope.ticketCategory.ticketCheckInStrategy || 'ONCE_PER_EVENT';

--- a/src/main/webapp/resources/js/admin/feature/configuration/configuration.js
+++ b/src/main/webapp/resources/js/admin/feature/configuration/configuration.js
@@ -231,7 +231,7 @@
                 }
                 handleEuCountries(systemConf, results[2].data);
                 if(systemConf.alfioPi) {
-                    systemConf.alfioPiOptions = _.filter(systemConf.alfioPi.settings, function(pi) { return pi.key !== 'LABEL_LAYOUT'});
+                    systemConf.alfioPiOptions = _.filter(systemConf.alfioPi.settings, function(pi) { return pi.key !== 'LABEL_LAYOUT' && pi.key !== 'CHECK_IN_COLOR_CONFIGURATION'});
                 }
 
                 systemConf.extensionSettings = results[3].data;
@@ -412,8 +412,9 @@
 
 
                     if(eventConf.alfioPi) {
-                        eventConf.alfioPiOptions = _.filter(eventConf.alfioPi.settings, function(pi) { return pi.key !== 'LABEL_LAYOUT'});
+                        eventConf.alfioPiOptions = _.filter(eventConf.alfioPi.settings, function(pi) { return pi.key !== 'LABEL_LAYOUT' && pi.key !== 'CHECK_IN_COLOR_CONFIGURATION'});
                         eventConf.labelLayout = _.find(eventConf.alfioPi.settings, function(pi) { return pi.key === 'LABEL_LAYOUT'});
+                        eventConf.colorConfiguration = _.find(eventConf.alfioPi.settings, function(pi) { return pi.key === 'CHECK_IN_COLOR_CONFIGURATION'});
                     }
                     eventConf.extensionSettings = result[2].data;
                     eventConf.cancel = function() {

--- a/src/main/webapp/resources/js/admin/feature/ticket-category/ticket-category-detail.html
+++ b/src/main/webapp/resources/js/admin/feature/ticket-category/ticket-category-detail.html
@@ -52,6 +52,7 @@
                     <i class="fa fa-link fa-1_5x"></i><span class="sr-only">Access Code</span>
                     <span class="text-muted"><span ng-if="$ctrl.event.id">{{$ctrl.baseUrl}}/event/{{$ctrl.event.shortName}}/code/{{ticketCategory.code}}</span>{{$ctrl.ticketCategory.code}}</span>
                 </h5>
+                <h5 data-ng-if="$ctrl.ticketCategory.id" class="text-muted">ID: {{$ctrl.ticketCategory.id}}</h5>
             </div>
             <div class="col-xs-7 category-detail">
                 <div ng-if="$ctrl.categoryHasDescriptions($ctrl.ticketCategory)">

--- a/src/test/java/alfio/controller/api/v2/user/ReservationFlowIntegrationTest.java
+++ b/src/test/java/alfio/controller/api/v2/user/ReservationFlowIntegrationTest.java
@@ -20,11 +20,11 @@ import alfio.TestConfiguration;
 import alfio.config.DataSourceConfiguration;
 import alfio.config.Initializer;
 import alfio.controller.IndexController;
-import alfio.controller.api.v1.AttendeeApiController;
 import alfio.controller.api.admin.AdditionalServiceApiController;
 import alfio.controller.api.admin.CheckInApiController;
 import alfio.controller.api.admin.EventApiController;
 import alfio.controller.api.admin.UsersApiController;
+import alfio.controller.api.v1.AttendeeApiController;
 import alfio.controller.api.v2.InfoApiController;
 import alfio.controller.api.v2.TranslationsApiController;
 import alfio.controller.api.v2.model.EventCode;
@@ -225,11 +225,11 @@ public class ReservationFlowIntegrationTest extends BaseIntegrationTest {
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
                 new DateTimeModification(LocalDate.now().minusDays(1), LocalTime.now()),
                 new DateTimeModification(LocalDate.now().plusDays(1), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null),
+                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null),
             new TicketCategoryModification(null, "hidden", 2,
                 new DateTimeModification(LocalDate.now().minusDays(1), LocalTime.now()),
                 new DateTimeModification(LocalDate.now().plusDays(1), LocalTime.now()),
-                DESCRIPTION, BigDecimal.ONE, true, "", true, URL_CODE_HIDDEN, null, null, null, null, 0, null)
+                DESCRIPTION, BigDecimal.ONE, true, "", true, URL_CODE_HIDDEN, null, null, null, null, 0, null, null)
             );
         Pair<Event, String> eventAndUser = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
 

--- a/src/test/java/alfio/manager/AdminReservationManagerIntegrationTest.java
+++ b/src/test/java/alfio/manager/AdminReservationManagerIntegrationTest.java
@@ -93,7 +93,7 @@ public class AdminReservationManagerIntegrationTest extends BaseIntegrationTest 
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null));
         performExistingCategoryTest(categories, false, Collections.singletonList(1), false, true, 0, AVAILABLE_SEATS);
     }
 
@@ -103,11 +103,11 @@ public class AdminReservationManagerIntegrationTest extends BaseIntegrationTest 
             new TicketCategoryModification(null, "default", 10,
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null),
+                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null),
             new TicketCategoryModification(null, "2nd", 10,
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null));
         performExistingCategoryTest(categories, false, Arrays.asList(10,10), false, true, 0, AVAILABLE_SEATS);
     }
 
@@ -117,7 +117,7 @@ public class AdminReservationManagerIntegrationTest extends BaseIntegrationTest 
             new TicketCategoryModification(null, "default", 1,
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null));
         performExistingCategoryTest(categories, false, Collections.singletonList(1), false, true, 0, AVAILABLE_SEATS);
     }
 
@@ -127,7 +127,7 @@ public class AdminReservationManagerIntegrationTest extends BaseIntegrationTest 
             new TicketCategoryModification(null, "default", 1,
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null));
         performExistingCategoryTest(categories, false, Collections.singletonList(1), true, true, AVAILABLE_SEATS, AVAILABLE_SEATS+1);
     }
 
@@ -137,7 +137,7 @@ public class AdminReservationManagerIntegrationTest extends BaseIntegrationTest 
             new TicketCategoryModification(null, "default", 1,
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null));
         performExistingCategoryTest(categories, true, Collections.singletonList(2), false, true, 0, AVAILABLE_SEATS);
     }
 
@@ -147,7 +147,7 @@ public class AdminReservationManagerIntegrationTest extends BaseIntegrationTest 
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null));
         performExistingCategoryTest(categories, true, Collections.singletonList(AVAILABLE_SEATS + 1), false, false, 0, AVAILABLE_SEATS);
     }
 
@@ -157,7 +157,7 @@ public class AdminReservationManagerIntegrationTest extends BaseIntegrationTest 
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null));
         performExistingCategoryTest(categories, true, Collections.singletonList(AVAILABLE_SEATS + 1), false, false, 0, AVAILABLE_SEATS);
     }
 
@@ -167,7 +167,7 @@ public class AdminReservationManagerIntegrationTest extends BaseIntegrationTest 
             new TicketCategoryModification(null, "default", 1,
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null));
         Pair<Event, String> eventWithUsername = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = eventWithUsername.getKey();
         String username = eventWithUsername.getValue();
@@ -201,7 +201,7 @@ public class AdminReservationManagerIntegrationTest extends BaseIntegrationTest 
             new TicketCategoryModification(null, "default", 1,
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null));
         Pair<Event, String> eventWithUsername = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = eventWithUsername.getKey();
         String username = eventWithUsername.getValue();
@@ -247,7 +247,7 @@ public class AdminReservationManagerIntegrationTest extends BaseIntegrationTest 
             new TicketCategoryModification(null, "default", 1,
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null));
         Triple<Event, String, TicketReservation> testResult = performExistingCategoryTest(categories, true, Collections.singletonList(2), false, true, 0, AVAILABLE_SEATS);
         assertNotNull(testResult);
         Result<Triple<TicketReservation, List<Ticket>, Event>> result = adminReservationManager.confirmReservation(testResult.getLeft().getShortName(), testResult.getRight().getId(), testResult.getMiddle(), EMPTY);
@@ -266,7 +266,7 @@ public class AdminReservationManagerIntegrationTest extends BaseIntegrationTest 
             new TicketCategoryModification(null, "default", 1,
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null));
         int attendees = 2;
         Triple<Event, String, TicketReservation> testResult = performExistingCategoryTest(categories, true, Collections.singletonList(attendees), false, true, 0, AVAILABLE_SEATS);
         assertNotNull(testResult);

--- a/src/test/java/alfio/manager/CheckInManagerIntegrationTest.java
+++ b/src/test/java/alfio/manager/CheckInManagerIntegrationTest.java
@@ -45,12 +45,15 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZonedDateTime;
-import java.util.*;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static alfio.test.util.IntegrationTestUtil.*;
 import static org.junit.Assert.assertTrue;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = {DataSourceConfiguration.class, TestConfiguration.class})
 @ActiveProfiles({Initializer.PROFILE_DEV, Initializer.PROFILE_DISABLE_JOBS, Initializer.PROFILE_INTEGRATION_TEST})
@@ -84,7 +87,7 @@ public class CheckInManagerIntegrationTest {
                 new DateTimeModification(LocalDate.now().minusDays(1), LocalTime.now()),
                 new DateTimeModification(LocalDate.now().plusDays(1), LocalTime.now()),
                 DESCRIPTION, BigDecimal.TEN, false,
-                "", false, null, null, null, null, null, 0, null)
+                "", false, null, null, null, null, null, 0, null, null)
         );
         Pair<Event, String> eventAndUser = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         var event = eventAndUser.getLeft();

--- a/src/test/java/alfio/manager/ConfigurationManagerIntegrationTest.java
+++ b/src/test/java/alfio/manager/ConfigurationManagerIntegrationTest.java
@@ -105,7 +105,7 @@ public class ConfigurationManagerIntegrationTest extends BaseIntegrationTest {
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 Collections.singletonMap("en", "desc"), BigDecimal.TEN, false, "", false, null, null,
-                null, null, null, 0, null));
+                null, null, null, 0, null, null));
         EventModification em = new EventModification(null, Event.EventType.INTERNAL, "url", "url", "url", null, null, null,
             "eventShortName", "displayName", organization.getId(),
             "muh location", "0.0", "0.0", ZoneId.systemDefault().getId(), desc,

--- a/src/test/java/alfio/manager/EventManagerCategoriesTest.java
+++ b/src/test/java/alfio/manager/EventManagerCategoriesTest.java
@@ -56,7 +56,7 @@ public class EventManagerCategoriesTest {
         EventRepository eventRepository = mock(EventRepository.class);
         event = mock(Event.class);
         when(event.getId()).thenReturn(eventId);
-        eventManager = new EventManager(null, eventRepository, null, ticketCategoryRepository, ticketCategoryDescriptionRepository, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+        eventManager = new EventManager(null, eventRepository, null, ticketCategoryRepository, ticketCategoryDescriptionRepository, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
         when(eventRepository.countExistingTickets(0)).thenReturn(availableSeats);
         when(event.getZoneId()).thenReturn(ZoneId.systemDefault());
     }

--- a/src/test/java/alfio/manager/EventManagerCheckInConfigurationTest.java
+++ b/src/test/java/alfio/manager/EventManagerCheckInConfigurationTest.java
@@ -1,0 +1,88 @@
+/**
+ * This file is part of alf.io.
+ *
+ * alf.io is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * alf.io is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with alf.io.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package alfio.manager;
+
+import alfio.manager.system.ConfigurationManager;
+import alfio.model.Event;
+import alfio.repository.system.ConfigurationRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.ZoneId;
+import java.util.Optional;
+
+import static alfio.model.system.ConfigurationKeys.CHECK_IN_COLOR_CONFIGURATION;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@DisplayName("EventManager: handle category check-in configuration")
+class EventManagerCheckInConfigurationTest {
+
+    private Event event;
+    private EventManager eventManager;
+    private ConfigurationManager configurationManager;
+    private ConfigurationRepository configurationRepository;
+    private ConfigurationManager.MaybeConfiguration configuration;
+    private final int eventId = 0;
+    private final int availableSeats = 20;
+
+
+    @BeforeEach
+    void init() {
+        event = mock(Event.class);
+        when(event.getId()).thenReturn(eventId);
+        when(event.getOrganizationId()).thenReturn(1);
+        configurationManager = mock(ConfigurationManager.class);
+        configurationRepository = mock(ConfigurationRepository.class);
+        eventManager = new EventManager(null, null, null, null, null, null, null, null, configurationManager, null, null, null, null, null, null, null, null, null, null, null, configurationRepository);
+        when(event.getZoneId()).thenReturn(ZoneId.systemDefault());
+        configuration = mock(ConfigurationManager.MaybeConfiguration.class);
+        when(configurationManager.getFor(eq(CHECK_IN_COLOR_CONFIGURATION), any())).thenReturn(configuration);
+    }
+
+    @Test
+    void insertConfiguration() {
+        when(configuration.getValue()).thenReturn(Optional.empty());
+        eventManager.saveBadgeColorConfiguration("warning", event, 1);
+        verify(configurationRepository).insertEventLevel(eq(1), eq(eventId), eq(CHECK_IN_COLOR_CONFIGURATION.name()), eq("{\"defaultColorName\":\"success\",\"configurations\":[{\"colorName\":\"warning\",\"categories\":[1]}]}"), isNull());
+    }
+
+    @Test
+    void saveConfigurationNewColor() {
+        var json = "{\"defaultColorName\":\"success\",\"configurations\":[{\"colorName\":\"info\",\"categories\":[5]}]}";
+        when(configuration.getValue()).thenReturn(Optional.of(json));
+        eventManager.saveBadgeColorConfiguration("warning", event, 1);
+        verify(configurationRepository).updateEventLevel(eq(eventId), eq(1), eq(CHECK_IN_COLOR_CONFIGURATION.name()), eq("{\"defaultColorName\":\"success\",\"configurations\":[{\"colorName\":\"info\",\"categories\":[5]},{\"colorName\":\"warning\",\"categories\":[1]}]}"));
+    }
+
+    @Test
+    void saveConfigurationExistingColor() {
+        var json = "{\"defaultColorName\":\"success\",\"configurations\":[{\"colorName\":\"info\",\"categories\":[5]}]}";
+        when(configuration.getValue()).thenReturn(Optional.of(json));
+        eventManager.saveBadgeColorConfiguration("info", event, 1);
+        verify(configurationRepository).updateEventLevel(eq(eventId), eq(1), eq(CHECK_IN_COLOR_CONFIGURATION.name()), eq("{\"defaultColorName\":\"success\",\"configurations\":[{\"colorName\":\"info\",\"categories\":[5,1]}]}"));
+    }
+
+    @Test
+    void saveConfigurationModifyColor() {
+        var json = "{\"defaultColorName\":\"success\",\"configurations\":[{\"colorName\":\"info\",\"categories\":[1]}]}";
+        when(configuration.getValue()).thenReturn(Optional.of(json));
+        eventManager.saveBadgeColorConfiguration("warning", event, 1);
+        verify(configurationRepository).updateEventLevel(eq(eventId), eq(1), eq(CHECK_IN_COLOR_CONFIGURATION.name()), eq("{\"defaultColorName\":\"success\",\"configurations\":[{\"colorName\":\"warning\",\"categories\":[1]}]}"));
+    }
+}

--- a/src/test/java/alfio/manager/EventManagerHandleTicketModificationTest.java
+++ b/src/test/java/alfio/manager/EventManagerHandleTicketModificationTest.java
@@ -54,7 +54,7 @@ public class EventManagerHandleTicketModificationTest {
         ticketRepository = mock(TicketRepository.class);
 
         when(event.getId()).thenReturn(eventId);
-        eventManager = new EventManager(null, null, null, null, null, ticketRepository, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+        eventManager = new EventManager(null, null, null, null, null, ticketRepository, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
         when(original.getId()).thenReturn(originalCategoryId);
         when(updated.getId()).thenReturn(updatedCategoryId);
         when(original.getSrcPriceCts()).thenReturn(1000);

--- a/src/test/java/alfio/manager/EventManagerHandleTokenModificationTest.java
+++ b/src/test/java/alfio/manager/EventManagerHandleTokenModificationTest.java
@@ -53,7 +53,7 @@ class EventManagerHandleTokenModificationTest {
         TicketRepository ticketRepository = mock(TicketRepository.class);
         when(event.getId()).thenReturn(eventId);
         eventManager = new EventManager(null, null, null, null,
-            null, ticketRepository, specialPriceRepository, null, null, null, null, null, null, null, null, null, null, null, null, null);
+            null, ticketRepository, specialPriceRepository, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
         when(original.getId()).thenReturn(20);
         when(updated.getId()).thenReturn(30);
         when(original.getSrcPriceCts()).thenReturn(1000);

--- a/src/test/java/alfio/manager/EventManagerIntegrationTest.java
+++ b/src/test/java/alfio/manager/EventManagerIntegrationTest.java
@@ -93,7 +93,7 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
                 new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
                         new DateTimeModification(LocalDate.now(), LocalTime.now()),
                         new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                        DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null));
+                        DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null));
         Event event = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository).getKey();
         List<Ticket> tickets = ticketRepository.findFreeByEventId(event.getId());
         assertNotNull(tickets);
@@ -111,7 +111,7 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
                 new TicketCategoryModification(null, "default", 10,
                         new DateTimeModification(LocalDate.now(), LocalTime.now()),
                         new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                        DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null));
+                        DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null));
         Event event = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository).getKey();
         assertTrue(eventManager.eventExistsById(event.getId()));
         List<Ticket> tickets = ticketRepository.findFreeByEventId(event.getId());
@@ -127,7 +127,7 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
                 new TicketCategoryModification(null, "default", 10,
                         new DateTimeModification(LocalDate.now(), LocalTime.now()),
                         new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                        DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null));
+                        DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null));
         Event event = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository).getKey();
         List<Ticket> tickets = ticketRepository.findFreeByEventId(event.getId());
         assertNotNull(tickets);
@@ -145,16 +145,16 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
             new TicketCategoryModification(null, "default", 10,
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null),
+                DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null),
             new TicketCategoryModification(null, "default", 9,
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null),
+                DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null),
             new TicketCategoryModification(null, "default", 0,
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
 
-                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null));
         Event event = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository).getKey();
         List<Ticket> tickets = ticketRepository.findFreeByEventId(event.getId());
         assertNotNull(tickets);
@@ -169,15 +169,15 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
                 new TicketCategoryModification(null, "default", 10,
                         new DateTimeModification(LocalDate.now(), LocalTime.now()),
                         new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                        DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null),
+                        DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null),
                 new TicketCategoryModification(null, "default", 10,
                         new DateTimeModification(LocalDate.now(), LocalTime.now()),
                         new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                        DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null),
+                        DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null),
                 new TicketCategoryModification(null, "default", 0,
                         new DateTimeModification(LocalDate.now(), LocalTime.now()),
                         new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                        DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null));
+                        DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null));
         Event event = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository).getKey();
         List<Ticket> tickets = ticketRepository.findFreeByEventId(event.getId());
         assertNotNull(tickets);
@@ -200,13 +200,13 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
                 new TicketCategoryModification(null, "default", 10,
                         new DateTimeModification(LocalDate.now(), LocalTime.now()),
                         new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                        DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null));
+                        DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null));
         Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = pair.getKey();
         TicketCategoryModification tcm = new TicketCategoryModification(null, "default", -1,
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null);
+                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null);
         eventManager.insertCategory(event.getId(), tcm, pair.getValue());
         List<Ticket> tickets = ticketRepository.findFreeByEventId(event.getId());
         assertNotNull(tickets);
@@ -222,7 +222,7 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
                 new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
                         new DateTimeModification(LocalDate.now(), LocalTime.now()),
                         new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                        DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null));
+                        DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null));
         Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = pair.getKey();
         //shrink the original category to AVAILABLE_SEATS - 2, this would free two seats
@@ -230,14 +230,14 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
         TicketCategoryModification shrink = new TicketCategoryModification(categoryId, "default", AVAILABLE_SEATS - 2,
             new DateTimeModification(LocalDate.now(), LocalTime.now()),
             new DateTimeModification(LocalDate.now(), LocalTime.now()),
-            DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null);
+            DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null);
         eventManager.updateCategory(categoryId, event.getId(), shrink, pair.getRight());
 
         //now insert an unbounded ticket category
         TicketCategoryModification tcm = new TicketCategoryModification(null, "default", 10,
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null);
+                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null);
         eventManager.insertCategory(event.getId(), tcm, pair.getValue());
 
         waitingQueueSubscriptionProcessor.distributeAvailableSeats(event);
@@ -255,7 +255,7 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
                 new TicketCategoryModification(null, "default", 10,
                         new DateTimeModification(LocalDate.now(), LocalTime.now()),
                         new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                        DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null));
+                        DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null));
         Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = pair.getKey();
         EventModification update = new EventModification(event.getId(), Event.EventType.INTERNAL, null, null, null, null, null, null, null, null, event.getOrganizationId(), null,
@@ -280,7 +280,7 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
                 new TicketCategoryModification(null, "default", 10,
                         new DateTimeModification(LocalDate.now(), LocalTime.now()),
                         new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                        DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null));
+                        DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null));
         Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = pair.getKey();
         EventModification update = new EventModification(event.getId(), Event.EventType.INTERNAL, null, null, null, null, null, null, null, null, event.getOrganizationId(), null,
@@ -302,7 +302,7 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
                 new TicketCategoryModification(null, "default", 10,
                         new DateTimeModification(LocalDate.now(), LocalTime.now()),
                         new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                        DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null));
+                        DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null));
         Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = pair.getKey();
         EventModification update = new EventModification(event.getId(), Event.EventType.INTERNAL, null, null, null, null, null, null, null, null, event.getOrganizationId(), null,
@@ -323,7 +323,7 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
                 new TicketCategoryModification(null, "default", 10,
                         new DateTimeModification(LocalDate.now(), LocalTime.now()),
                         new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                        DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null));
+                        DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null));
         Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = pair.getKey();
         EventModification update = new EventModification(event.getId(), Event.EventType.INTERNAL, null, null, null, null, null, null, null, null, event.getOrganizationId(), null,
@@ -344,13 +344,13 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
                 new TicketCategoryModification(null, "default", 0,
                         new DateTimeModification(LocalDate.now(), LocalTime.now()),
                         new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                        DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null));
+                        DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null));
         Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = pair.getKey();
         TicketCategoryModification tcm = new TicketCategoryModification(null, "default", 10,
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null);
+                DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null);
         Result<Integer> result = eventManager.insertCategory(event, tcm, pair.getValue());
         assertTrue(result.isSuccess());
         List<Ticket> tickets = ticketRepository.findFreeByEventId(event.getId());
@@ -367,14 +367,14 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
                 new TicketCategoryModification(null, "default", 10,
                         new DateTimeModification(LocalDate.now(), LocalTime.now()),
                         new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                        DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null));
+                        DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null));
         Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = pair.getKey();
         TicketCategory category = ticketCategoryRepository.findAllTicketCategories(event.getId()).get(0);
         TicketCategoryModification tcm = new TicketCategoryModification(category.getId(), "default", 20,
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null);
+                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null);
         eventManager.updateCategory(category.getId(), event.getId(), tcm, pair.getValue());
         waitingQueueSubscriptionProcessor.distributeAvailableSeats(event);
         List<Ticket> tickets = ticketRepository.findFreeByEventId(event.getId());
@@ -390,7 +390,7 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
             new TicketCategoryModification(null, "default", 10,
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null));
         Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = pair.getLeft();
         String username = pair.getRight();
@@ -448,7 +448,7 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null));
         Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = pair.getLeft();
         String username = pair.getRight();
@@ -458,7 +458,7 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
         TicketCategoryModification tcm = new TicketCategoryModification(category.getId(), category.getName(), AVAILABLE_SEATS,
             DateTimeModification.fromZonedDateTime(category.getUtcInception()),
             DateTimeModification.fromZonedDateTime(category.getUtcExpiration()),
-            categoryDescription, category.getPrice(), false, "", true, null, null, null, null, null, 0, null);
+            categoryDescription, category.getPrice(), false, "", true, null, null, null, null, null, 0, null, null);
         Result<TicketCategory> result = eventManager.updateCategory(category.getId(), event, tcm, username);
         assertTrue(result.isSuccess());
         assertEquals(Integer.valueOf(0), ticketRepository.countFreeTicketsForUnbounded(event.getId()));
@@ -470,7 +470,7 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null));
         Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = pair.getLeft();
         String username = pair.getRight();
@@ -482,7 +482,7 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
         TicketCategoryModification tcm = new TicketCategoryModification(category.getId(), category.getName(), AVAILABLE_SEATS,
             DateTimeModification.fromZonedDateTime(category.getUtcInception()),
             DateTimeModification.fromZonedDateTime(category.getUtcExpiration()),
-            categoryDescription, category.getPrice(), false, "", false, null, null, null, null, null, 0, null);
+            categoryDescription, category.getPrice(), false, "", false, null, null, null, null, null, 0, null, null);
         Result<TicketCategory> result = eventManager.updateCategory(category.getId(), event, tcm, username);
         assertTrue(result.isSuccess());
         assertEquals(AVAILABLE_SEATS, ticketRepository.countReleasedUnboundedTickets(event.getId()).intValue());
@@ -497,7 +497,7 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
 
-                DESCRIPTION, BigDecimal.TEN, true, "", true, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, true, "", true, null, null, null, null, null, 0, null, null));
         Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
 
         Event event = pair.getLeft();
@@ -509,7 +509,7 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
         TicketCategoryModification tcm = new TicketCategoryModification(category.getId(), category.getName(), 10,
             DateTimeModification.fromZonedDateTime(category.getUtcInception()),
             DateTimeModification.fromZonedDateTime(category.getUtcExpiration()),
-            categoryDescription, category.getPrice(), true, "", false, null, null, null, null, null, 0, null);
+            categoryDescription, category.getPrice(), true, "", false, null, null, null, null, null, 0, null, null);
         Result<TicketCategory> result = eventManager.updateCategory(category.getId(), event, tcm, username);
         assertFalse(result.isSuccess());
     }
@@ -520,7 +520,7 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
             new TicketCategoryModification(null, "default", 10,
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null));
         Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = pair.getLeft();
         String username = pair.getRight();
@@ -535,7 +535,7 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
         TicketCategoryModification tcm = new TicketCategoryModification(category.getId(), category.getName(), 10,
             DateTimeModification.fromZonedDateTime(category.getUtcInception()),
             DateTimeModification.fromZonedDateTime(category.getUtcExpiration()),
-            categoryDescription, category.getPrice(), false, "", false, null, null, null, null, null, 0, null);
+            categoryDescription, category.getPrice(), false, "", false, null, null, null, null, null, 0, null, null);
         Result<TicketCategory> result = eventManager.updateCategory(category.getId(), event, tcm, username);
         assertFalse(result.isSuccess());
     }
@@ -547,7 +547,7 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
 
-                DESCRIPTION, BigDecimal.TEN, true, "", true, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, true, "", true, null, null, null, null, null, 0, null, null));
         Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
 
         Event event = pair.getLeft();
@@ -559,7 +559,7 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
         TicketCategoryModification tcm = new TicketCategoryModification(category.getId(), category.getName(), 11,
             DateTimeModification.fromZonedDateTime(category.getUtcInception()),
             DateTimeModification.fromZonedDateTime(category.getUtcExpiration()),
-            categoryDescription, category.getPrice(), true, "", true, null, null, null, null, null, 0, null);
+            categoryDescription, category.getPrice(), true, "", true, null, null, null, null, null, 0, null, null);
         Result<TicketCategory> result = eventManager.updateCategory(category.getId(), event, tcm, username);
         assertTrue(result.isSuccess());
         assertEquals(11, ticketRepository.countFreeTickets(event.getId(), category.getId()).intValue());
@@ -572,7 +572,7 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
 
-                DESCRIPTION, BigDecimal.TEN, true, "", true, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, true, "", true, null, null, null, null, null, 0, null, null));
         Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
 
         Event event = pair.getLeft();
@@ -584,7 +584,7 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
         TicketCategoryModification tcm = new TicketCategoryModification(category.getId(), category.getName(), 9,
             DateTimeModification.fromZonedDateTime(category.getUtcInception()),
             DateTimeModification.fromZonedDateTime(category.getUtcExpiration()),
-            categoryDescription, category.getPrice(), true, "", true, null, null, null, null, null, 0, null);
+            categoryDescription, category.getPrice(), true, "", true, null, null, null, null, null, 0, null, null);
         Result<TicketCategory> result = eventManager.updateCategory(category.getId(), event, tcm, username);
         assertTrue(result.isSuccess());
         assertEquals(9, ticketRepository.countFreeTickets(event.getId(), category.getId()).intValue());
@@ -602,7 +602,7 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
 
-                DESCRIPTION, BigDecimal.TEN, true, "", true, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, true, "", true, null, null, null, null, null, 0, null, null));
         Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
 
         Event event = pair.getLeft();
@@ -623,7 +623,7 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
         TicketCategoryModification tcmOk = new TicketCategoryModification(category.getId(), category.getName(), 2,
             DateTimeModification.fromZonedDateTime(category.getUtcInception()),
             DateTimeModification.fromZonedDateTime(category.getUtcExpiration()),
-            categoryDescription, category.getPrice(), true, "", true, null, null, null, null, null, 0, null);
+            categoryDescription, category.getPrice(), true, "", true, null, null, null, null, null, 0, null, null);
         Result<TicketCategory> resOk = eventManager.updateCategory(category.getId(), event, tcmOk, username);
         Assert.assertTrue(resOk.isSuccess());
 
@@ -631,7 +631,7 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
         TicketCategoryModification tcm = new TicketCategoryModification(category.getId(), category.getName(), 1,
             DateTimeModification.fromZonedDateTime(category.getUtcInception()),
             DateTimeModification.fromZonedDateTime(category.getUtcExpiration()),
-            categoryDescription, category.getPrice(), true, "", true, null, null, null, null, null, 0, null);
+            categoryDescription, category.getPrice(), true, "", true, null, null, null, null, null, 0, null, null);
         Result<TicketCategory> res = eventManager.updateCategory(category.getId(), event, tcm, username);
         Assert.assertFalse(res.isSuccess());
         Assert.assertTrue(res.getErrors().contains(ErrorCode.CategoryError.NOT_ENOUGH_FREE_TOKEN_FOR_SHRINK));
@@ -646,7 +646,7 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
         TicketCategoryModification tcm = new TicketCategoryModification(null, "additional", 20,
             DateTimeModification.fromZonedDateTime(ZonedDateTime.now(event.getZoneId()).minusMinutes(1)),
             DateTimeModification.fromZonedDateTime(ZonedDateTime.now(event.getZoneId()).plusDays(5)),
-            Collections.emptyMap(), BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null);
+            Collections.emptyMap(), BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null);
         Result<Integer> result = eventManager.insertCategory(event, tcm, username);
         assertTrue(result.isSuccess());
         assertEquals(20, ticketRepository.countReleasedTicketInCategory(event.getId(), result.getData()).intValue());
@@ -661,7 +661,7 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
         TicketCategoryModification tcm = new TicketCategoryModification(null, "additional", 20,
             DateTimeModification.fromZonedDateTime(ZonedDateTime.now(event.getZoneId()).minusMinutes(1)),
             DateTimeModification.fromZonedDateTime(ZonedDateTime.now(event.getZoneId()).plusDays(5)),
-            Collections.emptyMap(), BigDecimal.TEN, true, "", true, null, null, null, null, null, 0, null);
+            Collections.emptyMap(), BigDecimal.TEN, true, "", true, null, null, null, null, null, 0, null, null);
         Result<Integer> result = eventManager.insertCategory(event, tcm, username);
         assertTrue(result.isSuccess());
         assertEquals(20, ticketRepository.countFreeTickets(event.getId(), result.getData()).intValue());
@@ -673,7 +673,7 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null));
         Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = pair.getLeft();
         String username = pair.getRight();
@@ -687,12 +687,12 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
         TicketCategoryModification tcm = new TicketCategoryModification(null, "new", 1,
             DateTimeModification.fromZonedDateTime(ZonedDateTime.now()),
             DateTimeModification.fromZonedDateTime(ZonedDateTime.now().plusDays(1)),
-            Collections.emptyMap(), BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null);
+            Collections.emptyMap(), BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null);
         Result<Integer> insertResult = eventManager.insertCategory(event, tcm, username);
         assertTrue(insertResult.isSuccess());
         Integer categoryID = insertResult.getData();
         tcm = new TicketCategoryModification(categoryID, tcm.getName(), AVAILABLE_SEATS,
-            tcm.getInception(), tcm.getExpiration(), tcm.getDescription(), tcm.getPrice(), false, "", true, null, null, null, null, null, 0, null);
+            tcm.getInception(), tcm.getExpiration(), tcm.getDescription(), tcm.getPrice(), false, "", true, null, null, null, null, null, 0, null, null);
         Result<TicketCategory> result = eventManager.updateCategory(categoryID, event, tcm, username);
         assertFalse(result.isSuccess());
     }
@@ -703,7 +703,7 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null));
         Pair<Event, String> pair = initEvent(cat, organizationRepository, userManager, eventManager, eventRepository);
         var event = pair.getLeft();
         var categories = ticketCategoryRepository.findAllTicketCategories(event.getId());
@@ -720,7 +720,7 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null));
         Pair<Event, String> pair = initEvent(cat, organizationRepository, userManager, eventManager, eventRepository);
         var event = pair.getLeft();
         var tickets = ticketRepository.selectNotAllocatedTicketsForUpdate(event.getId(), 1, List.of(Ticket.TicketStatus.FREE.name()));
@@ -740,7 +740,7 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null));
         Pair<Event, String> pair = initEvent(cat, organizationRepository, userManager, eventManager, eventRepository);
         var event = pair.getLeft();
         var categories = ticketCategoryRepository.findAllTicketCategories(event.getId());
@@ -758,7 +758,7 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null));
         Pair<Event, String> pair = initEvent(cat, organizationRepository, userManager, eventManager, eventRepository);
         var event = pair.getLeft();
         var categories = ticketCategoryRepository.findAllTicketCategories(event.getId());
@@ -778,11 +778,11 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
             new TicketCategoryModification(null, "first", AVAILABLE_SEATS,
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 2, null),
+                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 2, null, null),
             new TicketCategoryModification(null, "second", AVAILABLE_SEATS,
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 1, null));
+                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 1, null, null));
 
         Pair<Event, String> pair = initEvent(cat, organizationRepository, userManager, eventManager, eventRepository);
         var event = pair.getLeft();
@@ -809,7 +809,7 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
             new TicketCategoryModification(null, "default", 10,
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null));
         Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
 
         Event event = pair.getKey();

--- a/src/test/java/alfio/manager/EventManagerUnbindTicketsTest.java
+++ b/src/test/java/alfio/manager/EventManagerUnbindTicketsTest.java
@@ -84,7 +84,7 @@ public class EventManagerUnbindTicketsTest {
             ticketRepository, specialPriceRepository, null, null, null,
             null, null, null,
             null, null, organizationRepository,
-            null, null, null, null);
+            null, null, null, null, null);
     }
 
     @Test

--- a/src/test/java/alfio/manager/GroupManagerIntegrationTest.java
+++ b/src/test/java/alfio/manager/GroupManagerIntegrationTest.java
@@ -97,7 +97,7 @@ public class GroupManagerIntegrationTest extends BaseIntegrationTest {
             new TicketCategoryModification(null, "default", 10,
                 new DateTimeModification(LocalDate.now().plusDays(1), LocalTime.now()),
                 new DateTimeModification(LocalDate.now().plusDays(2), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null));
         Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = pair.getKey();
         Group group = groupManager.createNew("test", "This is a test", event.getOrganizationId());
@@ -145,7 +145,7 @@ public class GroupManagerIntegrationTest extends BaseIntegrationTest {
             new TicketCategoryModification(null, "default", 10,
                 new DateTimeModification(LocalDate.now().plusDays(1), LocalTime.now()),
                 new DateTimeModification(LocalDate.now().plusDays(2), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null));
         Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = pair.getKey();
         Group group = groupManager.createNew("test", "This is a test", event.getOrganizationId());

--- a/src/test/java/alfio/manager/TicketReservationManagerIntegrationTest.java
+++ b/src/test/java/alfio/manager/TicketReservationManagerIntegrationTest.java
@@ -111,7 +111,7 @@ public class TicketReservationManagerIntegrationTest extends BaseIntegrationTest
                         new DateTimeModification(LocalDate.now(), LocalTime.now()),
                         new DateTimeModification(LocalDate.now(), LocalTime.now()),
                         DESCRIPTION, BigDecimal.TEN, false, "", false, null,
-                    null, null, null, null, 0, null));
+                    null, null, null, null, 0, null, null));
         Event event = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository).getKey();
 
         TicketReservationModification tr = new TicketReservationModification();
@@ -134,11 +134,11 @@ public class TicketReservationManagerIntegrationTest extends BaseIntegrationTest
                 new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
                         new DateTimeModification(LocalDate.now(), LocalTime.now()),
                         new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                        DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null),
+                        DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null),
                 new TicketCategoryModification(null, "default", 10,
                         new DateTimeModification(LocalDate.now(), LocalTime.now()),
                         new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                        DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null));
+                        DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null));
         Pair<Event, String> eventAndUsername = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = eventAndUsername.getKey();
 
@@ -231,7 +231,7 @@ public class TicketReservationManagerIntegrationTest extends BaseIntegrationTest
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null));
         Event event = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository).getKey();
 
         TicketCategory unbounded = ticketCategoryRepository.findAllTicketCategories(event.getId()).stream().filter(t -> !t.isBounded()).findFirst().orElseThrow(IllegalStateException::new);
@@ -304,7 +304,7 @@ public class TicketReservationManagerIntegrationTest extends BaseIntegrationTest
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null));
         Event event = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository).getKey();
 
         var firstAsKey = additionalServiceRepository.insert(event.getId(), 1000, true, 1, 100, 1, ZonedDateTime.now().minusHours(1), ZonedDateTime.now().plusHours(1), BigDecimal.TEN, AdditionalService.VatType.INHERITED, AdditionalService.AdditionalServiceType.SUPPLEMENT, AdditionalService.SupplementPolicy.OPTIONAL_UNLIMITED_AMOUNT);
@@ -350,7 +350,7 @@ public class TicketReservationManagerIntegrationTest extends BaseIntegrationTest
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, true, "", true, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, true, "", true, null, null, null, null, null, 0, null, null));
         Event event = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository).getKey();
 
         TicketCategory category = ticketCategoryRepository.findAllTicketCategories(event.getId()).stream().filter(TicketCategory::isAccessRestricted).findFirst().orElseThrow();
@@ -420,7 +420,7 @@ public class TicketReservationManagerIntegrationTest extends BaseIntegrationTest
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null));
 
         List<EventModification.AdditionalService> additionalServices = Collections.singletonList(new EventModification.AdditionalService(null, BigDecimal.TEN, true, 1, 100, 5,
             DateTimeModification.fromZonedDateTime(ZonedDateTime.now().minusDays(1L)), DateTimeModification.fromZonedDateTime(ZonedDateTime.now().plusDays(1L)),
@@ -466,7 +466,7 @@ public class TicketReservationManagerIntegrationTest extends BaseIntegrationTest
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null));
         Event event = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository).getKey();
 
         TicketCategory unbounded = ticketCategoryRepository.findAllTicketCategories(event.getId()).stream().filter(t -> !t.isBounded()).findFirst().orElseThrow(IllegalStateException::new);
@@ -485,7 +485,7 @@ public class TicketReservationManagerIntegrationTest extends BaseIntegrationTest
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null));
         Event event = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository).getKey();
 
         TicketCategory unbounded = ticketCategoryRepository.findAllTicketCategories(event.getId()).get(0);
@@ -522,7 +522,7 @@ public class TicketReservationManagerIntegrationTest extends BaseIntegrationTest
             new TicketCategoryModification(null, "default", 10,
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null));
         Pair<Event, String> eventAndUsername = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = eventAndUsername.getKey();
 
@@ -560,7 +560,7 @@ public class TicketReservationManagerIntegrationTest extends BaseIntegrationTest
             new TicketCategoryModification(null, "default", 10,
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null));
         Pair<Event, String> eventAndUsername = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = eventAndUsername.getKey();
 

--- a/src/test/java/alfio/manager/UploadedResourceIntegrationTest.java
+++ b/src/test/java/alfio/manager/UploadedResourceIntegrationTest.java
@@ -89,7 +89,7 @@ public class UploadedResourceIntegrationTest extends BaseIntegrationTest {
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
                 new DateTimeModification(LocalDate.now().minusDays(1), LocalTime.now()),
                 new DateTimeModification(LocalDate.now().plusDays(1), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null));
         Pair<Event, String> eventAndUser = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
 
         event = eventAndUser.getKey();

--- a/src/test/java/alfio/manager/WaitingQueueManagerIntegrationTest.java
+++ b/src/test/java/alfio/manager/WaitingQueueManagerIntegrationTest.java
@@ -164,7 +164,7 @@ public class WaitingQueueManagerIntegrationTest extends BaseIntegrationTest {
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null));
         Event event = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository).getKey();
         TicketCategory unbounded = ticketCategoryRepository.findAllTicketCategories(event.getId()).get(0);
 
@@ -191,7 +191,7 @@ public class WaitingQueueManagerIntegrationTest extends BaseIntegrationTest {
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
                 new DateTimeModification(start.toLocalDate(), start.toLocalTime()),
                 new DateTimeModification(end.toLocalDate(), end.toLocalTime()),
-                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null));
 
         configurationManager.saveSystemConfiguration(ConfigurationKeys.ENABLE_WAITING_QUEUE, "true");
 
@@ -251,7 +251,7 @@ public class WaitingQueueManagerIntegrationTest extends BaseIntegrationTest {
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
                 new DateTimeModification(start.toLocalDate(), start.toLocalTime()),
                 new DateTimeModification(end.toLocalDate(), end.toLocalTime()),
-                DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null));
 
         configurationManager.saveSystemConfiguration(ConfigurationKeys.ENABLE_WAITING_QUEUE, "true");
 
@@ -310,11 +310,11 @@ public class WaitingQueueManagerIntegrationTest extends BaseIntegrationTest {
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
                 new DateTimeModification(start.toLocalDate(), start.toLocalTime()),
                 new DateTimeModification(end.toLocalDate(), end.toLocalTime()),
-                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null),
+                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null),
             new TicketCategoryModification(null, "default2", AVAILABLE_SEATS,
                 new DateTimeModification(start.toLocalDate(), start.toLocalTime()),
                 new DateTimeModification(end.toLocalDate(), end.toLocalTime()),
-                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null));
 
         configurationManager.saveSystemConfiguration(ConfigurationKeys.ENABLE_WAITING_QUEUE, "true");
 
@@ -386,11 +386,11 @@ public class WaitingQueueManagerIntegrationTest extends BaseIntegrationTest {
             new TicketCategoryModification(null, "default", 2,
                 new DateTimeModification(start.toLocalDate(), start.toLocalTime()),
                 new DateTimeModification(end.toLocalDate(), end.toLocalTime()),
-                DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null),
+                DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null),
             new TicketCategoryModification(null, "default2", 10,
                 new DateTimeModification(start.toLocalDate(), start.toLocalTime()),
                 new DateTimeModification(end.toLocalDate(), end.toLocalTime()),
-                DESCRIPTION, BigDecimal.TEN, true, "", true, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, true, "", true, null, null, null, null, null, 0, null, null));
 
         configurationManager.saveSystemConfiguration(ConfigurationKeys.ENABLE_WAITING_QUEUE, "true");
         Pair<Event, String> eventAndUsername = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
@@ -404,7 +404,7 @@ public class WaitingQueueManagerIntegrationTest extends BaseIntegrationTest {
         ZoneId zoneId = event.getZoneId();
         Result<TicketCategory> ticketCategoryResult = eventManager.updateCategory(first.getId(), event, new TicketCategoryModification(first.getId(), first.getName(), 3,
             fromZonedDateTime(first.getInception(zoneId)), fromZonedDateTime(first.getExpiration(zoneId)), Collections.emptyMap(),
-            first.getPrice(), false, "", true, null, null, null, null, null, 0, null), eventAndUsername.getValue());
+            first.getPrice(), false, "", true, null, null, null, null, null, 0, null, null), eventAndUsername.getValue());
         assertTrue(ticketCategoryResult.isSuccess());
         assertEquals(1, ticketRepository.countReleasedTicketInCategory(event.getId(), first.getId()).intValue());
         //now we should have an extra available ticket
@@ -421,11 +421,11 @@ public class WaitingQueueManagerIntegrationTest extends BaseIntegrationTest {
             new TicketCategoryModification(null, "default", 2,
                 new DateTimeModification(start.toLocalDate(), start.toLocalTime()),
                 new DateTimeModification(end.toLocalDate(), end.toLocalTime()),
-                DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null),
+                DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null),
             new TicketCategoryModification(null, "default2", 10,
                 new DateTimeModification(start.toLocalDate(), start.toLocalTime()),
                 new DateTimeModification(end.toLocalDate(), end.toLocalTime()),
-                DESCRIPTION, BigDecimal.TEN, true, "", true, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, true, "", true, null, null, null, null, null, 0, null, null));
 
         configurationManager.saveSystemConfiguration(ConfigurationKeys.ENABLE_WAITING_QUEUE, "true");
         Pair<Event, String> eventAndUsername = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
@@ -462,10 +462,10 @@ public class WaitingQueueManagerIntegrationTest extends BaseIntegrationTest {
             new TicketCategoryModification(null, "defaultFirst", firstSeats,
                 new DateTimeModification(start.toLocalDate(), start.toLocalTime()),
                 new DateTimeModification(LocalDate.now().plusDays(1), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", firstBounded, null, null, null, null, null, 0, null),
+                DESCRIPTION, BigDecimal.TEN, false, "", firstBounded, null, null, null, null, null, 0, null, null),
             new TicketCategoryModification(null, "defaultLast", lastSeats,
                 new DateTimeModification(LocalDate.now().plusDays(1), LocalTime.now()),
                 new DateTimeModification(LocalDate.now().plusDays(2), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", lastBounded, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, false, "", lastBounded, null, null, null, null, null, 0, null, null));
     }
 }

--- a/src/test/java/alfio/manager/WaitingQueueProcessorIntegrationTest.java
+++ b/src/test/java/alfio/manager/WaitingQueueProcessorIntegrationTest.java
@@ -109,7 +109,7 @@ public class WaitingQueueProcessorIntegrationTest extends BaseIntegrationTest {
                 new TicketCategoryModification(null, "default", 10,
                         new DateTimeModification(LocalDate.now().plusDays(1), LocalTime.now()),
                         new DateTimeModification(LocalDate.now().plusDays(2), LocalTime.now()),
-                        DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null));
+                        DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null));
         Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = pair.getKey();
         waitingQueueManager.subscribe(event, new CustomerName("Giuseppe Garibaldi", "Giuseppe", "Garibaldi", event.mustUseFirstAndLastName()), "peppino@garibaldi.com", null, Locale.ENGLISH);
@@ -122,7 +122,7 @@ public class WaitingQueueProcessorIntegrationTest extends BaseIntegrationTest {
         TicketCategoryModification tcm = new TicketCategoryModification(null, "default", 10,
                 new DateTimeModification(LocalDate.now().minusDays(1), LocalTime.now()),
                 new DateTimeModification(LocalDate.now().plusDays(5), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null);
+                DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null);
         eventManager.insertCategory(event.getId(), tcm, pair.getValue());
 
         waitingQueueSubscriptionProcessor.distributeAvailableSeats(event);
@@ -187,7 +187,7 @@ public class WaitingQueueProcessorIntegrationTest extends BaseIntegrationTest {
         TicketCategory category = eventManager.loadTicketCategories(event).get(0);
         eventManager.updateCategory(category.getId(), event.getId(), new TicketCategoryModification(category.getId(), category.getName(), category.getMaxTickets() + 1,
             fromZonedDateTime(category.getInception(event.getZoneId())), fromZonedDateTime(category.getExpiration(event.getZoneId())), emptyMap(), category.getPrice(),
-            category.isAccessRestricted(), "", category.isBounded(), null, null, null, null, null, 0, null), "admin");
+            category.isAccessRestricted(), "", category.isBounded(), null, null, null, null, null, 0, null, null), "admin");
 
         //now the waiting queue processor should create the reservation for the first in line
         waitingQueueSubscriptionProcessor.distributeAvailableSeats(event);
@@ -205,13 +205,13 @@ public class WaitingQueueProcessorIntegrationTest extends BaseIntegrationTest {
             new TicketCategoryModification(null, "default", boundedCategorySize,
                 new DateTimeModification(LocalDate.now().minusDays(1), LocalTime.now()),
                 new DateTimeModification(LocalDate.now().plusDays(2), LocalTime.now()),
-                DESCRIPTION, BigDecimal.ZERO, false, "", true, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.ZERO, false, "", true, null, null, null, null, null, 0, null, null));
 
         if(withUnboundedCategory) {
              categories.add(new TicketCategoryModification(null, "unbounded", 0,
                  new DateTimeModification(LocalDate.now().minusDays(1), LocalTime.now()),
                  new DateTimeModification(LocalDate.now().plusDays(2), LocalTime.now()),
-                 DESCRIPTION, BigDecimal.ZERO, false, "", false, null, null, null, null, null, 0, null));
+                 DESCRIPTION, BigDecimal.ZERO, false, "", false, null, null, null, null, null, 0, null, null));
         }
 
         Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);

--- a/src/test/java/alfio/manager/WaitingQueueProcessorMultiThreadedIntegrationTest.java
+++ b/src/test/java/alfio/manager/WaitingQueueProcessorMultiThreadedIntegrationTest.java
@@ -108,7 +108,7 @@ public class WaitingQueueProcessorMultiThreadedIntegrationTest {
                 new TicketCategoryModification(null, "default", 10,
                     new DateTimeModification(LocalDate.now().plusDays(1), LocalTime.now()),
                     new DateTimeModification(LocalDate.now().plusDays(2), LocalTime.now()),
-                    DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null));
+                    DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null));
             Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
             event = pair.getKey();
             waitingQueueManager.subscribe(event, new CustomerName("Giuseppe Garibaldi", "Giuseppe", "Garibaldi", event.mustUseFirstAndLastName()), "peppino@garibaldi.com", null, Locale.ENGLISH);
@@ -136,7 +136,7 @@ public class WaitingQueueProcessorMultiThreadedIntegrationTest {
             TicketCategoryModification tcm = new TicketCategoryModification(null, "default", 10,
                 new DateTimeModification(LocalDate.now().minusDays(1), LocalTime.now()),
                 new DateTimeModification(LocalDate.now().plusDays(5), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null);
+                DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null);
             eventManager.insertCategory(event.getId(), tcm, pair.getValue());
 
 

--- a/src/test/java/alfio/manager/i18n/MessageSourceManagerIntegrationTest.java
+++ b/src/test/java/alfio/manager/i18n/MessageSourceManagerIntegrationTest.java
@@ -91,7 +91,7 @@ public class MessageSourceManagerIntegrationTest extends BaseIntegrationTest {
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
                 new DateTimeModification(LocalDate.now().minusDays(1), LocalTime.now()),
                 new DateTimeModification(LocalDate.now().plusDays(1), LocalTime.now()),
-                Map.of("en", "desc"), BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null)
+                Map.of("en", "desc"), BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null)
         );
         Pair<Event, String> eventAndUser = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
 

--- a/src/test/java/alfio/manager/system/DataMigratorIntegrationTest.java
+++ b/src/test/java/alfio/manager/system/DataMigratorIntegrationTest.java
@@ -136,7 +136,7 @@ public class DataMigratorIntegrationTest extends BaseIntegrationTest {
                 new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
                         new DateTimeModification(LocalDate.now(), LocalTime.now()),
                         new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                        DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null));
+                        DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null));
         Pair<Event, String> eventUsername = initEvent(categories);
         Event event = eventUsername.getKey();
 
@@ -165,7 +165,7 @@ public class DataMigratorIntegrationTest extends BaseIntegrationTest {
                 new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
                         new DateTimeModification(LocalDate.now(), LocalTime.now()),
                         new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                        DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null));
+                        DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null));
         Pair<Event, String> eventUsername = initEvent(categories); 
         Event event = eventUsername.getKey();
 
@@ -194,7 +194,7 @@ public class DataMigratorIntegrationTest extends BaseIntegrationTest {
                 new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
                         new DateTimeModification(LocalDate.now(), LocalTime.now()),
                         new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                        DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null));
+                        DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null));
         Pair<Event, String> eventUsername = initEvent(categories); 
         Event event = eventUsername.getKey();
         
@@ -224,7 +224,7 @@ public class DataMigratorIntegrationTest extends BaseIntegrationTest {
                 new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
                         new DateTimeModification(LocalDate.now(), LocalTime.now()),
                         new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                        DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null));
+                        DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null));
         Pair<Event, String> eventUsername = initEvent(categories, null); 
         Event event = eventUsername.getKey();
 
@@ -250,7 +250,7 @@ public class DataMigratorIntegrationTest extends BaseIntegrationTest {
                 new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
                         new DateTimeModification(LocalDate.now(), LocalTime.now()),
                         new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                        DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null));
+                        DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null));
         Pair<Event, String> eventUsername = initEvent(categories); 
         Event event = eventUsername.getKey();
         try {
@@ -274,7 +274,7 @@ public class DataMigratorIntegrationTest extends BaseIntegrationTest {
                 new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
                         new DateTimeModification(LocalDate.now(), LocalTime.now()),
                         new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                        DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null));
+                        DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null));
         Pair<Event, String> eventUsername = initEvent(categories); 
         Event event = eventUsername.getKey();
         try {
@@ -316,11 +316,11 @@ public class DataMigratorIntegrationTest extends BaseIntegrationTest {
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS -1,
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null),
+                DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null),
             new TicketCategoryModification(null, "default", 1,
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null));
         Pair<Event, String> eventUsername = initEvent(categories);
         Event event = eventUsername.getKey();
         TicketCategory firstCategory = ticketCategoryRepository.findAllTicketCategories(event.getId()).stream().filter(TicketCategory::isBounded).findFirst().orElseThrow(IllegalStateException::new);
@@ -339,7 +339,7 @@ public class DataMigratorIntegrationTest extends BaseIntegrationTest {
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null));
         Pair<Event, String> eventUsername = initEvent(categories);
         Event event = eventUsername.getKey();
         TicketReservationModification trm = new TicketReservationModification();

--- a/src/test/java/alfio/repository/EventRepositoryIntegrationTest.java
+++ b/src/test/java/alfio/repository/EventRepositoryIntegrationTest.java
@@ -115,13 +115,13 @@ public class EventRepositoryIntegrationTest extends BaseIntegrationTest {
             new TicketCategoryModification(null, "default", 0,
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
                 new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null));
+                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null));
         Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = pair.getKey();
         TicketCategoryModification tcm = new TicketCategoryModification(null, "default", 10,
             new DateTimeModification(LocalDate.now(), LocalTime.now()),
             new DateTimeModification(LocalDate.now(), LocalTime.now()),
-            DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null);
+            DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null);
         Result<Integer> result = eventManager.insertCategory(event, tcm, pair.getValue());
         assertTrue(result.isSuccess());
 


### PR DESCRIPTION
It is common practice for multi-day events to have badges of different colors depending on which days an attendee can access the event.

In order to speed up the check-in operations, some time ago we have implemented an experimental support for badge colors on [Alf.io-PI](https://github.com/alfio-event/Alf.io-PI), with a substantial increase of the check-in throughput.

Now it's time to implement this functionality also on the mobile app. To do so, we're centralizing the configuration on the backoffice, rather than on the check-in stations