### PR TITLE
Prevent confirmation email to be sent twice.

### DIFF
--- a/src/main/java/alfio/manager/TicketReservationManager.java
+++ b/src/main/java/alfio/manager/TicketReservationManager.java
@@ -16,83 +16,43 @@
  */
 package alfio.manager;
 
-import static alfio.model.Audit.EntityType.RESERVATION;
-import static alfio.model.Audit.EventType.EXTERNAL_INVOICE_NUMBER;
-import static alfio.model.Audit.EventType.MATCHING_PAYMENT_FOUND;
-import static alfio.model.BillingDocument.Type.CREDIT_NOTE;
-import static alfio.model.BillingDocument.Type.INVOICE;
-import static alfio.model.BillingDocument.Type.RECEIPT;
-import static alfio.model.PromoCodeDiscount.categoriesOrNull;
-import static alfio.model.TicketReservation.TicketReservationStatus.CANCELLED;
-import static alfio.model.TicketReservation.TicketReservationStatus.EXTERNAL_PROCESSING_PAYMENT;
-import static alfio.model.TicketReservation.TicketReservationStatus.IN_PAYMENT;
-import static alfio.model.TicketReservation.TicketReservationStatus.OFFLINE_PAYMENT;
-import static alfio.model.TicketReservation.TicketReservationStatus.PENDING;
-import static alfio.model.TicketReservation.TicketReservationStatus.WAITING_EXTERNAL_CONFIRMATION;
-import static alfio.model.system.ConfigurationKeys.ALLOW_FREE_TICKETS_CANCELLATION;
-import static alfio.model.system.ConfigurationKeys.ASSIGNMENT_REMINDER_INTERVAL;
-import static alfio.model.system.ConfigurationKeys.ASSIGNMENT_REMINDER_START;
-import static alfio.model.system.ConfigurationKeys.AUTOMATIC_REMOVAL_EXPIRED_OFFLINE_PAYMENT;
-import static alfio.model.system.ConfigurationKeys.BANK_ACCOUNT_NR;
-import static alfio.model.system.ConfigurationKeys.BANK_ACCOUNT_OWNER;
-import static alfio.model.system.ConfigurationKeys.BASE_URL;
-import static alfio.model.system.ConfigurationKeys.ENABLE_TICKET_TRANSFER;
-import static alfio.model.system.ConfigurationKeys.INVOICE_ADDRESS;
-import static alfio.model.system.ConfigurationKeys.MAX_AMOUNT_OF_TICKETS_BY_RESERVATION;
-import static alfio.model.system.ConfigurationKeys.NOTIFY_ALL_FAILED_PAYMENT_ATTEMPTS;
-import static alfio.model.system.ConfigurationKeys.OFFLINE_REMINDER_HOURS;
-import static alfio.model.system.ConfigurationKeys.OPTIONAL_DATA_REMINDER_ENABLED;
-import static alfio.model.system.ConfigurationKeys.RESERVATION_MIN_TIMEOUT_AFTER_FAILED_PAYMENT;
-import static alfio.model.system.ConfigurationKeys.RESERVATION_TIMEOUT;
-import static alfio.model.system.ConfigurationKeys.SEND_TICKETS_AUTOMATICALLY;
-import static alfio.model.system.ConfigurationKeys.VAT_NR;
-import static alfio.util.MonetaryUtil.formatCents;
-import static alfio.util.MonetaryUtil.unitToCents;
-import static alfio.util.Wrappers.optionally;
-import static java.util.Arrays.asList;
-import static java.util.Collections.singletonList;
-import static java.util.Collections.singletonMap;
-import static java.util.stream.Collectors.groupingBy;
-import static java.util.stream.Collectors.joining;
-import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toMap;
-import static java.util.stream.Collectors.toSet;
-import static org.apache.commons.lang3.StringUtils.defaultString;
-import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
-import static org.apache.commons.lang3.StringUtils.stripAll;
-import static org.apache.commons.lang3.StringUtils.stripToEmpty;
-import static org.apache.commons.lang3.StringUtils.stripToNull;
-import static org.apache.commons.lang3.StringUtils.trimToEmpty;
-import static org.apache.commons.lang3.StringUtils.trimToNull;
-import static org.apache.commons.lang3.time.DateUtils.addHours;
-import static org.apache.commons.lang3.time.DateUtils.truncate;
-
-import java.math.BigDecimal;
-import java.time.Clock;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.OptionalInt;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
-
+import alfio.controller.api.support.TicketHelper;
+import alfio.controller.form.UpdateTicketOwnerForm;
+import alfio.manager.i18n.MessageSourceManager;
+import alfio.manager.payment.BankTransferManager;
+import alfio.manager.payment.PaymentSpecification;
+import alfio.manager.support.*;
+import alfio.manager.system.ConfigurationLevel;
+import alfio.manager.system.ConfigurationManager;
+import alfio.manager.system.Mailer;
+import alfio.model.*;
+import alfio.model.AdditionalServiceItem.AdditionalServiceItemStatus;
+import alfio.model.PromoCodeDiscount.DiscountType;
+import alfio.model.SpecialPrice.Status;
+import alfio.model.Ticket.TicketStatus;
+import alfio.model.TicketReservation.TicketReservationStatus;
+import alfio.model.decorator.AdditionalServiceItemPriceContainer;
+import alfio.model.decorator.AdditionalServicePriceContainer;
+import alfio.model.decorator.TicketPriceContainer;
+import alfio.model.group.LinkedGroup;
+import alfio.model.modification.ASReservationWithOptionalCodeModification;
+import alfio.model.modification.AdditionalServiceReservationModification;
+import alfio.model.modification.TicketReservationWithOptionalCodeModification;
+import alfio.model.result.ErrorCode;
+import alfio.model.result.Result;
+import alfio.model.system.ConfigurationKeys;
+import alfio.model.transaction.*;
+import alfio.model.transaction.capabilities.OfflineProcessor;
+import alfio.model.transaction.capabilities.ServerInitiatedTransaction;
+import alfio.model.transaction.capabilities.SignedWebhookHandler;
+import alfio.model.user.Organization;
+import alfio.model.user.Role;
+import alfio.repository.*;
+import alfio.repository.user.OrganizationRepository;
+import alfio.repository.user.UserRepository;
+import alfio.util.*;
+import ch.digitalfondue.npjt.AffectedRowCountAndKey;
+import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.time.DateUtils;
@@ -108,97 +68,35 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.DefaultTransactionDefinition;
 import org.springframework.transaction.support.TransactionTemplate;
 
