### PR TITLE
Feature/97 add svg support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -138,6 +138,8 @@ dependencies {
     compile "com.openhtmltopdf:openhtmltopdf-core:1.0.2"
     compile "com.openhtmltopdf:openhtmltopdf-pdfbox:1.0.2"
     compile "ch.digitalfondue.jfiveparse:jfiveparse:0.7.1"
+    compile "org.apache.xmlgraphics:batik-transcoder:1.12"
+    compile "org.apache.xmlgraphics:batik-codec:1.12"
     /**/
     compile "com.google.zxing:core:3.4.0"
     compile "com.google.zxing:javase:3.4.0"

--- a/src/main/webapp/resources/angular-templates/admin/partials/event/fragment/edit-event-header.html
+++ b/src/main/webapp/resources/angular-templates/admin/partials/event/fragment/edit-event-header.html
@@ -123,7 +123,7 @@
     </div>
     <div class="page-header">
         <h3>Logo</h3>
-        <small class="text-muted">Upload the event logo in PNG or JPG format.</small>
+        <small class="text-muted">Upload the event logo in PNG, JPG or SVG format.</small>
     </div>
     <div class="row">
         <div class="col-xs-6">

--- a/src/main/webapp/resources/angular-templates/admin/partials/event/fragment/edit-event-header.html
+++ b/src/main/webapp/resources/angular-templates/admin/partials/event/fragment/edit-event-header.html
@@ -123,7 +123,7 @@
     </div>
     <div class="page-header">
         <h3>Logo</h3>
-        <small class="text-muted">Upload the event logo in PNG, JPG or SVG format.</small>
+        <small class="text-muted">Upload the event logo in PNG, JPG, GIF or SVG format.</small>
     </div>
     <div class="row">
         <div class="col-xs-6">

--- a/src/main/webapp/resources/js/admin/directive/admin-directive.js
+++ b/src/main/webapp/resources/js/admin/directive/admin-directive.js
@@ -534,8 +534,8 @@
                     };
                     if (files.length <= 0) {
                 		alert('Your image not uploaded correctly.Please upload the image again');
-	                } else if (!((files[0].type === 'image/png') || (files[0].type === 'image/jpeg'))) {
-	                	alert('only png or jpeg files are accepted');
+	                } else if (!((files[0].type === 'image/png') || (files[0].type === 'image/jpeg') || (files[0].type === 'image/svg+xml'))) {
+	                	alert('Only PNG, JPG or SVG image files are accepted');
 	                } else if (files[0].size > (1024 * 200)) {
 	                	alert('Image size exceeds the allowable limit 200KB');
 	                } else {

--- a/src/main/webapp/resources/js/admin/directive/admin-directive.js
+++ b/src/main/webapp/resources/js/admin/directive/admin-directive.js
@@ -534,8 +534,8 @@
                     };
                     if (files.length <= 0) {
                 		alert('Your image not uploaded correctly.Please upload the image again');
-	                } else if (!((files[0].type === 'image/png') || (files[0].type === 'image/jpeg') || (files[0].type === 'image/svg+xml'))) {
-	                	alert('Only PNG, JPG or SVG image files are accepted');
+	                } else if (!((files[0].type === 'image/png') || (files[0].type === 'image/jpeg') || (files[0].type === 'image/gif') || (files[0].type === 'image/svg+xml'))) {
+	                	alert('Only PNG, JPG, GIF or SVG image files are accepted');
 	                } else if (files[0].size > (1024 * 200)) {
 	                	alert('Image size exceeds the allowable limit 200KB');
 	                } else {

--- a/website/content/en/docs/Event Setup/create-in-person-event.md
+++ b/website/content/en/docs/Event Setup/create-in-person-event.md
@@ -105,7 +105,7 @@ Alf.io currently supports the following formats:
 
 - PNG
 - JPG
-
+- SVG
 
 ## Seats and payment info
 

--- a/website/content/en/docs/Event Setup/create-in-person-event.md
+++ b/website/content/en/docs/Event Setup/create-in-person-event.md
@@ -105,6 +105,7 @@ Alf.io currently supports the following formats:
 
 - PNG
 - JPG
+- GIF
 - SVG
 
 ## Seats and payment info


### PR DESCRIPTION
Adds SVG support using rasterization rather than direct SVG inclusion since it has a lot of constraints on both different java middleware and end users terminals compatibility.
Adds GIF image support.

Closes #97 