### PR TITLE
Detect Asynchronous Events + More

### DIFF
--- a/src/test/java/alfio/controller/api/v2/user/ReservationFlowIntegrationTest.java
+++ b/src/test/java/alfio/controller/api/v2/user/ReservationFlowIntegrationTest.java
@@ -584,7 +584,7 @@ public class ReservationFlowIntegrationTest extends BaseIntegrationTest {
             jdbcTemplate.update("delete from extension_log", Map.of());
             reservationApiV2Controller.cancelPendingReservation(event.getShortName(), res.getBody().getValue());
 
-            // cannot have just one row in the log, every execution causes AT LEAST two logs
+            // cannot have just one row in the log, every execution causes EXACTLY two logs
             // log expected: RESERVATION_CANCELLED
             extLogs = extensionLogRepository.getPage(null, null, null, 100, 0);
             assertEquals(2, extLogs.size());
@@ -931,7 +931,6 @@ public class ReservationFlowIntegrationTest extends BaseIntegrationTest {
             validatePayment(event.getShortName(), reservationId);
 
             extLogs = extensionLogRepository.getPage(null, null, null, 100, 0);
-            System.out.println(extLogs);
             assertEquals(4, extLogs.size()); // cannot expect 1, check if one of rows contains reservation cancelled
 
             assertEquals("RESERVATION_CONFIRMED", extLogs.get(1).getDescription());

--- a/src/test/resources/extension.js
+++ b/src/test/resources/extension.js
@@ -14,7 +14,7 @@ function getScriptMetadata() {
             'RESERVATION_EXPIRED', //fired when reservation(s) expired
             'RESERVATION_CANCELLED', //fired when reservation(s) are cancelled
             'TICKET_CANCELLED', //fired when ticket(s) (but not the entire reservation) are cancelled
-            'TICKET_ASSIGNED', //fired on ticket assignment. No results expected.,
+            'TICKET_ASSIGNED', //fired on ticket assignment. No results expected.
             'TICKET_CHECKED_IN', //fired when a ticket has been checked in. No results expected.
             'WAITING_QUEUE_SUBSCRIPTION', //fired on waiting queue subscription. No results expected.
             'EVENT_CREATED', //fired when an event has been created. Return boolean for synchronous variant, no results expected for the asynchronous one.

--- a/src/test/resources/extension.js
+++ b/src/test/resources/extension.js
@@ -14,7 +14,8 @@ function getScriptMetadata() {
             'RESERVATION_EXPIRED', //fired when reservation(s) expired
             'RESERVATION_CANCELLED', //fired when reservation(s) are cancelled
             'TICKET_CANCELLED', //fired when ticket(s) (but not the entire reservation) are cancelled
-            'TICKET_ASSIGNED', //fired on ticket assignment. No results expected.
+            'TICKET_ASSIGNED', //fired on ticket assignment. No results expected.,
+            'TICKET_CHECKED_IN', //fired when a ticket has been checked in. No results expected.
             'WAITING_QUEUE_SUBSCRIPTION', //fired on waiting queue subscription. No results expected.
             'EVENT_CREATED', //fired when an event has been created. Return boolean for synchronous variant, no results expected for the asynchronous one.
             'EVENT_STATUS_CHANGE', //fired when an event status has changed (normally, from DRAFT to PUBLIC). Return boolean for synchronous variant, no results expected for the asynchronous one.


### PR DESCRIPTION
In `ReservatioFlowIntegrationTest`, add an asynchronous extension to the database to enable detecting `RESERVATION_CONFIRMED` (an asynchronous event). We clear the extension_log table whenever we assert for presence of log. This PR also tests for `RESERVATION_CANCELLED`, `TICKET_ASSIGNED`, and `TICKET_CHECKED_IN`. Each time an event is logged, we expect to find exactly two logs for the event.

**Find all RESERVATION_CONFIRMED**
* There is only one `log(WARN) from script with event: RESERVATION_CONFIRMED` in the test output