-import alfio.controller.api.support.TicketHelper;
-import alfio.controller.form.UpdateTicketOwnerForm;
-import alfio.manager.i18n.MessageSourceManager;
-import alfio.manager.payment.BankTransferManager;
-import alfio.manager.payment.PaymentSpecification;
-import alfio.manager.support.CategoryEvaluator;
-import alfio.manager.support.FeeCalculator;
-import alfio.manager.support.PartialTicketTextGenerator;
-import alfio.manager.support.PaymentResult;
-import alfio.manager.support.PaymentWebhookResult;
-import alfio.manager.system.ConfigurationLevel;
-import alfio.manager.system.ConfigurationManager;
-import alfio.manager.system.Mailer;
-import alfio.model.AdditionalService;
-import alfio.model.AdditionalServiceItem;
-import alfio.model.AdditionalServiceItem.AdditionalServiceItemStatus;
-import alfio.model.AdditionalServiceText;
-import alfio.model.Audit;
-import alfio.model.BillingDocument;
-import alfio.model.CustomerName;
-import alfio.model.Event;
-import alfio.model.EventAndOrganizationId;
-import alfio.model.OrderSummary;
-import alfio.model.PriceContainer;
-import alfio.model.PromoCodeDiscount;
-import alfio.model.PromoCodeDiscount.DiscountType;
-import alfio.model.ReservationIdAndEventId;
-import alfio.model.SpecialPrice;
-import alfio.model.SpecialPrice.Status;
-import alfio.model.SummaryPriceContainer;
-import alfio.model.SummaryRow;
-import alfio.model.Ticket;
-import alfio.model.Ticket.TicketStatus;
-import alfio.model.TicketCategory;
-import alfio.model.TicketFieldValue;
-import alfio.model.TicketReservation;
-import alfio.model.TicketReservation.TicketReservationStatus;
-import alfio.model.TicketReservationInfo;
-import alfio.model.TicketReservationInvoicingAdditionalInfo;
-import alfio.model.TicketReservationWithTransaction;
-import alfio.model.TicketWithCategory;
-import alfio.model.TotalPrice;
-import alfio.model.decorator.AdditionalServiceItemPriceContainer;
-import alfio.model.decorator.AdditionalServicePriceContainer;
-import alfio.model.decorator.TicketPriceContainer;
-import alfio.model.group.LinkedGroup;
-import alfio.model.modification.ASReservationWithOptionalCodeModification;
-import alfio.model.modification.AdditionalServiceReservationModification;
-import alfio.model.modification.TicketReservationWithOptionalCodeModification;
-import alfio.model.result.ErrorCode;
-import alfio.model.result.Result;
-import alfio.model.system.ConfigurationKeys;
-import alfio.model.transaction.PaymentContext;
-import alfio.model.transaction.PaymentMethod;
-import alfio.model.transaction.PaymentProxy;
-import alfio.model.transaction.Transaction;
-import alfio.model.transaction.TransactionInitializationToken;
-import alfio.model.transaction.capabilities.OfflineProcessor;
-import alfio.model.transaction.capabilities.ServerInitiatedTransaction;
-import alfio.model.transaction.capabilities.SignedWebhookHandler;
-import alfio.model.user.Organization;
-import alfio.model.user.Role;
-import alfio.repository.AdditionalServiceItemRepository;
-import alfio.repository.AdditionalServiceRepository;
-import alfio.repository.AdditionalServiceTextRepository;
-import alfio.repository.AuditingRepository;
-import alfio.repository.BillingDocumentRepository;
-import alfio.repository.EventRepository;
-import alfio.repository.InvoiceSequencesRepository;
-import alfio.repository.PromoCodeDiscountRepository;
-import alfio.repository.SpecialPriceRepository;
-import alfio.repository.TicketCategoryDescriptionRepository;
-import alfio.repository.TicketCategoryRepository;
-import alfio.repository.TicketFieldRepository;
-import alfio.repository.TicketRepository;
-import alfio.repository.TicketReservationRepository;
-import alfio.repository.TicketSearchRepository;
-import alfio.repository.TransactionRepository;
-import alfio.repository.user.OrganizationRepository;
-import alfio.repository.user.UserRepository;
-import alfio.util.ErrorsCode;
-import alfio.util.EventUtil;
-import alfio.util.Json;
-import alfio.util.LocaleUtil;
-import alfio.util.MonetaryUtil;
-import alfio.util.ObjectDiffUtil;
-import alfio.util.TemplateManager;
-import alfio.util.TemplateResource;
-import alfio.util.Wrappers;
-import ch.digitalfondue.npjt.AffectedRowCountAndKey;
-import lombok.extern.log4j.Log4j2;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static alfio.model.Audit.EntityType.RESERVATION;
+import static alfio.model.Audit.EventType.*;
+import static alfio.model.BillingDocument.Type.*;
+import static alfio.model.PromoCodeDiscount.categoriesOrNull;
+import static alfio.model.TicketReservation.TicketReservationStatus.*;
+import static alfio.model.system.ConfigurationKeys.*;
+import static alfio.util.MonetaryUtil.formatCents;
+import static alfio.util.MonetaryUtil.unitToCents;
+import static alfio.util.Wrappers.optionally;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static java.util.stream.Collectors.*;
+import static org.apache.commons.lang3.StringUtils.*;
+import static org.apache.commons.lang3.time.DateUtils.addHours;
+import static org.apache.commons.lang3.time.DateUtils.truncate;
 
 @Component
 @Transactional
