### PR TITLE
hide count if there is no visible category available

### DIFF
--- a/src/main/java/alfio/controller/api/v2/user/EventApiV2Controller.java
+++ b/src/main/java/alfio/controller/api/v2/user/EventApiV2Controller.java
@@ -215,7 +215,7 @@ public class EventApiV2Controller {
 
                 Integer availableTicketsCount = null;
                 if(configurationsValues.get(DISPLAY_TICKETS_LEFT_INDICATOR).getValueAsBooleanOrDefault(false)) {
-                    availableTicketsCount = ticketRepository.countFreeTicketsForUnbounded(event.getId());
+                    availableTicketsCount = ticketRepository.countFreeTicketsForPublicStatistics(event.getId());
                 }
 
                 return new ResponseEntity<>(new EventWithAdditionalInfo(event, locationDescriptor.getMapUrl(), organization, descriptions,

--- a/src/main/java/alfio/repository/TicketRepository.java
+++ b/src/main/java/alfio/repository/TicketRepository.java
@@ -85,6 +85,9 @@ public interface TicketRepository {
     @Query("select count(*) from ticket where status = 'FREE' and category_id is null and event_id = :eventId")
     Integer countFreeTicketsForUnbounded(@Bind("eventId") int eventId);
 
+    @Query("select case(show_public_statistics) when true then dynamic_allocation else 0 end from events_statistics where id = :eventId")
+    Integer countFreeTicketsForPublicStatistics(@Bind("eventId") int eventId);
+
     @Query("select count(*) from ticket where status in ('FREE', 'RELEASED') and category_id is null and event_id = :eventId")
     Integer countNotAllocatedFreeAndReleasedTicket(@Bind("eventId") int eventId);
 

--- a/src/main/resources/alfio/db/PGSQL/afterMigrate__003_VIEW_ticket_category_statistics.sql
+++ b/src/main/resources/alfio/db/PGSQL/afterMigrate__003_VIEW_ticket_category_statistics.sql
@@ -23,6 +23,7 @@ from
 
 (select
   id as ticket_category_id,
+  access_restricted,
   max_tickets,
   bounded,
   is_expired,
@@ -35,7 +36,7 @@ from
   coalesce(stuck_count, 0) as stuck_count
 from
 
-(select max_tickets, bounded, id, event_id, expiration < now() as is_expired from ticket_category ) ticket_cat
+(select max_tickets, bounded, id, event_id, expiration < now() as is_expired, access_restricted from ticket_category ) ticket_cat
 
 left join
 

--- a/src/main/resources/alfio/db/PGSQL/afterMigrate__004_VIEW_events_statistics.sql
+++ b/src/main/resources/alfio/db/PGSQL/afterMigrate__004_VIEW_events_statistics.sql
@@ -38,8 +38,8 @@ create view events_statistics as (select
         allocated_count - sold_tickets_count - stats.checked_in_count - pending_count
       end as not_sold_tickets,
       is_containing_orphan_tickets_count > 0 as is_containing_orphan_tickets,
-      is_containing_stuck_tickets_count > 0 as is_containing_stuck_tickets_count
-
+      is_containing_stuck_tickets_count > 0 as is_containing_stuck_tickets_count,
+      public_and_valid_count > 0 as show_public_statistics
 
 from
 (select
@@ -57,5 +57,6 @@ from
 	sum(case (bounded) when false then 1 else 0 end) > 0 contains_unbounded_categories,
 	sum(case (is_containing_orphan_tickets) when true then 1 else 0 end) is_containing_orphan_tickets_count,
     sum(case (is_containing_stuck_tickets) when true then 1 else 0 end) is_containing_stuck_tickets_count,
+    sum(case (access_restricted = false and is_expired = false) when true then 1 else 0 end) as public_and_valid_count,
 	event_id from ticket_category_statistics group by event_id) as stats
 inner join event on event_id = event.id);


### PR DESCRIPTION
This fixes the "Schrödinger Tickets" problem:

![image](https://user-images.githubusercontent.com/3385346/70348661-74e1b780-1863-11ea-926a-4401d6854b7c.png)

This bug is triggered if all of the following conditions are met:

- display ticket left indicator is enabled, and
- all ticket categories are dynamic, and
- all ticket categories are expired

