### PR TITLE
Add external config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -212,6 +212,7 @@ dependencies {
     }
 
     implementation "org.joda:joda-money:1.0.1"
+    annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 }
 
 // -- license configuration
@@ -271,6 +272,8 @@ processResources {
 compileJava {
     options.compilerArgs = ['-Xlint:all,-serial,-processing']
 }
+
+compileJava.dependsOn(processResources)
 
 //propagate the system properties to the tests
 test {

--- a/src/main/java/alfio/config/SpringBootInitializer.java
+++ b/src/main/java/alfio/config/SpringBootInitializer.java
@@ -16,8 +16,10 @@
  */
 package alfio.config;
 
+import alfio.manager.system.ExternalConfiguration;
 import com.openhtmltopdf.util.XRLog;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.servlet.ServletContextInitializer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -39,6 +41,7 @@ import static org.springframework.web.context.support.WebApplicationContextUtils
         org.springframework.boot.autoconfigure.web.servlet.HttpEncodingAutoConfiguration.class,
         org.springframework.boot.autoconfigure.session.SessionAutoConfiguration.class,
         org.springframework.boot.autoconfigure.quartz.QuartzAutoConfiguration.class})
+@EnableConfigurationProperties(ExternalConfiguration.class)
 @Configuration
 @Profile(Initializer.PROFILE_SPRING_BOOT)
 public class SpringBootInitializer {

--- a/src/main/java/alfio/db/PGSQL/V22_1_14_8__MigrateMailchimp.java
+++ b/src/main/java/alfio/db/PGSQL/V22_1_14_8__MigrateMailchimp.java
@@ -19,6 +19,7 @@ package alfio.db.PGSQL;
 import alfio.extension.Extension;
 import alfio.extension.ExtensionService;
 import alfio.extension.ScriptingExecutionService;
+import alfio.manager.system.ExternalConfiguration;
 import alfio.repository.ExtensionLogRepository;
 import alfio.repository.ExtensionRepository;
 import ch.digitalfondue.npjt.Bind;
@@ -50,7 +51,7 @@ public class V22_1_14_8__MigrateMailchimp extends BaseSpringJdbcMigration {
         ExtensionRepository extensionRepository = QueryFactory.from(ExtensionRepository.class, "PGSQL", jdbcTemplate.getDataSource());
         ExtensionLogRepository extensionLogRepository = QueryFactory.from(ExtensionLogRepository.class, "PGSQL", jdbcTemplate.getDataSource());
         PluginRepository pluginRepository = QueryFactory.from(PluginRepository.class, "PGSQL", jdbcTemplate.getDataSource());
-        ExtensionService extensionService = new ExtensionService(new ScriptingExecutionService(), extensionRepository, extensionLogRepository, new DataSourceTransactionManager(jdbcTemplate.getDataSource()));
+        ExtensionService extensionService = new ExtensionService(new ScriptingExecutionService(), extensionRepository, extensionLogRepository, new DataSourceTransactionManager(jdbcTemplate.getDataSource()), new ExternalConfiguration());
 
         extensionService.createOrUpdate(null, null, new Extension("-", "mailchimp", getMailChimpScript(), true));
 

--- a/src/main/java/alfio/manager/payment/PayPalManager.java
+++ b/src/main/java/alfio/manager/payment/PayPalManager.java
@@ -271,7 +271,7 @@ public class PayPalManager implements PaymentProvider, RefundRequest, PaymentInf
             }
             Capture c = Capture.get(apiContext, transactionId);
             String gatewayFee = Optional.ofNullable(c.getTransactionFee())
-                .map(currency -> MonetaryUtil.formatUnit(new BigDecimal(currency.getValue()), currency.getCurrency()))
+                .map(currency -> String.valueOf(MonetaryUtil.unitToCents(new BigDecimal(currency.getValue()), currency.getCurrency())))
                 .orElse(null);
             return Optional.of(new PaymentInformation(c.getAmount().getTotal(), refund, gatewayFee, platformFeeSupplier.get()));
         } catch (PayPalRESTException ex) {

--- a/src/main/java/alfio/manager/system/ConfigurationLevel.java
+++ b/src/main/java/alfio/manager/system/ConfigurationLevel.java
@@ -21,7 +21,12 @@ import alfio.model.system.ConfigurationPathLevel;
 
 public interface ConfigurationLevel {
 
+
     ConfigurationPathLevel getPathLevel(); //waiting for pattern matching...
+
+    static ConfigurationLevel external() {
+        return new ConfigurationLevels.ExternalLevel();
+    }
 
     static ConfigurationLevel system() {
         return new ConfigurationLevels.SystemLevel();

--- a/src/main/java/alfio/manager/system/ConfigurationLevels.java
+++ b/src/main/java/alfio/manager/system/ConfigurationLevels.java
@@ -23,6 +23,14 @@ import static alfio.model.system.ConfigurationPathLevel.*;
 import static alfio.model.system.ConfigurationPathLevel.TICKET_CATEGORY;
 
 class ConfigurationLevels {
+
+    static class ExternalLevel implements ConfigurationLevel {
+        @Override
+        public ConfigurationPathLevel getPathLevel() {
+            return EXTERNAL;
+        }
+    }
+
     static class SystemLevel implements ConfigurationLevel {
         @Override
         public ConfigurationPathLevel getPathLevel() {

--- a/src/main/java/alfio/manager/system/ExternalConfiguration.java
+++ b/src/main/java/alfio/manager/system/ExternalConfiguration.java
@@ -1,0 +1,104 @@
+/**
+ * This file is part of alf.io.
+ *
+ * alf.io is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * alf.io is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with alf.io.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package alfio.manager.system;
+
+import alfio.model.ExtensionSupport;
+import alfio.model.system.Configuration;
+import alfio.model.system.ConfigurationKeyValuePathLevel;
+import alfio.model.system.ConfigurationPathLevel;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+@Component
+@ConfigurationProperties("alfio.override.system")
+@Getter
+@Setter
+public class ExternalConfiguration {
+    private static final String EXTERNAL_EXTENSION_PATH = "::EXTERNAL::";
+    private static final int EXTERNAL_CONFIGURATION_ID = Integer.MIN_VALUE;
+    private Map<String, String> settings = new HashMap<>();
+    private List<ExtensionOverride> extensions = new ArrayList<>();
+
+    public List<Configuration> load(String key) {
+        return getSingle(key).map(List::of).orElse(List.of());
+    }
+
+    public Optional<Configuration> getSingle(String key) {
+        return Optional.ofNullable(settings.get(key)).map(value -> new Configuration(EXTERNAL_CONFIGURATION_ID, key, value, ConfigurationPathLevel.EXTERNAL));
+    }
+
+    public List<ConfigurationKeyValuePathLevel> getAll(Collection<String> keys) {
+        return keys.stream()
+            .map(this::getSingle)
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .map(c -> new ConfigurationKeyValuePathLevel(c.getKey(), c.getValue(), c.getConfigurationPathLevel()))
+            .collect(Collectors.toList());
+    }
+
+    public Optional<String> getScript(String path, String name) {
+        if(EXTERNAL_EXTENSION_PATH.equals(path)) {
+            return extensions.stream().filter(e -> e.isValid() && e.id.equals(name))
+                .map(ExtensionOverride::getFile)
+                .findFirst();
+        }
+        return Optional.empty();
+    }
+
+    public List<ExtensionSupport.ScriptPathNameHash> getAllExtensionsFor(String event, boolean async) {
+        return extensions.stream()
+            .filter(e -> e.async == async && e.isValid() && e.getEvents().contains(event))
+            .map(e -> new ExtensionSupport.ScriptPathNameHash(EXTERNAL_EXTENSION_PATH, e.getId(), DigestUtils.sha256Hex(e.file)))
+            .collect(Collectors.toList());
+    }
+
+    public Map<String, String> getParametersForExtension(String id) {
+        return extensions.stream().filter(ExtensionOverride::isValid).map(ExtensionOverride::getParams)
+            .findFirst()
+            .orElse(Map.of());
+    }
+
+    @Data
+    public static class ExtensionOverride {
+        private String id;
+        private String file;
+        private List<String> events;
+        private boolean async;
+        private Map<String, String> params;
+
+        boolean isValid() {
+            return isNotBlank(id)
+                && isNotBlank(file)
+                && events != null && !events.isEmpty();
+        }
+    }
+
+    public static boolean isExternalPath(String path) {
+        return EXTERNAL_EXTENSION_PATH.equals(path);
+    }
+
+
+}

--- a/src/main/java/alfio/model/system/ConfigurationPathLevel.java
+++ b/src/main/java/alfio/model/system/ConfigurationPathLevel.java
@@ -19,7 +19,7 @@ package alfio.model.system;
 import java.util.Comparator;
 
 public enum ConfigurationPathLevel implements Comparable<ConfigurationPathLevel> {
-    SYSTEM(0), ORGANIZATION(1), EVENT(2), TICKET_CATEGORY(3);
+    EXTERNAL(-1), SYSTEM(0), ORGANIZATION(1), EVENT(2), TICKET_CATEGORY(3);
 
     private final int priority;
 

--- a/src/main/java/alfio/repository/system/ConfigurationRepository.java
+++ b/src/main/java/alfio/repository/system/ConfigurationRepository.java
@@ -83,6 +83,9 @@ public interface ConfigurationRepository {
     @Query(SYSTEM_FIND_BY_KEY)
     Optional<Configuration> findOptionalByKey(@Bind("key") String key);
 
+    @Query(SYSTEM_FIND_BY_KEY)
+    List<Configuration> findByKeyAtSystemLevel(@Bind("key") String key);
+
     @Query(SYSTEM_FIND_BY_KEY + " UNION ALL " + ORGANIZATION_FIND_BY_KEY)
     List<Configuration> findByOrganizationAndKey(@Bind("organizationId") int organizationId, @Bind("key") String key);
 

--- a/src/test/java/alfio/manager/system/ConfigurationLevelTest.java
+++ b/src/test/java/alfio/manager/system/ConfigurationLevelTest.java
@@ -25,6 +25,13 @@ import static org.junit.jupiter.api.Assertions.*;
 class ConfigurationLevelTest {
 
     @Test
+    void external() {
+        ConfigurationLevel external = ConfigurationLevel.external();
+        assertTrue(external instanceof ConfigurationLevels.ExternalLevel);
+        assertEquals(ConfigurationPathLevel.EXTERNAL, external.getPathLevel());
+    }
+
+    @Test
     void system() {
         ConfigurationLevel system = ConfigurationLevel.system();
         assertTrue(system instanceof ConfigurationLevels.SystemLevel);


### PR DESCRIPTION
In some cases it can be useful to externalize:

- system configuration
- extensions

and not to save them to the database. 
This PR enables support for external configuration and extensions, which can be defined either:

- as JSON, using the [SPRING_APPLICATION_JSON](https://docs.spring.io/spring-boot/docs/2.1.7.RELEASE/reference/html/boot-features-external-config.html)
- in the application.properties