@@ -596,8 +494,11 @@ public class TicketReservationManager {
     }
 
     private void transitionToComplete(PaymentSpecification spec, TotalPrice reservationCost, PaymentProxy paymentProxy) {
-        generateInvoiceNumber(spec, reservationCost);
-        completeReservation(spec, paymentProxy, true, true);
+        var status = ticketReservationRepository.findOptionalStatusAndValidationById(spec.getReservationId()).orElseThrow().getStatus();
+        if(status != COMPLETE) {
+            generateInvoiceNumber(spec, reservationCost);
+            completeReservation(spec, paymentProxy, true, true);
+        }
     }
 
     private void generateInvoiceNumber(PaymentSpecification spec, TotalPrice reservationCost) {
@@ -946,11 +847,17 @@ public class TicketReservationManager {
 
     private void transitionToInPayment(PaymentSpecification spec) {
         requiresNewTransactionTemplate.execute(status -> {
-            int updatedReservation = ticketReservationRepository.updateTicketReservation(spec.getReservationId(),
-                IN_PAYMENT.toString(), spec.getEmail(), spec.getCustomerName().getFullName(),
-                spec.getCustomerName().getFirstName(), spec.getCustomerName().getLastName(),
-                spec.getLocale().getLanguage(), spec.getBillingAddress(),null, PaymentProxy.STRIPE.toString(), spec.getCustomerReference());
-            Validate.isTrue(updatedReservation == 1, "expected exactly one updated reservation, got " + updatedReservation);
+            var optionalStatusAndValidation = ticketReservationRepository.findOptionalStatusAndValidationById(spec.getReservationId());
+            if(optionalStatusAndValidation.isPresent() && optionalStatusAndValidation.get().getStatus() == COMPLETE) {
+                // reservation has been already completed. Let's check if there is a corresponding audit event
+                Validate.isTrue(auditingRepository.countAuditsOfTypeForReservation(spec.getReservationId(), PAYMENT_CONFIRMED) == 1, "Trying to confirm an already paid reservation, but can't find autiting event");
+            } else {
+                int updatedReservation = ticketReservationRepository.updateTicketReservation(spec.getReservationId(),
+                    IN_PAYMENT.toString(), spec.getEmail(), spec.getCustomerName().getFullName(),
+                    spec.getCustomerName().getFirstName(), spec.getCustomerName().getLastName(),
+                    spec.getLocale().getLanguage(), spec.getBillingAddress(),null, PaymentProxy.STRIPE.toString(), spec.getCustomerReference());
+                Validate.isTrue(updatedReservation == 1, "expected exactly one updated reservation, got " + updatedReservation);
+            }
             return null;
         });
     }


### PR DESCRIPTION
If the reservation has been already confirmed by a payment provider
webhook, do not call the confirmation logic again