### PR TITLE
Fix errorprone warnings

### DIFF
--- a/src/test/java/alfio/TestConfiguration.java
+++ b/src/test/java/alfio/TestConfiguration.java
@@ -37,6 +37,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.http.HttpClient;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -101,7 +102,7 @@ public class TestConfiguration {
         properties.put("alfio.version", "2.0-SNAPSHOT");
         properties.put("alfio.build-ts", ZonedDateTime.now(ZoneId.of("UTC")).minusDays(1).toString());
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        PrintWriter pw = new PrintWriter(out);
+        PrintWriter pw = new PrintWriter(out, true, Charset.defaultCharset());
         properties.list(pw);
         pw.flush();
         var configurer =  new PropertySourcesPlaceholderConfigurer();

--- a/src/test/java/alfio/controller/api/admin/PollAdminApiControllerTest.java
+++ b/src/test/java/alfio/controller/api/admin/PollAdminApiControllerTest.java
@@ -95,8 +95,8 @@ class PollAdminApiControllerTest {
         IntegrationTestUtil.ensureMinimalConfiguration(configurationRepository);
         List<TicketCategoryModification> categories = List.of(
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
-                new DateTimeModification(LocalDate.now().minusDays(1), LocalTime.now()),
-                new DateTimeModification(LocalDate.now().plusDays(1), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK).minusDays(1), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK).plusDays(1), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.ZERO, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty())
         );
         Pair<Event, String> eventAndUser = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);

--- a/src/test/java/alfio/controller/api/admin/PollAdminApiControllerTest.java
+++ b/src/test/java/alfio/controller/api/admin/PollAdminApiControllerTest.java
@@ -173,6 +173,7 @@ class PollAdminApiControllerTest {
 
         // allow tickets to vote
         var poll = pollRepository.findSingleForEvent(event.getId(), pollId).orElseThrow();
+        assertNotNull(poll);
         var participantForm = new PollAdminApiController.UpdateParticipantsForm(List.of(ticketId));
         var allowRes = controller.allowAttendees(event.getShortName(), pollId, participantForm);
         assertTrue(allowRes.getStatusCode().is2xxSuccessful());

--- a/src/test/java/alfio/controller/api/v2/user/PollApiControllerIntegrationTest.java
+++ b/src/test/java/alfio/controller/api/v2/user/PollApiControllerIntegrationTest.java
@@ -102,8 +102,8 @@ class PollApiControllerIntegrationTest {
         IntegrationTestUtil.ensureMinimalConfiguration(configurationRepository);
         List<TicketCategoryModification> categories = List.of(
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
-                new DateTimeModification(LocalDate.now().minusDays(1), LocalTime.now()),
-                new DateTimeModification(LocalDate.now().plusDays(1), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK).minusDays(1), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK).plusDays(1), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.ZERO, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty())
         );
         Pair<Event, String> eventAndUser = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);

--- a/src/test/java/alfio/controller/api/v2/user/ReservationFlowIntegrationTest.java
+++ b/src/test/java/alfio/controller/api/v2/user/ReservationFlowIntegrationTest.java
@@ -100,8 +100,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static alfio.manager.ExtensionManager.ExtensionEvent.*;
-import static alfio.test.util.IntegrationTestUtil.AVAILABLE_SEATS;
-import static alfio.test.util.IntegrationTestUtil.initEvent;
+import static alfio.test.util.IntegrationTestUtil.*;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 
@@ -234,12 +233,12 @@ public class ReservationFlowIntegrationTest extends BaseIntegrationTest {
         IntegrationTestUtil.ensureMinimalConfiguration(configurationRepository);
         List<TicketCategoryModification> categories = Arrays.asList(
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
-                new DateTimeModification(LocalDate.now().minusDays(1), LocalTime.now()),
-                new DateTimeModification(LocalDate.now().plusDays(1), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK).minusDays(1), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK).plusDays(1), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()),
             new TicketCategoryModification(null, "hidden", 2,
-                new DateTimeModification(LocalDate.now().minusDays(1), LocalTime.now()),
-                new DateTimeModification(LocalDate.now().plusDays(1), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK).minusDays(1), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK).plusDays(1), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.ONE, true, "", true, URL_CODE_HIDDEN, null, null, null, null, 0, null, null, AlfioMetadata.empty())
             );
         Pair<Event, String> eventAndUser = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
@@ -247,11 +246,11 @@ public class ReservationFlowIntegrationTest extends BaseIntegrationTest {
         event = eventAndUser.getKey();
         user = eventAndUser.getValue() + "_owner";
         //promo code at event level
-        eventManager.addPromoCode(PROMO_CODE, event.getId(), null, ZonedDateTime.now().minusDays(2), event.getEnd().plusDays(2), 10, PromoCodeDiscount.DiscountType.PERCENTAGE, null, 3, "description", "test@test.ch", PromoCodeDiscount.CodeType.DISCOUNT, null);
+        eventManager.addPromoCode(PROMO_CODE, event.getId(), null, ZonedDateTime.now(TEST_CLOCK).minusDays(2), event.getEnd().plusDays(2), 10, PromoCodeDiscount.DiscountType.PERCENTAGE, null, 3, "description", "test@test.ch", PromoCodeDiscount.CodeType.DISCOUNT, null);
 
         hiddenCategoryId = ticketCategoryRepository.findAllTicketCategories(event.getId()).stream().filter(TicketCategory::isAccessRestricted).collect(Collectors.toList()).get(0).getId();
 
-        eventManager.addPromoCode(HIDDEN_CODE, event.getId(), null, ZonedDateTime.now().minusDays(2), event.getEnd().plusDays(2), 0, PromoCodeDiscount.DiscountType.NONE, null, null, "hidden", "test@test.ch", PromoCodeDiscount.CodeType.ACCESS, hiddenCategoryId);
+        eventManager.addPromoCode(HIDDEN_CODE, event.getId(), null, ZonedDateTime.now(TEST_CLOCK).minusDays(2), event.getEnd().plusDays(2), 0, PromoCodeDiscount.DiscountType.NONE, null, null, "hidden", "test@test.ch", PromoCodeDiscount.CodeType.ACCESS, hiddenCategoryId);
 
 
         // add additional fields before and after, with one mandatory
@@ -272,7 +271,7 @@ public class ReservationFlowIntegrationTest extends BaseIntegrationTest {
         // add additional service
         var addServ = new EventModification.AdditionalService(null, new BigDecimal("40.00"), true, 0, 1, 1,
 
-            new DateTimeModification(ZonedDateTime.now().minusDays(2).toLocalDate(), ZonedDateTime.now().minusDays(2).toLocalTime()),
+            new DateTimeModification(ZonedDateTime.now(TEST_CLOCK).minusDays(2).toLocalDate(), ZonedDateTime.now(TEST_CLOCK).minusDays(2).toLocalTime()),
             new DateTimeModification(event.getEnd().plusDays(2).toLocalDate(), event.getEnd().plusDays(2).toLocalTime()),
             event.getVat(), AdditionalService.VatType.INHERITED,
             null,
@@ -519,7 +518,7 @@ public class ReservationFlowIntegrationTest extends BaseIntegrationTest {
 
         // dynamic promo codes can be applied only automatically
         {
-            eventManager.addPromoCode("DYNAMIC_CODE", event.getId(), null, ZonedDateTime.now().minusDays(2), event.getEnd().plusDays(2), 10, PromoCodeDiscount.DiscountType.PERCENTAGE, null, 3, "description", "test@test.ch", PromoCodeDiscount.CodeType.DYNAMIC, null);
+            eventManager.addPromoCode("DYNAMIC_CODE", event.getId(), null, ZonedDateTime.now(TEST_CLOCK).minusDays(2), event.getEnd().plusDays(2), 10, PromoCodeDiscount.DiscountType.PERCENTAGE, null, 3, "description", "test@test.ch", PromoCodeDiscount.CodeType.DYNAMIC, null);
             assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, eventApiV2Controller.validateCode(event.getShortName(), "DYNAMIC_CODE").getStatusCode());
 
             // try to enter it anyway

--- a/src/test/java/alfio/controller/api/v2/user/ReservationFlowIntegrationTest.java
+++ b/src/test/java/alfio/controller/api/v2/user/ReservationFlowIntegrationTest.java
@@ -174,10 +174,6 @@ public class ReservationFlowIntegrationTest extends BaseIntegrationTest {
     @Autowired
     private TicketReservationManager ticketReservationManager;
 
-    @Autowired
-    private WaitingQueueSubscriptionProcessor waitingQueueSubscriptionProcessor;
-    //
-
     //
     @Autowired
     private InfoApiController infoApiController;
@@ -199,9 +195,6 @@ public class ReservationFlowIntegrationTest extends BaseIntegrationTest {
     //
     @Autowired
     private NamedParameterJdbcTemplate jdbcTemplate;
-
-    @Autowired
-    private ExtensionRepository extensionRepository;
 
     @Autowired
     private ExtensionLogRepository extensionLogRepository;

--- a/src/test/java/alfio/manager/AdminReservationManagerIntegrationTest.java
+++ b/src/test/java/alfio/manager/AdminReservationManagerIntegrationTest.java
@@ -92,8 +92,8 @@ public class AdminReservationManagerIntegrationTest extends BaseIntegrationTest 
     public void testReserveFromExistingCategory() throws Exception {
         List<TicketCategoryModification> categories = Collections.singletonList(
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         performExistingCategoryTest(categories, false, Collections.singletonList(1), false, true, 0, AVAILABLE_SEATS);
     }
@@ -102,12 +102,12 @@ public class AdminReservationManagerIntegrationTest extends BaseIntegrationTest 
     public void testReserveFromExistingMultipleCategories() throws Exception {
         List<TicketCategoryModification> categories = Arrays.asList(
             new TicketCategoryModification(null, "default", 10,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()),
             new TicketCategoryModification(null, "2nd", 10,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         performExistingCategoryTest(categories, false, Arrays.asList(10,10), false, true, 0, AVAILABLE_SEATS);
     }
@@ -116,8 +116,8 @@ public class AdminReservationManagerIntegrationTest extends BaseIntegrationTest 
     public void testReserveFromExistingCategoryNotEnoughSeatsNotBounded() throws Exception {
         List<TicketCategoryModification> categories = Collections.singletonList(
             new TicketCategoryModification(null, "default", 1,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         performExistingCategoryTest(categories, false, Collections.singletonList(1), false, true, 0, AVAILABLE_SEATS);
     }
@@ -126,8 +126,8 @@ public class AdminReservationManagerIntegrationTest extends BaseIntegrationTest 
     public void testReserveExistingCategoryNotEnoughSeatsNotBoundedSoldOut() throws Exception {
         List<TicketCategoryModification> categories = Collections.singletonList(
             new TicketCategoryModification(null, "default", 1,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         performExistingCategoryTest(categories, false, Collections.singletonList(1), true, true, AVAILABLE_SEATS, AVAILABLE_SEATS+1);
     }
@@ -136,8 +136,8 @@ public class AdminReservationManagerIntegrationTest extends BaseIntegrationTest 
     public void testReserveFromExistingCategoryNotEnoughSeatsBounded() throws Exception {
         List<TicketCategoryModification> categories = Collections.singletonList(
             new TicketCategoryModification(null, "default", 1,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         performExistingCategoryTest(categories, true, Collections.singletonList(2), false, true, 0, AVAILABLE_SEATS);
     }
@@ -146,8 +146,8 @@ public class AdminReservationManagerIntegrationTest extends BaseIntegrationTest 
     public void testReserveFromExistingCategoryNotEnoughSeatsNoExtensionAllowedBounded() throws Exception {
         List<TicketCategoryModification> categories = Collections.singletonList(
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         performExistingCategoryTest(categories, true, Collections.singletonList(AVAILABLE_SEATS + 1), false, false, 0, AVAILABLE_SEATS);
     }
@@ -156,8 +156,8 @@ public class AdminReservationManagerIntegrationTest extends BaseIntegrationTest 
     public void testReserveFromExistingCategoryNotEnoughSeatsNoExtensionAllowedNotBounded() throws Exception {
         List<TicketCategoryModification> categories = Collections.singletonList(
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         performExistingCategoryTest(categories, true, Collections.singletonList(AVAILABLE_SEATS + 1), false, false, 0, AVAILABLE_SEATS);
     }
@@ -166,13 +166,13 @@ public class AdminReservationManagerIntegrationTest extends BaseIntegrationTest 
     public void testReserveFromNewCategory() throws Exception {
         List<TicketCategoryModification> categories = Collections.singletonList(
             new TicketCategoryModification(null, "default", 1,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Pair<Event, String> eventWithUsername = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = eventWithUsername.getKey();
         String username = eventWithUsername.getValue();
-        DateTimeModification expiration = DateTimeModification.fromZonedDateTime(ZonedDateTime.now().plusDays(1));
+        DateTimeModification expiration = DateTimeModification.fromZonedDateTime(ZonedDateTime.now(TEST_CLOCK).plusDays(1));
         CustomerData customerData = new CustomerData("Integration", "Test", "integration-test@test.ch", "Billing Address", "reference", "en", "1234", "CH", null);
         Category category = new Category(null, "name", new BigDecimal("100.00"));
         int attendees = AVAILABLE_SEATS;
@@ -182,7 +182,7 @@ public class AdminReservationManagerIntegrationTest extends BaseIntegrationTest 
         assertTrue(result.isSuccess());
         Pair<TicketReservation, List<Ticket>> data = result.getData();
         List<Ticket> tickets = data.getRight();
-        assertTrue(tickets.size() == attendees);
+        assertEquals(tickets.size(), attendees);
         assertNotNull(data.getLeft());
         int categoryId = tickets.get(0).getCategoryId();
         eventManager.getSingleEvent(event.getShortName(), username);
@@ -200,13 +200,13 @@ public class AdminReservationManagerIntegrationTest extends BaseIntegrationTest 
     public void testReserveMixed() throws Exception {
         List<TicketCategoryModification> categories = Collections.singletonList(
             new TicketCategoryModification(null, "default", 1,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Pair<Event, String> eventWithUsername = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = eventWithUsername.getKey();
         String username = eventWithUsername.getValue();
-        DateTimeModification expiration = DateTimeModification.fromZonedDateTime(ZonedDateTime.now().plusDays(1));
+        DateTimeModification expiration = DateTimeModification.fromZonedDateTime(ZonedDateTime.now(TEST_CLOCK).plusDays(1));
         CustomerData customerData = new CustomerData("Integration", "Test", "integration-test@test.ch", "Billing Address", "reference", "en", "1234", "CH", null);
 
         TicketCategory existingCategory = ticketCategoryRepository.findAllTicketCategories(event.getId()).get(0);
@@ -246,8 +246,8 @@ public class AdminReservationManagerIntegrationTest extends BaseIntegrationTest 
     public void testConfirmReservation() throws Exception {
         List<TicketCategoryModification> categories = Collections.singletonList(
             new TicketCategoryModification(null, "default", 1,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Triple<Event, String, TicketReservation> testResult = performExistingCategoryTest(categories, true, Collections.singletonList(2), false, true, 0, AVAILABLE_SEATS);
         assertNotNull(testResult);
@@ -265,8 +265,8 @@ public class AdminReservationManagerIntegrationTest extends BaseIntegrationTest 
     public void testConfirmReservationSendConfirmationEmail() {
         List<TicketCategoryModification> categories = Collections.singletonList(
             new TicketCategoryModification(null, "default", 1,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         int attendees = 2;
         Triple<Event, String, TicketReservation> testResult = performExistingCategoryTest(categories, true, Collections.singletonList(attendees), false, true, 0, AVAILABLE_SEATS);
@@ -288,7 +288,7 @@ public class AdminReservationManagerIntegrationTest extends BaseIntegrationTest 
         Pair<Event, String> eventWithUsername = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = eventWithUsername.getKey();
         String username = eventWithUsername.getValue();
-        DateTimeModification expiration = DateTimeModification.fromZonedDateTime(ZonedDateTime.now().plusDays(1));
+        DateTimeModification expiration = DateTimeModification.fromZonedDateTime(ZonedDateTime.now(TEST_CLOCK).plusDays(1));
         CustomerData customerData = new CustomerData("Integration", "Test", "integration-test@test.ch", "Billing Address", "reference", "en", "1234", "CH", null);
         Iterator<Integer> attendeesIterator = attendeesNr.iterator();
         List<TicketCategory> existingCategories = ticketCategoryRepository.findAllTicketCategories(event.getId());

--- a/src/test/java/alfio/manager/CheckInManagerIntegrationTest.java
+++ b/src/test/java/alfio/manager/CheckInManagerIntegrationTest.java
@@ -86,8 +86,8 @@ public class CheckInManagerIntegrationTest {
         IntegrationTestUtil.ensureMinimalConfiguration(configurationRepository);
         List<TicketCategoryModification> categories = List.of(
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
-                new DateTimeModification(LocalDate.now().minusDays(1), LocalTime.now()),
-                new DateTimeModification(LocalDate.now().plusDays(1), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK).minusDays(1), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK).plusDays(1), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false,
                 "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty())
         );
@@ -100,8 +100,8 @@ public class CheckInManagerIntegrationTest {
             1,
             100,
             2,
-            DateTimeModification.fromZonedDateTime(ZonedDateTime.now().minusDays(1)),
-            DateTimeModification.fromZonedDateTime(ZonedDateTime.now().plusDays(1)),
+            DateTimeModification.fromZonedDateTime(ZonedDateTime.now(TEST_CLOCK).minusDays(1)),
+            DateTimeModification.fromZonedDateTime(ZonedDateTime.now(TEST_CLOCK).plusDays(1)),
             BigDecimal.ZERO,
             AdditionalService.VatType.INHERITED,
             List.of(),

--- a/src/test/java/alfio/manager/ConfigurationManagerIntegrationTest.java
+++ b/src/test/java/alfio/manager/ConfigurationManagerIntegrationTest.java
@@ -57,6 +57,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static alfio.model.system.ConfigurationKeys.*;
+import static alfio.test.util.IntegrationTestUtil.TEST_CLOCK;
 import static org.junit.Assert.*;
 
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -103,15 +104,15 @@ public class ConfigurationManagerIntegrationTest extends BaseIntegrationTest {
 
         List<TicketCategoryModification> ticketsCategory = Collections.singletonList(
             new TicketCategoryModification(null, "default", 20,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 Collections.singletonMap("en", "desc"), BigDecimal.TEN, false, "", false, null, null,
                 null, null, null, 0, null, null, AlfioMetadata.empty()));
         EventModification em = new EventModification(null, Event.EventFormat.IN_PERSON, "url", "url", "url", null, null, null,
             "eventShortName", "displayName", organization.getId(),
             "muh location", "0.0", "0.0", ZoneId.systemDefault().getId(), desc,
-            new DateTimeModification(LocalDate.now(), LocalTime.now()),
-            new DateTimeModification(LocalDate.now(), LocalTime.now()),
+            new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+            new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
             BigDecimal.TEN, "CHF", 20, BigDecimal.ONE, true, null, ticketsCategory, false, new LocationDescriptor("","","",""), 7, null, null, AlfioMetadata.empty());
         eventManager.createEvent(em, USERNAME);
 

--- a/src/test/java/alfio/manager/ConfigurationManagerIntegrationTest.java
+++ b/src/test/java/alfio/manager/ConfigurationManagerIntegrationTest.java
@@ -138,7 +138,7 @@ public class ConfigurationManagerIntegrationTest extends BaseIntegrationTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testMissingConfigValue() {
-        var config = configurationManager.getFor(SMTP_PASSWORD, ConfigurationLevel.event(event)).getRequiredValue();
+        configurationManager.getFor(SMTP_PASSWORD, ConfigurationLevel.event(event)).getRequiredValue();
         fail("something wrong happened...");
     }
 

--- a/src/test/java/alfio/manager/DemoModeDataManagerIntegrationTest.java
+++ b/src/test/java/alfio/manager/DemoModeDataManagerIntegrationTest.java
@@ -47,8 +47,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
-import static alfio.test.util.IntegrationTestUtil.AVAILABLE_SEATS;
-import static alfio.test.util.IntegrationTestUtil.initEvent;
+import static alfio.test.util.IntegrationTestUtil.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -91,8 +90,8 @@ class DemoModeDataManagerIntegrationTest extends BaseIntegrationTest {
     void deleteExpiredUsersAndEvents() {
         List<TicketCategoryModification> categories = Collections.singletonList(
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 Map.of("en", "desc"), BigDecimal.TEN, false, "", false, null,
                 null, null, null, null, 0, null, null, AlfioMetadata.empty()));
 
@@ -110,8 +109,8 @@ class DemoModeDataManagerIntegrationTest extends BaseIntegrationTest {
     void doNotDeleteNewUsers() {
         List<TicketCategoryModification> categories = Collections.singletonList(
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 Map.of("en", "desc"), BigDecimal.TEN, false, "", false, null,
                 null, null, null, null, 0, null, null, AlfioMetadata.empty()));
 

--- a/src/test/java/alfio/manager/EventManagerCategoriesTest.java
+++ b/src/test/java/alfio/manager/EventManagerCategoriesTest.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static alfio.manager.testSupport.TicketCategoryGenerator.generateCategoryStream;
+import static alfio.test.util.IntegrationTestUtil.TEST_CLOCK;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -67,7 +68,7 @@ public class EventManagerCategoriesTest {
     void createTicketsForUnboundedCategory() {
         List<TicketCategory> categories = generateCategoryStream().limit(3).collect(Collectors.toList());
         when(ticketCategoryRepository.findAllTicketCategories(eq(eventId))).thenReturn(categories);
-        MapSqlParameterSource[] parameterSources = eventManager.prepareTicketsBulkInsertParameters(ZonedDateTime.now(), event, availableSeats, Ticket.TicketStatus.FREE);
+        MapSqlParameterSource[] parameterSources = eventManager.prepareTicketsBulkInsertParameters(ZonedDateTime.now(TEST_CLOCK), event, availableSeats, Ticket.TicketStatus.FREE);
         assertNotNull(parameterSources);
         assertEquals(availableSeats, parameterSources.length);
         assertTrue(Arrays.stream(parameterSources).allMatch(ps -> Ticket.TicketStatus.FREE.name().equals(ps.getValue("status"))));
@@ -78,7 +79,7 @@ public class EventManagerCategoriesTest {
     void createTicketsForUnboundedCategories() {
         List<TicketCategory> categories = generateCategoryStream().limit(6).collect(Collectors.toList());
         when(ticketCategoryRepository.findAllTicketCategories(eq(eventId))).thenReturn(categories);
-        MapSqlParameterSource[] parameterSources = eventManager.prepareTicketsBulkInsertParameters(ZonedDateTime.now(), event, availableSeats, Ticket.TicketStatus.FREE);
+        MapSqlParameterSource[] parameterSources = eventManager.prepareTicketsBulkInsertParameters(ZonedDateTime.now(TEST_CLOCK), event, availableSeats, Ticket.TicketStatus.FREE);
         assertNotNull(parameterSources);
         assertEquals(availableSeats, parameterSources.length);
         assertTrue(Arrays.stream(parameterSources).allMatch(ps -> Ticket.TicketStatus.FREE.name().equals(ps.getValue("status"))));
@@ -89,7 +90,7 @@ public class EventManagerCategoriesTest {
     void createTicketsOnlyForBounded() {
         List<TicketCategory> categories = generateCategoryStream().limit(2).collect(Collectors.toList());
         when(ticketCategoryRepository.findAllTicketCategories(eq(eventId))).thenReturn(categories);
-        MapSqlParameterSource[] parameterSources = eventManager.prepareTicketsBulkInsertParameters(ZonedDateTime.now(), event, availableSeats, Ticket.TicketStatus.FREE);
+        MapSqlParameterSource[] parameterSources = eventManager.prepareTicketsBulkInsertParameters(ZonedDateTime.now(TEST_CLOCK), event, availableSeats, Ticket.TicketStatus.FREE);
         assertNotNull(parameterSources);
         assertEquals(availableSeats, parameterSources.length);
         assertEquals(4L, Arrays.stream(parameterSources).filter(p -> p.getValue("categoryId") != null).count());

--- a/src/test/java/alfio/manager/EventManagerHandleTokenModificationTest.java
+++ b/src/test/java/alfio/manager/EventManagerHandleTokenModificationTest.java
@@ -23,8 +23,6 @@ import alfio.repository.TicketRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 
 import java.time.ZoneId;
 import java.util.Arrays;
@@ -96,7 +94,6 @@ class EventManagerHandleTokenModificationTest {
     @Test
     @DisplayName("handle the ticket addition")
     void handleTicketAddition() {
-        ArgumentCaptor<SqlParameterSource[]> captor = ArgumentCaptor.forClass(SqlParameterSource[].class);
         when(original.isAccessRestricted()).thenReturn(true);
         when(updated.isAccessRestricted()).thenReturn(true);
         eventManager.handleTokenModification(original, updated, 50);

--- a/src/test/java/alfio/manager/EventManagerIntegrationTest.java
+++ b/src/test/java/alfio/manager/EventManagerIntegrationTest.java
@@ -92,8 +92,8 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
     public void testUnboundedTicketsGeneration() {
         List<TicketCategoryModification> categories = Collections.singletonList(
                 new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
-                        new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                        new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                        new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                        new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                         DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Event event = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository).getKey();
         List<Ticket> tickets = ticketRepository.findFreeByEventId(event.getId());
@@ -110,8 +110,8 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
 
         List<TicketCategoryModification> categories = Collections.singletonList(
                 new TicketCategoryModification(null, "default", 10,
-                        new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                        new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                        new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                        new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                         DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Event event = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository).getKey();
         assertTrue(eventManager.eventExistsById(event.getId()));
@@ -126,8 +126,8 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
     public void testUnboundedEventGeneration() {
         List<TicketCategoryModification> categories = Collections.singletonList(
                 new TicketCategoryModification(null, "default", 10,
-                        new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                        new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                        new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                        new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                         DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Event event = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository).getKey();
         List<Ticket> tickets = ticketRepository.findFreeByEventId(event.getId());
@@ -144,16 +144,16 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
     public void testEventGenerationWithUnboundedCategory() {
         List<TicketCategoryModification> categories = Arrays.asList(
             new TicketCategoryModification(null, "default", 10,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()),
             new TicketCategoryModification(null, "default", 9,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()),
             new TicketCategoryModification(null, "default", 0,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
 
                 DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Event event = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository).getKey();
@@ -168,16 +168,16 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
     public void testEventGenerationWithOverflow() {
         List<TicketCategoryModification> categories = Arrays.asList(
                 new TicketCategoryModification(null, "default", 10,
-                        new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                        new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                        new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                        new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                         DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()),
                 new TicketCategoryModification(null, "default", 10,
-                        new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                        new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                        new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                        new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                         DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()),
                 new TicketCategoryModification(null, "default", 0,
-                        new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                        new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                        new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                        new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                         DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Event event = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository).getKey();
         List<Ticket> tickets = ticketRepository.findFreeByEventId(event.getId());
@@ -199,14 +199,14 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
     public void testAddUnboundedCategory() {
         List<TicketCategoryModification> categories = Collections.singletonList(
                 new TicketCategoryModification(null, "default", 10,
-                        new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                        new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                        new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                        new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                         DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = pair.getKey();
         TicketCategoryModification tcm = new TicketCategoryModification(null, "default", -1,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty());
         eventManager.insertCategory(event.getId(), tcm, pair.getValue());
         List<Ticket> tickets = ticketRepository.findFreeByEventId(event.getId());
@@ -221,23 +221,23 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
         //create the event with a single category which contains all the tickets
         List<TicketCategoryModification> categories = Collections.singletonList(
                 new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
-                        new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                        new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                        new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                        new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                         DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = pair.getKey();
         //shrink the original category to AVAILABLE_SEATS - 2, this would free two seats
         int categoryId = ticketCategoryRepository.findAllTicketCategories(event.getId()).get(0).getId();
         TicketCategoryModification shrink = new TicketCategoryModification(categoryId, "default", AVAILABLE_SEATS - 2,
-            new DateTimeModification(LocalDate.now(), LocalTime.now()),
-            new DateTimeModification(LocalDate.now(), LocalTime.now()),
+            new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+            new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
             DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null, AlfioMetadata.empty());
         eventManager.updateCategory(categoryId, event.getId(), shrink, pair.getRight());
 
         //now insert an unbounded ticket category
         TicketCategoryModification tcm = new TicketCategoryModification(null, "default", 10,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty());
         eventManager.insertCategory(event.getId(), tcm, pair.getValue());
 
@@ -254,8 +254,8 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
     public void testIncreaseEventSeatsWithAnUnboundedCategory() {
         List<TicketCategoryModification> categories = Collections.singletonList(
                 new TicketCategoryModification(null, "default", 10,
-                        new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                        new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                        new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                        new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                         DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = pair.getKey();
@@ -279,8 +279,8 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
     public void testIncreaseEventSeatsWithABoundedCategory() {
         List<TicketCategoryModification> categories = Collections.singletonList(
                 new TicketCategoryModification(null, "default", 10,
-                        new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                        new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                        new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                        new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                         DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = pair.getKey();
@@ -301,8 +301,8 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
     public void testDecreaseEventSeatsWithAnUnboundedCategory() {
         List<TicketCategoryModification> categories = Collections.singletonList(
                 new TicketCategoryModification(null, "default", 10,
-                        new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                        new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                        new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                        new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                         DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = pair.getKey();
@@ -322,8 +322,8 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
     public void testDecreaseEventSeatsWithABoundedCategory() {
         List<TicketCategoryModification> categories = Collections.singletonList(
                 new TicketCategoryModification(null, "default", 10,
-                        new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                        new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                        new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                        new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                         DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = pair.getKey();
@@ -343,14 +343,14 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
     public void testAddBoundedCategoryToUnboundedEvent() {
         List<TicketCategoryModification> categories = Collections.singletonList(
                 new TicketCategoryModification(null, "default", 0,
-                        new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                        new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                        new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                        new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                         DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = pair.getKey();
         TicketCategoryModification tcm = new TicketCategoryModification(null, "default", 10,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null, AlfioMetadata.empty());
         Result<Integer> result = eventManager.insertCategory(event, tcm, pair.getValue());
         assertTrue(result.isSuccess());
@@ -366,15 +366,15 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
     public void testUpdateBoundedCategory() {
         List<TicketCategoryModification> categories = Collections.singletonList(
                 new TicketCategoryModification(null, "default", 10,
-                        new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                        new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                        new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                        new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                         DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = pair.getKey();
         TicketCategory category = ticketCategoryRepository.findAllTicketCategories(event.getId()).get(0);
         TicketCategoryModification tcm = new TicketCategoryModification(category.getId(), "default", 20,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty());
         eventManager.updateCategory(category.getId(), event.getId(), tcm, pair.getValue());
         waitingQueueSubscriptionProcessor.distributeAvailableSeats(event);
@@ -389,8 +389,8 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
     public void testUpdateEventHeader() {
         List<TicketCategoryModification> categories = Collections.singletonList(
             new TicketCategoryModification(null, "default", 10,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = pair.getLeft();
@@ -448,8 +448,8 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
     public void testUpdateBoundedFlagToTrue() {
         List<TicketCategoryModification> categories = Collections.singletonList(
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = pair.getLeft();
@@ -470,8 +470,8 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
     public void testUpdateBoundedFlagToFalse() {
         List<TicketCategoryModification> categories = Collections.singletonList(
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = pair.getLeft();
@@ -496,8 +496,8 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
     public void testValidationBoundedFailedRestrictedFlag() {
         List<TicketCategoryModification> categories = Collections.singletonList(
             new TicketCategoryModification(null, "default", 10,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
 
                 DESCRIPTION, BigDecimal.TEN, true, "", true, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
@@ -520,8 +520,8 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
     public void testValidationBoundedFailedPendingTickets() {
         List<TicketCategoryModification> categories = Collections.singletonList(
             new TicketCategoryModification(null, "default", 10,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = pair.getLeft();
@@ -546,8 +546,8 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
     public void testIncreaseRestrictedCategory() {
         List<TicketCategoryModification> categories = Collections.singletonList(
             new TicketCategoryModification(null, "default", 10,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
 
                 DESCRIPTION, BigDecimal.TEN, true, "", true, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
@@ -571,8 +571,8 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
     public void testDecreaseRestrictedCategory() {
         List<TicketCategoryModification> categories = Collections.singletonList(
             new TicketCategoryModification(null, "default", 10,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
 
                 DESCRIPTION, BigDecimal.TEN, true, "", true, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
@@ -601,8 +601,8 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
 
         List<TicketCategoryModification> categories = Collections.singletonList(
             new TicketCategoryModification(null, "default", 4,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
 
                 DESCRIPTION, BigDecimal.TEN, true, "", true, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
@@ -673,8 +673,8 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
     public void testNewBoundedCategoryWithExistingBoundedAndPendingTicket() {
         List<TicketCategoryModification> categories = Collections.singletonList(
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = pair.getLeft();
@@ -703,8 +703,8 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
     public void deleteUnboundedTicketCategorySuccess() {
         List<TicketCategoryModification> cat = List.of(
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Pair<Event, String> pair = initEvent(cat, organizationRepository, userManager, eventManager, eventRepository);
         var event = pair.getLeft();
@@ -720,8 +720,8 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
     public void deleteUnboundedTicketCategoryFailure() {
         List<TicketCategoryModification> cat = Collections.singletonList(
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Pair<Event, String> pair = initEvent(cat, organizationRepository, userManager, eventManager, eventRepository);
         var event = pair.getLeft();
@@ -740,8 +740,8 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
     public void deleteBoundedTicketCategorySuccess() {
         List<TicketCategoryModification> cat = List.of(
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Pair<Event, String> pair = initEvent(cat, organizationRepository, userManager, eventManager, eventRepository);
         var event = pair.getLeft();
@@ -758,8 +758,8 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
     public void deleteBoundedTicketCategoryFailure() {
         List<TicketCategoryModification> cat = Collections.singletonList(
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Pair<Event, String> pair = initEvent(cat, organizationRepository, userManager, eventManager, eventRepository);
         var event = pair.getLeft();
@@ -778,12 +778,12 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
     public void rearrangeTicketCategories() {
         List<TicketCategoryModification> cat = List.of(
             new TicketCategoryModification(null, "first", AVAILABLE_SEATS,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 2, null, null, AlfioMetadata.empty()),
             new TicketCategoryModification(null, "second", AVAILABLE_SEATS,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 1, null, null, AlfioMetadata.empty()));
 
         Pair<Event, String> pair = initEvent(cat, organizationRepository, userManager, eventManager, eventRepository);
@@ -809,8 +809,8 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
     private Pair<Event, String> generateAndEditEvent(int newEventSize) {
         List<TicketCategoryModification> categories = Collections.singletonList(
             new TicketCategoryModification(null, "default", 10,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
 

--- a/src/test/java/alfio/manager/EventManagerIntegrationTest.java
+++ b/src/test/java/alfio/manager/EventManagerIntegrationTest.java
@@ -532,7 +532,7 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
 
         List<Integer> tickets = ticketRepository.selectTicketInCategoryForUpdate(event.getId(), category.getId(), 1, Collections.singletonList(Ticket.TicketStatus.FREE.name()));
         String reservationId = "12345678";
-        ticketReservationRepository.createNewReservation(reservationId, ZonedDateTime.now(), DateUtils.addDays(new Date(), 1), null, "en", event.getId(), event.getVat(), event.isVatIncluded(), event.getCurrency());
+        ticketReservationRepository.createNewReservation(reservationId, ZonedDateTime.now(TEST_CLOCK), DateUtils.addDays(new Date(), 1), null, "en", event.getId(), event.getVat(), event.isVatIncluded(), event.getCurrency());
         ticketRepository.reserveTickets(reservationId, tickets, category.getId(), "en", 100, "CHF");
         TicketCategoryModification tcm = new TicketCategoryModification(category.getId(), category.getName(), 10,
             DateTimeModification.fromZonedDateTime(category.getUtcInception()),
@@ -687,8 +687,8 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
         ticketReservationManager.createTicketReservation(event, Collections.singletonList(reservation), Collections.emptyList(),
             DateUtils.addDays(new Date(), 1), Optional.empty(), Locale.ENGLISH, false);
         TicketCategoryModification tcm = new TicketCategoryModification(null, "new", 1,
-            DateTimeModification.fromZonedDateTime(ZonedDateTime.now()),
-            DateTimeModification.fromZonedDateTime(ZonedDateTime.now().plusDays(1)),
+            DateTimeModification.fromZonedDateTime(ZonedDateTime.now(TEST_CLOCK)),
+            DateTimeModification.fromZonedDateTime(ZonedDateTime.now(TEST_CLOCK).plusDays(1)),
             Collections.emptyMap(), BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null, AlfioMetadata.empty());
         Result<Integer> insertResult = eventManager.insertCategory(event, tcm, username);
         assertTrue(insertResult.isSuccess());
@@ -730,7 +730,7 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
         assertEquals(1, categories.size());
         int categoryId = categories.get(0).getId();
         String reservationId = UUID.randomUUID().toString();
-        ticketReservationRepository.createNewReservation(reservationId, ZonedDateTime.now(), DateUtils.addDays(new Date(), 1), null, "en", event.getId(), event.getVat(), event.isVatIncluded(), event.getCurrency());
+        ticketReservationRepository.createNewReservation(reservationId, ZonedDateTime.now(TEST_CLOCK), DateUtils.addDays(new Date(), 1), null, "en", event.getId(), event.getVat(), event.isVatIncluded(), event.getCurrency());
         int result = ticketRepository.reserveTickets(reservationId, tickets, categoryId, "en", 0, "CHF");
         assertEquals(1, result);
         assertThrows(IllegalStateException.class, () -> eventManager.deleteCategory(event.getShortName(), categoryId, pair.getRight()));
@@ -768,7 +768,7 @@ public class EventManagerIntegrationTest extends BaseIntegrationTest {
         int categoryId = categories.get(0).getId();
         var tickets = ticketRepository.selectTicketInCategoryForUpdate(event.getId(), categoryId, 1, List.of(Ticket.TicketStatus.FREE.name()));
         String reservationId = UUID.randomUUID().toString();
-        ticketReservationRepository.createNewReservation(reservationId, ZonedDateTime.now(), DateUtils.addDays(new Date(), 1), null, "en", event.getId(), event.getVat(), event.isVatIncluded(), event.getCurrency());
+        ticketReservationRepository.createNewReservation(reservationId, ZonedDateTime.now(TEST_CLOCK), DateUtils.addDays(new Date(), 1), null, "en", event.getId(), event.getVat(), event.isVatIncluded(), event.getCurrency());
         int result = ticketRepository.reserveTickets(reservationId, tickets, categoryId, "en", 0, "CHF");
         assertEquals(1, result);
         assertThrows(IllegalStateException.class, () -> eventManager.deleteCategory(event.getShortName(), categoryId, pair.getRight()));

--- a/src/test/java/alfio/manager/EventManagerUnbindTicketsTest.java
+++ b/src/test/java/alfio/manager/EventManagerUnbindTicketsTest.java
@@ -28,7 +28,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -42,7 +45,6 @@ public class EventManagerUnbindTicketsTest {
     private final String username = "username";
     private final int categoryId = 1;
     private final int organizationId = 2;
-    private final Map<String, String> desc = Collections.singletonMap("en", "desc");
 
     private TicketCategoryRepository ticketCategoryRepository;
     private TicketCategoryDescriptionRepository ticketCategoryDescriptionRepository;

--- a/src/test/java/alfio/manager/GroupManagerIntegrationTest.java
+++ b/src/test/java/alfio/manager/GroupManagerIntegrationTest.java
@@ -96,8 +96,8 @@ public class GroupManagerIntegrationTest extends BaseIntegrationTest {
 
         List<TicketCategoryModification> categories = Collections.singletonList(
             new TicketCategoryModification(null, "default", 10,
-                new DateTimeModification(LocalDate.now().plusDays(1), LocalTime.now()),
-                new DateTimeModification(LocalDate.now().plusDays(2), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK).plusDays(1), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK).plusDays(2), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = pair.getKey();
@@ -144,8 +144,8 @@ public class GroupManagerIntegrationTest extends BaseIntegrationTest {
     public void testDuplicates() {
         List<TicketCategoryModification> categories = Collections.singletonList(
             new TicketCategoryModification(null, "default", 10,
-                new DateTimeModification(LocalDate.now().plusDays(1), LocalTime.now()),
-                new DateTimeModification(LocalDate.now().plusDays(2), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK).plusDays(1), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK).plusDays(2), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = pair.getKey();

--- a/src/test/java/alfio/manager/TicketReservationManagerConcurrentTest.java
+++ b/src/test/java/alfio/manager/TicketReservationManagerConcurrentTest.java
@@ -56,8 +56,7 @@ import java.util.concurrent.Executors;
 import java.util.stream.Stream;
 
 import static alfio.manager.TicketReservationManagerIntegrationTest.DESCRIPTION;
-import static alfio.test.util.IntegrationTestUtil.AVAILABLE_SEATS;
-import static alfio.test.util.IntegrationTestUtil.initEvent;
+import static alfio.test.util.IntegrationTestUtil.*;
 import static org.junit.Assert.*;
 
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -102,8 +101,8 @@ public class TicketReservationManagerConcurrentTest {
         transactionTemplate.execute(tx -> {
             List<TicketCategoryModification> categories = Collections.singletonList(
                 new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
-                    new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                    new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                    new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                    new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                     DESCRIPTION, BigDecimal.TEN, true, "", true, null,
                     null, null, null, null, null, TicketCategory.TicketCheckInStrategy.ONCE_PER_EVENT, null, AlfioMetadata.empty()));
 
@@ -114,7 +113,7 @@ public class TicketReservationManagerConcurrentTest {
             firstCategoryId = ticketCategoryRepository.findAllTicketCategories(eventId).get(0).getId();
 
             specialPriceTokenGenerator.generatePendingCodesForCategory(firstCategoryId);
-            promoCodeDiscountRepository.addPromoCode(ACCESS_CODE, eventId, event.getOrganizationId(), ZonedDateTime.now(), ZonedDateTime.now().plusDays(1), 0, PromoCodeDiscount.DiscountType.NONE, null, 100, null, null, PromoCodeDiscount.CodeType.ACCESS, firstCategoryId);
+            promoCodeDiscountRepository.addPromoCode(ACCESS_CODE, eventId, event.getOrganizationId(), ZonedDateTime.now(TEST_CLOCK), ZonedDateTime.now(TEST_CLOCK).plusDays(1), 0, PromoCodeDiscount.DiscountType.NONE, null, 100, null, null, PromoCodeDiscount.CodeType.ACCESS, firstCategoryId);
             promoCodeDiscount = promoCodeDiscountRepository.findPublicPromoCodeInEventOrOrganization(eventId, ACCESS_CODE).orElseThrow();
             return null;
         });

--- a/src/test/java/alfio/manager/TicketReservationManagerIntegrationTest.java
+++ b/src/test/java/alfio/manager/TicketReservationManagerIntegrationTest.java
@@ -58,8 +58,7 @@ import java.util.stream.Collectors;
 
 import static alfio.model.system.ConfigurationKeys.AUTOMATIC_REMOVAL_EXPIRED_OFFLINE_PAYMENT;
 import static alfio.model.system.ConfigurationKeys.DEFERRED_BANK_TRANSFER_ENABLED;
-import static alfio.test.util.IntegrationTestUtil.AVAILABLE_SEATS;
-import static alfio.test.util.IntegrationTestUtil.initEvent;
+import static alfio.test.util.IntegrationTestUtil.*;
 import static org.junit.Assert.*;
 
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -114,8 +113,8 @@ public class TicketReservationManagerIntegrationTest extends BaseIntegrationTest
     public void testPriceIsOverridden() {
         List<TicketCategoryModification> categories = Collections.singletonList(
                 new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
-                        new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                        new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                        new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                        new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                         DESCRIPTION, BigDecimal.TEN, false, "", false, null,
                     null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Event event = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository).getKey();
@@ -138,12 +137,12 @@ public class TicketReservationManagerIntegrationTest extends BaseIntegrationTest
     public void testTicketSelection() {
         List<TicketCategoryModification> categories = List.of(
                 new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
-                        new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                        new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                        new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                        new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                         DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()),
                 new TicketCategoryModification(null, "default", 10,
-                        new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                        new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                        new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                        new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                         DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Pair<Event, String> eventAndUsername = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = eventAndUsername.getKey();
@@ -204,7 +203,7 @@ public class TicketReservationManagerIntegrationTest extends BaseIntegrationTest
 
         var soldStatisticsList = ticketReservationRepository.getSoldStatistic(event.getId(), from, to, "day");
         assertEquals(3, soldStatisticsList.size());
-        assertEquals(LocalDate.now().toString(), soldStatisticsList.get(1).getDate());
+        assertEquals(LocalDate.now(TEST_CLOCK).toString(), soldStatisticsList.get(1).getDate());
         assertEquals(19L, soldStatisticsList.get(1).getCount()); // -> 19 tickets reserved
         assertEquals(19L, soldStatisticsList.stream().mapToLong(TicketsByDateStatistic::getCount).sum());
 
@@ -243,8 +242,8 @@ public class TicketReservationManagerIntegrationTest extends BaseIntegrationTest
 
         List<TicketCategoryModification> categories = List.of(
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Pair<Event, String> eventAndUsername = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = eventAndUsername.getKey();
@@ -299,8 +298,8 @@ public class TicketReservationManagerIntegrationTest extends BaseIntegrationTest
     public void testTicketWithDiscount() {
         List<TicketCategoryModification> categories = Collections.singletonList(
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Event event = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository).getKey();
 
@@ -378,13 +377,13 @@ public class TicketReservationManagerIntegrationTest extends BaseIntegrationTest
     public void testAdditionalServiceWithDiscount() {
         List<TicketCategoryModification> categories = Collections.singletonList(
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Event event = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository).getKey();
 
-        var firstAsKey = additionalServiceRepository.insert(event.getId(), 1000, true, 1, 100, 1, ZonedDateTime.now().minusHours(1), ZonedDateTime.now().plusHours(1), BigDecimal.TEN, AdditionalService.VatType.INHERITED, AdditionalService.AdditionalServiceType.SUPPLEMENT, AdditionalService.SupplementPolicy.OPTIONAL_UNLIMITED_AMOUNT);
-        var secondAsKey = additionalServiceRepository.insert(event.getId(), 500, true, 2, 100, 1, ZonedDateTime.now().minusHours(1), ZonedDateTime.now().plusHours(1), BigDecimal.TEN, AdditionalService.VatType.INHERITED, AdditionalService.AdditionalServiceType.DONATION, AdditionalService.SupplementPolicy.OPTIONAL_UNLIMITED_AMOUNT);
+        var firstAsKey = additionalServiceRepository.insert(event.getId(), 1000, true, 1, 100, 1, ZonedDateTime.now(TEST_CLOCK).minusHours(1), ZonedDateTime.now(TEST_CLOCK).plusHours(1), BigDecimal.TEN, AdditionalService.VatType.INHERITED, AdditionalService.AdditionalServiceType.SUPPLEMENT, AdditionalService.SupplementPolicy.OPTIONAL_UNLIMITED_AMOUNT);
+        var secondAsKey = additionalServiceRepository.insert(event.getId(), 500, true, 2, 100, 1, ZonedDateTime.now(TEST_CLOCK).minusHours(1), ZonedDateTime.now(TEST_CLOCK).plusHours(1), BigDecimal.TEN, AdditionalService.VatType.INHERITED, AdditionalService.AdditionalServiceType.DONATION, AdditionalService.SupplementPolicy.OPTIONAL_UNLIMITED_AMOUNT);
 
         TicketCategory unbounded = ticketCategoryRepository.findAllTicketCategories(event.getId()).stream().filter(t -> !t.isBounded()).findFirst().orElseThrow(IllegalStateException::new);
 
@@ -427,8 +426,8 @@ public class TicketReservationManagerIntegrationTest extends BaseIntegrationTest
     private Triple<Event, TicketCategory, String> testTicketsWithAccessCode() {
         List<TicketCategoryModification> categories = Collections.singletonList(
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, true, "", true, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Event event = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository).getKey();
 
@@ -501,12 +500,12 @@ public class TicketReservationManagerIntegrationTest extends BaseIntegrationTest
     public void testWithAdditionalServices() {
         List<TicketCategoryModification> categories = Collections.singletonList(
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
 
         List<EventModification.AdditionalService> additionalServices = Collections.singletonList(new EventModification.AdditionalService(null, BigDecimal.TEN, true, 1, 100, 5,
-            DateTimeModification.fromZonedDateTime(ZonedDateTime.now().minusDays(1L)), DateTimeModification.fromZonedDateTime(ZonedDateTime.now().plusDays(1L)),
+            DateTimeModification.fromZonedDateTime(ZonedDateTime.now(TEST_CLOCK).minusDays(1L)), DateTimeModification.fromZonedDateTime(ZonedDateTime.now(TEST_CLOCK).plusDays(1L)),
             BigDecimal.TEN, AdditionalService.VatType.INHERITED, Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), AdditionalService.AdditionalServiceType.SUPPLEMENT, AdditionalService.SupplementPolicy.OPTIONAL_UNLIMITED_AMOUNT));
         Event event = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository, additionalServices).getKey();
 
@@ -549,8 +548,8 @@ public class TicketReservationManagerIntegrationTest extends BaseIntegrationTest
     public void testTicketSelectionNotEnoughTicketsAvailable() {
         List<TicketCategoryModification> categories = Collections.singletonList(
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Event event = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository).getKey();
 
@@ -568,8 +567,8 @@ public class TicketReservationManagerIntegrationTest extends BaseIntegrationTest
     public void testDeletePendingPaymentUnboundedCategory() {
         List<TicketCategoryModification> categories = Collections.singletonList(
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Event event = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository).getKey();
 
@@ -609,8 +608,8 @@ public class TicketReservationManagerIntegrationTest extends BaseIntegrationTest
     public void testCleanupExpiredReservations() {
         List<TicketCategoryModification> categories = List.of(
             new TicketCategoryModification(null, "default", 10,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Pair<Event, String> eventAndUsername = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = eventAndUsername.getKey();
@@ -647,8 +646,8 @@ public class TicketReservationManagerIntegrationTest extends BaseIntegrationTest
     public void testCleanupOfflineExpiredReservations() {
         List<TicketCategoryModification> categories = List.of(
             new TicketCategoryModification(null, "default", 10,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Pair<Event, String> eventAndUsername = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = eventAndUsername.getKey();

--- a/src/test/java/alfio/manager/TicketReservationManagerTest.java
+++ b/src/test/java/alfio/manager/TicketReservationManagerTest.java
@@ -74,6 +74,7 @@ import static alfio.manager.TicketReservationManager.buildCompleteBillingAddress
 import static alfio.model.Audit.EventType.PAYMENT_CONFIRMED;
 import static alfio.model.TicketReservation.TicketReservationStatus.*;
 import static alfio.model.system.ConfigurationKeys.*;
+import static alfio.test.util.IntegrationTestUtil.TEST_CLOCK;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
@@ -87,7 +88,6 @@ class TicketReservationManagerTest {
     private static final int EVENT_ID = 42;
     private static final int TICKET_CATEGORY_ID = 24;
     private static final String SPECIAL_PRICE_CODE = "SPECIAL-PRICE";
-    private static final String SPECIAL_PRICE_SESSION_ID = "session-id";
     private static final int SPECIAL_PRICE_ID = -42;
     private static final String USER_LANGUAGE = "it";
     private static final int TICKET_ID = 2048756;
@@ -256,7 +256,7 @@ class TicketReservationManagerTest {
         when(ticketCategory.getId()).thenReturn(TICKET_CATEGORY_ID);
         when(organizationRepository.getById(eq(ORGANIZATION_ID))).thenReturn(organization);
         when(event.getZoneId()).thenReturn(ZoneId.systemDefault());
-        when(event.getBegin()).thenReturn(ZonedDateTime.now().plusDays(1));
+        when(event.getBegin()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(1));
         when(event.getVatStatus()).thenReturn(PriceContainer.VatStatus.NOT_INCLUDED);
         when(userRepository.findIdByUserName(anyString())).thenReturn(Optional.empty());
         when(extensionManager.handleInvoiceGeneration(any(), any(), any())).thenReturn(Optional.empty());
@@ -334,7 +334,7 @@ class TicketReservationManagerTest {
         PartialTicketTextGenerator ownerChangeTextBuilder = mock(PartialTicketTextGenerator.class);
         when(ownerChangeTextBuilder.generate(eq(modified))).thenReturn(RenderedTemplate.multipart("Hello, world", "<p>Hello, world</p>"));
         when(original.getUserLanguage()).thenReturn(USER_LANGUAGE);
-        when(event.getBegin()).thenReturn(ZonedDateTime.now().minusSeconds(1));
+        when(event.getBegin()).thenReturn(ZonedDateTime.now(TEST_CLOCK).minusSeconds(1));
         trm.updateTicketOwner(original, Locale.ENGLISH, event, form, (a) -> null, ownerChangeTextBuilder, Optional.empty());
         verify(messageSource, times(1)).getMessage(eq("ticket-has-changed-owner-subject"), any(), eq(Locale.ITALIAN));
         verify(notificationManager, times(1)).sendSimpleEmail(eq(event), eq(RESERVATION_ID), eq(originalEmail), anyString(), any(TemplateGenerator.class));
@@ -418,7 +418,7 @@ class TicketReservationManagerTest {
 
         when(eventRepository.findByReservationId("abcd")).thenReturn(event);
         when(event.getZoneId()).thenReturn(ZoneId.systemDefault());
-        when(event.getBegin()).thenReturn(ZonedDateTime.now().minusDays(1));
+        when(event.getBegin()).thenReturn(ZonedDateTime.now(TEST_CLOCK).minusDays(1));
         when(eventRepository.findAll()).thenReturn(singletonList(event));
         when(ticketRepository.findAllReservationsConfirmedButNotAssignedForUpdate(anyInt())).thenReturn(singleton("abcd"));
         trm.sendReminderForTicketAssignment();
@@ -494,16 +494,16 @@ class TicketReservationManagerTest {
     @Test
     void returnTheExpiredDateAsConfigured() {
         initOfflinePaymentTest();
-        when(event.getBegin()).thenReturn(ZonedDateTime.now().plusDays(3));
+        when(event.getBegin()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(3));
         ZonedDateTime offlinePaymentDeadline = BankTransferManager.getOfflinePaymentDeadline(new PaymentContext(event), configurationManager);
-        ZonedDateTime expectedDate = ZonedDateTime.now().plusDays(2L).truncatedTo(ChronoUnit.HALF_DAYS).with(WorkingDaysAdjusters.defaultWorkingDays());
+        ZonedDateTime expectedDate = ZonedDateTime.now(TEST_CLOCK).plusDays(2L).truncatedTo(ChronoUnit.HALF_DAYS).with(WorkingDaysAdjusters.defaultWorkingDays());
         assertEquals(expectedDate, offlinePaymentDeadline);
     }
 
     @Test
     void returnTheConfiguredWaitingTime() {
         initOfflinePaymentTest();
-        when(event.getBegin()).thenReturn(ZonedDateTime.now().plusDays(3));
+        when(event.getBegin()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(3));
         OptionalInt offlinePaymentWaitingPeriod = BankTransferManager.getOfflinePaymentWaitingPeriod(new PaymentContext(event), configurationManager);
         assertTrue(offlinePaymentWaitingPeriod.isPresent());
         assertEquals(2, offlinePaymentWaitingPeriod.getAsInt());
@@ -512,19 +512,19 @@ class TicketReservationManagerTest {
     @Test
     void considerEventBeginDateWhileCalculatingExpDate() {
         initOfflinePaymentTest();
-        when(event.getBegin()).thenReturn(ZonedDateTime.now().plusDays(1));
+        when(event.getBegin()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(1));
         ZonedDateTime offlinePaymentDeadline = BankTransferManager.getOfflinePaymentDeadline(new PaymentContext(event), configurationManager);
 
-        long days = ChronoUnit.DAYS.between(LocalDate.now(), offlinePaymentDeadline.toLocalDate());
-        assertTrue("value must be 3 on Friday", LocalDate.now().getDayOfWeek() != DayOfWeek.FRIDAY || days == 3);
-        assertTrue("value must be 2 on Saturday",LocalDate.now().getDayOfWeek() != DayOfWeek.SATURDAY || days == 2);
-        assertTrue("value must be 1 on week days",!EnumSet.of(DayOfWeek.MONDAY, DayOfWeek.TUESDAY, DayOfWeek.WEDNESDAY, DayOfWeek.THURSDAY).contains(LocalDate.now().getDayOfWeek()) || days == 1);
+        long days = ChronoUnit.DAYS.between(LocalDate.now(TEST_CLOCK), offlinePaymentDeadline.toLocalDate());
+        assertTrue("value must be 3 on Friday", LocalDate.now(TEST_CLOCK).getDayOfWeek() != DayOfWeek.FRIDAY || days == 3);
+        assertTrue("value must be 2 on Saturday",LocalDate.now(TEST_CLOCK).getDayOfWeek() != DayOfWeek.SATURDAY || days == 2);
+        assertTrue("value must be 1 on week days",!EnumSet.of(DayOfWeek.MONDAY, DayOfWeek.TUESDAY, DayOfWeek.WEDNESDAY, DayOfWeek.THURSDAY).contains(LocalDate.now(TEST_CLOCK).getDayOfWeek()) || days == 1);
     }
 
     @Test
     void returnConfiguredWaitingTimeConsideringEventStart() {
         initOfflinePaymentTest();
-        when(event.getBegin()).thenReturn(ZonedDateTime.now().plusDays(1));
+        when(event.getBegin()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(1));
         OptionalInt offlinePaymentWaitingPeriod = BankTransferManager.getOfflinePaymentWaitingPeriod(new PaymentContext(event), configurationManager);
         assertTrue(offlinePaymentWaitingPeriod.isPresent());
         assertEquals(1, offlinePaymentWaitingPeriod.getAsInt());
@@ -533,16 +533,16 @@ class TicketReservationManagerTest {
     @Test
     void neverReturnADateInThePast() {
         initOfflinePaymentTest();
-        when(event.getBegin()).thenReturn(ZonedDateTime.now());
+        when(event.getBegin()).thenReturn(ZonedDateTime.now(TEST_CLOCK));
         ZonedDateTime offlinePaymentDeadline = BankTransferManager.getOfflinePaymentDeadline(new PaymentContext(event), configurationManager);
-        assertTrue(offlinePaymentDeadline.isAfter(ZonedDateTime.now()));
+        assertTrue(offlinePaymentDeadline.isAfter(ZonedDateTime.now(TEST_CLOCK)));
     }
 
 //    FIXME implement test
 //    @Test
 //    void throwExceptionAfterEventStart() {
 //        initOfflinePaymentTest();
-//        when(event.getBegin()).thenReturn(ZonedDateTime.now().minusDays(1));
+//        when(event.getBegin()).thenReturn(ZonedDateTime.now(TEST_CLOCK).minusDays(1));
 //        assertThrows(BankTransactionManager.OfflinePaymentException.class, () -> BankTransactionManager.getOfflinePaymentDeadline(event, configurationManager));
 //    }
 
@@ -748,7 +748,7 @@ class TicketReservationManagerTest {
 
     private void initConfirmReservation() {
         when(event.getZoneId()).thenReturn(ZoneId.systemDefault());
-        when(event.getBegin()).thenReturn(ZonedDateTime.now().plusDays(5));
+        when(event.getBegin()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(5));
     }
 
     @Test
@@ -807,7 +807,7 @@ class TicketReservationManagerTest {
     }
 
     private void mockBillingDocument() {
-        BillingDocument document = new BillingDocument(42, 42, "", "42", BillingDocument.Type.INVOICE, "{}", ZonedDateTime.now(), BillingDocument.Status.VALID, "42");
+        BillingDocument document = new BillingDocument(42, 42, "", "42", BillingDocument.Type.INVOICE, "{}", ZonedDateTime.now(TEST_CLOCK), BillingDocument.Status.VALID, "42");
         when(billingDocumentRepository.findLatestByReservationId(eq(RESERVATION_ID))).thenReturn(Optional.of(document));
     }
 
@@ -959,7 +959,7 @@ class TicketReservationManagerTest {
     void confirmOfflinePayments() {
         initConfirmReservation();
         TicketReservation reservation = mock(TicketReservation.class);
-        when(reservation.getConfirmationTimestamp()).thenReturn(ZonedDateTime.now());
+        when(reservation.getConfirmationTimestamp()).thenReturn(ZonedDateTime.now(TEST_CLOCK));
         when(reservation.getId()).thenReturn(RESERVATION_ID);
         when(reservation.getPaymentMethod()).thenReturn(PaymentProxy.OFFLINE);
         when(reservation.getStatus()).thenReturn(OFFLINE_PAYMENT);
@@ -991,7 +991,7 @@ class TicketReservationManagerTest {
         when(billingDocumentRepository.insert(anyInt(), anyString(), anyString(), any(BillingDocument.Type.class), anyString(), any(ZonedDateTime.class), anyInt()))
             .thenReturn(new AffectedRowCountAndKey<>(1, 1L));
         when(billingDocumentRepository.findByIdAndReservationId(anyLong(), anyString()))
-            .thenReturn(Optional.of(new BillingDocument(1, 1, "1", "42", BillingDocument.Type.INVOICE, "{}", ZonedDateTime.now(),
+            .thenReturn(Optional.of(new BillingDocument(1, 1, "1", "42", BillingDocument.Type.INVOICE, "{}", ZonedDateTime.now(TEST_CLOCK),
                 BillingDocument.Status.VALID, null)));
         when(json.fromJsonString(anyString(), eq(OrderSummary.class))).thenReturn(mock(OrderSummary.class));
         when(json.asJsonString(any())).thenReturn("{}");
@@ -1021,8 +1021,8 @@ class TicketReservationManagerTest {
             event.getLocation(),
             event.getLatitude(),
             event.getLongitude(),
-            Optional.ofNullable(event.getBegin()).orElse(ZonedDateTime.now().plusDays(2).minusHours(2)),
-            Optional.ofNullable(event.getEnd()).orElse(ZonedDateTime.now().plusDays(2)),
+            Optional.ofNullable(event.getBegin()).orElse(ZonedDateTime.now(TEST_CLOCK).plusDays(2).minusHours(2)),
+            Optional.ofNullable(event.getEnd()).orElse(ZonedDateTime.now(TEST_CLOCK).plusDays(2)),
             "UTC",
             event.getWebsiteUrl(),
             event.getExternalUrl(),
@@ -1125,7 +1125,7 @@ class TicketReservationManagerTest {
 
         when(eventRepository.findByReservationId(RESERVATION_ID)).thenReturn(event);
         when(event.getZoneId()).thenReturn(ZoneId.systemDefault());
-        when(event.getBegin()).thenReturn(ZonedDateTime.now().plusDays(1));
+        when(event.getBegin()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(1));
         when(eventRepository.findAll()).thenReturn(singletonList(event));
         when(ticketRepository.findAllReservationsConfirmedButNotAssignedForUpdate(anyInt())).thenReturn(singleton(RESERVATION_ID));
         when(ticketRepository.flagTicketAsReminderSent(ticketId)).thenReturn(1);
@@ -1147,7 +1147,7 @@ class TicketReservationManagerTest {
         when(configurationManager.getFor(eq(OPTIONAL_DATA_REMINDER_ENABLED), any())).thenReturn(
             new MaybeConfiguration(OPTIONAL_DATA_REMINDER_ENABLED)
         );
-        when(ticketReservation.latestNotificationTimestamp(any())).thenReturn(Optional.of(ZonedDateTime.now().minusDays(10)));
+        when(ticketReservation.latestNotificationTimestamp(any())).thenReturn(Optional.of(ZonedDateTime.now(TEST_CLOCK).minusDays(10)));
         String RESERVATION_ID = "abcd";
         when(ticketReservation.getId()).thenReturn(RESERVATION_ID);
         when(ticket.getTicketsReservationId()).thenReturn(RESERVATION_ID);
@@ -1158,7 +1158,7 @@ class TicketReservationManagerTest {
 
         when(eventRepository.findByReservationId(RESERVATION_ID)).thenReturn(event);
         when(event.getZoneId()).thenReturn(ZoneId.systemDefault());
-        when(event.getBegin()).thenReturn(ZonedDateTime.now().plusDays(1));
+        when(event.getBegin()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(1));
         when(eventRepository.findAll()).thenReturn(singletonList(event));
         when(ticketRepository.flagTicketAsReminderSent(ticketId)).thenReturn(1);
         trm.sendReminderForOptionalData();
@@ -1185,7 +1185,7 @@ class TicketReservationManagerTest {
 
         when(eventRepository.findByReservationId(RESERVATION_ID)).thenReturn(event);
         when(event.getZoneId()).thenReturn(ZoneId.systemDefault());
-        when(event.getBegin()).thenReturn(ZonedDateTime.now().plusDays(1));
+        when(event.getBegin()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(1));
         when(eventRepository.findAll()).thenReturn(singletonList(event));
         when(ticketRepository.flagTicketAsReminderSent(ticketId)).thenReturn(0);
         trm.sendReminderForOptionalData();

--- a/src/test/java/alfio/manager/TicketReservationManagerTest.java
+++ b/src/test/java/alfio/manager/TicketReservationManagerTest.java
@@ -255,7 +255,7 @@ class TicketReservationManagerTest {
         when(ticket.getSrcPriceCts()).thenReturn(10);
         when(ticketCategory.getId()).thenReturn(TICKET_CATEGORY_ID);
         when(organizationRepository.getById(eq(ORGANIZATION_ID))).thenReturn(organization);
-        when(event.getZoneId()).thenReturn(ZoneId.systemDefault());
+        when(event.getZoneId()).thenReturn(TEST_CLOCK.getZone());
         when(event.getBegin()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(1));
         when(event.getVatStatus()).thenReturn(PriceContainer.VatStatus.NOT_INCLUDED);
         when(userRepository.findIdByUserName(anyString())).thenReturn(Optional.empty());
@@ -417,7 +417,7 @@ class TicketReservationManagerTest {
         when(ticketReservationRepository.findReservationById(eq("abcd"))).thenReturn(reservation);
 
         when(eventRepository.findByReservationId("abcd")).thenReturn(event);
-        when(event.getZoneId()).thenReturn(ZoneId.systemDefault());
+        when(event.getZoneId()).thenReturn(TEST_CLOCK.getZone());
         when(event.getBegin()).thenReturn(ZonedDateTime.now(TEST_CLOCK).minusDays(1));
         when(eventRepository.findAll()).thenReturn(singletonList(event));
         when(ticketRepository.findAllReservationsConfirmedButNotAssignedForUpdate(anyInt())).thenReturn(singleton("abcd"));
@@ -488,7 +488,7 @@ class TicketReservationManagerTest {
     private void initOfflinePaymentTest() {
         when(configurationManager.getFor(eq(OFFLINE_PAYMENT_DAYS), any()))
             .thenReturn(new MaybeConfiguration(OFFLINE_PAYMENT_DAYS, new ConfigurationKeyValuePathLevel(OFFLINE_PAYMENT_DAYS.getValue(), "2", null)));
-        when(event.getZoneId()).thenReturn(ZoneId.systemDefault());
+        when(event.getZoneId()).thenReturn(TEST_CLOCK.getZone());
     }
 
     @Test
@@ -747,7 +747,7 @@ class TicketReservationManagerTest {
     //performPayment reservation
 
     private void initConfirmReservation() {
-        when(event.getZoneId()).thenReturn(ZoneId.systemDefault());
+        when(event.getZoneId()).thenReturn(TEST_CLOCK.getZone());
         when(event.getBegin()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(5));
     }
 
@@ -1124,7 +1124,7 @@ class TicketReservationManagerTest {
         when(ticketReservationRepository.findOptionalReservationById(eq(RESERVATION_ID))).thenReturn(Optional.of(ticketReservation));
 
         when(eventRepository.findByReservationId(RESERVATION_ID)).thenReturn(event);
-        when(event.getZoneId()).thenReturn(ZoneId.systemDefault());
+        when(event.getZoneId()).thenReturn(TEST_CLOCK.getZone());
         when(event.getBegin()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(1));
         when(eventRepository.findAll()).thenReturn(singletonList(event));
         when(ticketRepository.findAllReservationsConfirmedButNotAssignedForUpdate(anyInt())).thenReturn(singleton(RESERVATION_ID));
@@ -1157,7 +1157,7 @@ class TicketReservationManagerTest {
         when(ticketReservationRepository.findReservationByIdForUpdate(eq(RESERVATION_ID))).thenReturn(ticketReservation);
 
         when(eventRepository.findByReservationId(RESERVATION_ID)).thenReturn(event);
-        when(event.getZoneId()).thenReturn(ZoneId.systemDefault());
+        when(event.getZoneId()).thenReturn(TEST_CLOCK.getZone());
         when(event.getBegin()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(1));
         when(eventRepository.findAll()).thenReturn(singletonList(event));
         when(ticketRepository.flagTicketAsReminderSent(ticketId)).thenReturn(1);
@@ -1184,7 +1184,7 @@ class TicketReservationManagerTest {
         when(ticketReservationRepository.findReservationByIdForUpdate(eq(RESERVATION_ID))).thenReturn(ticketReservation);
 
         when(eventRepository.findByReservationId(RESERVATION_ID)).thenReturn(event);
-        when(event.getZoneId()).thenReturn(ZoneId.systemDefault());
+        when(event.getZoneId()).thenReturn(TEST_CLOCK.getZone());
         when(event.getBegin()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(1));
         when(eventRepository.findAll()).thenReturn(singletonList(event));
         when(ticketRepository.flagTicketAsReminderSent(ticketId)).thenReturn(0);

--- a/src/test/java/alfio/manager/UploadedResourceIntegrationTest.java
+++ b/src/test/java/alfio/manager/UploadedResourceIntegrationTest.java
@@ -47,8 +47,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.*;
 
-import static alfio.test.util.IntegrationTestUtil.AVAILABLE_SEATS;
-import static alfio.test.util.IntegrationTestUtil.initEvent;
+import static alfio.test.util.IntegrationTestUtil.*;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = {DataSourceConfiguration.class, TestConfiguration.class})
@@ -88,8 +87,8 @@ public class UploadedResourceIntegrationTest extends BaseIntegrationTest {
         IntegrationTestUtil.ensureMinimalConfiguration(configurationRepository);
         List<TicketCategoryModification> categories = Collections.singletonList(
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
-                new DateTimeModification(LocalDate.now().minusDays(1), LocalTime.now()),
-                new DateTimeModification(LocalDate.now().plusDays(1), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK).minusDays(1), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK).plusDays(1), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Pair<Event, String> eventAndUser = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
 

--- a/src/test/java/alfio/manager/WaitingQueueManagerIntegrationTest.java
+++ b/src/test/java/alfio/manager/WaitingQueueManagerIntegrationTest.java
@@ -78,8 +78,6 @@ public class WaitingQueueManagerIntegrationTest extends BaseIntegrationTest {
     @Autowired
     private ConfigurationManager configurationManager;
     @Autowired
-    private EventStatisticsManager eventStatisticsManager;
-    @Autowired
     private TicketReservationManager ticketReservationManager;
     @Autowired
     private TicketCategoryRepository ticketCategoryRepository;
@@ -134,7 +132,7 @@ public class WaitingQueueManagerIntegrationTest extends BaseIntegrationTest {
         TicketReservationWithOptionalCodeModification reservation = subscriptionDetail.getMiddle();
         assertEquals(Integer.valueOf(firstCategory.getId()), reservation.getTicketCategoryId());
         assertEquals(Integer.valueOf(1), reservation.getAmount());
-        assertTrue(subscriptionDetail.getRight().isAfter(ZonedDateTime.now()));
+        assertTrue(subscriptionDetail.getRight().isAfter(ZonedDateTime.now(TEST_CLOCK)));
 
     }
 
@@ -156,7 +154,7 @@ public class WaitingQueueManagerIntegrationTest extends BaseIntegrationTest {
         TicketReservationWithOptionalCodeModification reservation = subscriptionDetail.getMiddle();
         assertEquals(Integer.valueOf(firstCategory.getId()), reservation.getTicketCategoryId());
         assertEquals(Integer.valueOf(1), reservation.getAmount());
-        assertTrue(subscriptionDetail.getRight().isAfter(ZonedDateTime.now()));
+        assertTrue(subscriptionDetail.getRight().isAfter(ZonedDateTime.now(TEST_CLOCK)));
 
     }
 
@@ -164,8 +162,8 @@ public class WaitingQueueManagerIntegrationTest extends BaseIntegrationTest {
     public void testWaitingQueueForUnboundedCategory() {
         List<TicketCategoryModification> categories = Collections.singletonList(
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Event event = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository).getKey();
         TicketCategory unbounded = ticketCategoryRepository.findAllTicketCategories(event.getId()).get(0);
@@ -189,8 +187,8 @@ public class WaitingQueueManagerIntegrationTest extends BaseIntegrationTest {
 
     @Test
     public void testAssignTicketToWaitingQueueUnboundedCategory() {
-        LocalDateTime start = LocalDateTime.now().minusMinutes(1);
-        LocalDateTime end = LocalDateTime.now().plusMinutes(20);
+        LocalDateTime start = LocalDateTime.now(TEST_CLOCK).minusMinutes(1);
+        LocalDateTime end = LocalDateTime.now(TEST_CLOCK).plusMinutes(20);
         List<TicketCategoryModification> categories = Collections.singletonList(
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
                 new DateTimeModification(start.toLocalDate(), start.toLocalTime()),
@@ -248,13 +246,13 @@ public class WaitingQueueManagerIntegrationTest extends BaseIntegrationTest {
         TicketReservationWithOptionalCodeModification reservation = subscriptionDetail.getMiddle();
         assertEquals(Integer.valueOf(unbounded.getId()), reservation.getTicketCategoryId());
         assertEquals(Integer.valueOf(1), reservation.getAmount());
-        assertTrue(subscriptionDetail.getRight().isAfter(ZonedDateTime.now()));
+        assertTrue(subscriptionDetail.getRight().isAfter(ZonedDateTime.now(TEST_CLOCK)));
     }
 
     @Test
     public void testAssignTicketToWaitingQueueBoundedCategory() {
-        LocalDateTime start = LocalDateTime.now().minusMinutes(2);
-        LocalDateTime end = LocalDateTime.now().plusMinutes(20);
+        LocalDateTime start = LocalDateTime.now(TEST_CLOCK).minusMinutes(2);
+        LocalDateTime end = LocalDateTime.now(TEST_CLOCK).plusMinutes(20);
         List<TicketCategoryModification> categories = Collections.singletonList(
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
                 new DateTimeModification(start.toLocalDate(), start.toLocalTime()),
@@ -310,13 +308,13 @@ public class WaitingQueueManagerIntegrationTest extends BaseIntegrationTest {
         TicketReservationWithOptionalCodeModification reservation = subscriptionDetail.getMiddle();
         assertEquals(Integer.valueOf(bounded.getId()), reservation.getTicketCategoryId());
         assertEquals(Integer.valueOf(1), reservation.getAmount());
-        assertTrue(subscriptionDetail.getRight().isAfter(ZonedDateTime.now()));
+        assertTrue(subscriptionDetail.getRight().isAfter(ZonedDateTime.now(TEST_CLOCK)));
     }
 
     @Test
     public void testAssignTicketToWaitingQueueUnboundedCategorySelected() {
-        LocalDateTime start = LocalDateTime.now().minusHours(1);
-        LocalDateTime end = LocalDateTime.now().plusHours(1);
+        LocalDateTime start = LocalDateTime.now(TEST_CLOCK).minusHours(1);
+        LocalDateTime end = LocalDateTime.now(TEST_CLOCK).plusHours(1);
 
         List<TicketCategoryModification> categories = Arrays.asList(
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
@@ -364,14 +362,14 @@ public class WaitingQueueManagerIntegrationTest extends BaseIntegrationTest {
         TicketReservationWithOptionalCodeModification reservation = subscriptionDetail.getMiddle();
         assertEquals(Integer.valueOf(first.getId()), reservation.getTicketCategoryId());
         assertEquals(Integer.valueOf(1), reservation.getAmount());
-        assertTrue(subscriptionDetail.getRight().isAfter(ZonedDateTime.now()));
+        assertTrue(subscriptionDetail.getRight().isAfter(ZonedDateTime.now(TEST_CLOCK)));
 
         subscriptionDetail = subscriptions.get(1);
         assertEquals("john@doe2.com", subscriptionDetail.getLeft().getEmailAddress());
         reservation = subscriptionDetail.getMiddle();
         assertEquals(Integer.valueOf(second.getId()), reservation.getTicketCategoryId());
         assertEquals(Integer.valueOf(1), reservation.getAmount());
-        assertTrue(subscriptionDetail.getRight().isAfter(ZonedDateTime.now()));
+        assertTrue(subscriptionDetail.getRight().isAfter(ZonedDateTime.now(TEST_CLOCK)));
     }
 
     private String reserveTickets(Event event, TicketCategory category, int num) {
@@ -393,8 +391,8 @@ public class WaitingQueueManagerIntegrationTest extends BaseIntegrationTest {
 
     @Test
     public void testNoPublicCategoryAvailable() {
-        LocalDateTime start = LocalDateTime.now().minusHours(1);
-        LocalDateTime end = LocalDateTime.now().plusHours(1);
+        LocalDateTime start = LocalDateTime.now(TEST_CLOCK).minusHours(1);
+        LocalDateTime end = LocalDateTime.now(TEST_CLOCK).plusHours(1);
 
         List<TicketCategoryModification> categories = Arrays.asList(
             new TicketCategoryModification(null, "default", 2,
@@ -428,8 +426,8 @@ public class WaitingQueueManagerIntegrationTest extends BaseIntegrationTest {
 
     @Test
     public void testTicketBelongsToExpiredCategory() {
-        LocalDateTime start = LocalDateTime.now().minusHours(1);
-        LocalDateTime end = LocalDateTime.now().plusHours(1);
+        LocalDateTime start = LocalDateTime.now(TEST_CLOCK).minusHours(1);
+        LocalDateTime end = LocalDateTime.now(TEST_CLOCK).plusHours(1);
 
         List<TicketCategoryModification> categories = Arrays.asList(
             new TicketCategoryModification(null, "default", 2,
@@ -471,15 +469,15 @@ public class WaitingQueueManagerIntegrationTest extends BaseIntegrationTest {
     }
 
     private List<TicketCategoryModification> getPreSalesTicketCategoryModifications(boolean firstBounded, int firstSeats, boolean lastBounded, int lastSeats) {
-        LocalDateTime start = LocalDateTime.now().plusMinutes(4);
+        LocalDateTime start = LocalDateTime.now(TEST_CLOCK).plusMinutes(4);
         return Arrays.asList(
             new TicketCategoryModification(null, "defaultFirst", firstSeats,
                 new DateTimeModification(start.toLocalDate(), start.toLocalTime()),
-                new DateTimeModification(LocalDate.now().plusDays(1), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK).plusDays(1), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", firstBounded, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()),
             new TicketCategoryModification(null, "defaultLast", lastSeats,
-                new DateTimeModification(LocalDate.now().plusDays(1), LocalTime.now()),
-                new DateTimeModification(LocalDate.now().plusDays(2), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK).plusDays(1), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK).plusDays(2), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", lastBounded, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
     }
 }

--- a/src/test/java/alfio/manager/WaitingQueueProcessorIntegrationTest.java
+++ b/src/test/java/alfio/manager/WaitingQueueProcessorIntegrationTest.java
@@ -108,21 +108,21 @@ public class WaitingQueueProcessorIntegrationTest extends BaseIntegrationTest {
     public void testPreRegistration() {
         List<TicketCategoryModification> categories = Collections.singletonList(
                 new TicketCategoryModification(null, "default", 10,
-                        new DateTimeModification(LocalDate.now().plusDays(1), LocalTime.now()),
-                        new DateTimeModification(LocalDate.now().plusDays(2), LocalTime.now()),
+                        new DateTimeModification(LocalDate.now(TEST_CLOCK).plusDays(1), LocalTime.now(TEST_CLOCK)),
+                        new DateTimeModification(LocalDate.now(TEST_CLOCK).plusDays(2), LocalTime.now(TEST_CLOCK)),
                         DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = pair.getKey();
         waitingQueueManager.subscribe(event, new CustomerName("Giuseppe Garibaldi", "Giuseppe", "Garibaldi", event.mustUseFirstAndLastName()), "peppino@garibaldi.com", null, Locale.ENGLISH);
         waitingQueueManager.subscribe(event, new CustomerName("Nino Bixio", "Nino", "Bixio", event.mustUseFirstAndLastName()), "bixio@mille.org", null, Locale.ITALIAN);
-        assertTrue(waitingQueueRepository.countWaitingPeople(event.getId()) == 2);
+        assertEquals(2, (int) waitingQueueRepository.countWaitingPeople(event.getId()));
 
         waitingQueueSubscriptionProcessor.distributeAvailableSeats(event);
         assertEquals(18, ticketRepository.findFreeByEventId(event.getId()).size());
 
         TicketCategoryModification tcm = new TicketCategoryModification(null, "default", 10,
-                new DateTimeModification(LocalDate.now().minusDays(1), LocalTime.now()),
-                new DateTimeModification(LocalDate.now().plusDays(5), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK).minusDays(1), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK).plusDays(5), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null, AlfioMetadata.empty());
         eventManager.insertCategory(event.getId(), tcm, pair.getValue());
 
@@ -204,14 +204,14 @@ public class WaitingQueueProcessorIntegrationTest extends BaseIntegrationTest {
         List<TicketCategoryModification> categories = new ArrayList<>();
         categories.add(
             new TicketCategoryModification(null, "default", boundedCategorySize,
-                new DateTimeModification(LocalDate.now().minusDays(1), LocalTime.now()),
-                new DateTimeModification(LocalDate.now().plusDays(2), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK).minusDays(1), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK).plusDays(2), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.ZERO, false, "", true, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
 
         if(withUnboundedCategory) {
              categories.add(new TicketCategoryModification(null, "unbounded", 0,
-                 new DateTimeModification(LocalDate.now().minusDays(1), LocalTime.now()),
-                 new DateTimeModification(LocalDate.now().plusDays(2), LocalTime.now()),
+                 new DateTimeModification(LocalDate.now(TEST_CLOCK).minusDays(1), LocalTime.now(TEST_CLOCK)),
+                 new DateTimeModification(LocalDate.now(TEST_CLOCK).plusDays(2), LocalTime.now(TEST_CLOCK)),
                  DESCRIPTION, BigDecimal.ZERO, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         }
 
@@ -223,7 +223,7 @@ public class WaitingQueueProcessorIntegrationTest extends BaseIntegrationTest {
         assertEquals(boundedCategorySize, boundedReserved.size());
         List<Integer> reserved = new ArrayList<>(boundedReserved);
         String reservationId = UUID.randomUUID().toString();
-        ticketReservationRepository.createNewReservation(reservationId, ZonedDateTime.now(), DateUtils.addHours(new Date(), 1), null, Locale.ITALIAN.getLanguage(), event.getId(), event.getVat(), event.isVatIncluded(), event.getCurrency());
+        ticketReservationRepository.createNewReservation(reservationId, ZonedDateTime.now(TEST_CLOCK), DateUtils.addHours(new Date(), 1), null, Locale.ITALIAN.getLanguage(), event.getId(), event.getVat(), event.isVatIncluded(), event.getCurrency());
         List<Integer> reservedForUpdate = withUnboundedCategory ? reserved.subList(0, 19) : reserved;
         ticketRepository.reserveTickets(reservationId, reservedForUpdate, bounded.getId(), Locale.ITALIAN.getLanguage(), 0, "CHF");
         if(withUnboundedCategory) {

--- a/src/test/java/alfio/manager/WaitingQueueProcessorMultiThreadedIntegrationTest.java
+++ b/src/test/java/alfio/manager/WaitingQueueProcessorMultiThreadedIntegrationTest.java
@@ -104,14 +104,14 @@ public class WaitingQueueProcessorMultiThreadedIntegrationTest {
 
             List<TicketCategoryModification> categories = Collections.singletonList(
                 new TicketCategoryModification(null, "default", 10,
-                    new DateTimeModification(LocalDate.now().plusDays(1), LocalTime.now()),
-                    new DateTimeModification(LocalDate.now().plusDays(2), LocalTime.now()),
+                    new DateTimeModification(LocalDate.now(TEST_CLOCK).plusDays(1), LocalTime.now(TEST_CLOCK)),
+                    new DateTimeModification(LocalDate.now(TEST_CLOCK).plusDays(2), LocalTime.now(TEST_CLOCK)),
                     DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
             Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
             event = pair.getKey();
             waitingQueueManager.subscribe(event, new CustomerName("Giuseppe Garibaldi", "Giuseppe", "Garibaldi", event.mustUseFirstAndLastName()), "peppino@garibaldi.com", null, Locale.ENGLISH);
             waitingQueueManager.subscribe(event, new CustomerName("Nino Bixio", "Nino", "Bixio", event.mustUseFirstAndLastName()), "bixio@mille.org", null, Locale.ITALIAN);
-            assertTrue(waitingQueueRepository.countWaitingPeople(event.getId()) == 2);
+            assertEquals(2, (int) waitingQueueRepository.countWaitingPeople(event.getId()));
 
 
             final int parallelism = 10;
@@ -132,8 +132,8 @@ public class WaitingQueueProcessorMultiThreadedIntegrationTest {
             assertEquals(18, ticketRepository.findFreeByEventId(event.getId()).size());
 
             TicketCategoryModification tcm = new TicketCategoryModification(null, "default", 10,
-                new DateTimeModification(LocalDate.now().minusDays(1), LocalTime.now()),
-                new DateTimeModification(LocalDate.now().plusDays(5), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK).minusDays(1), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK).plusDays(5), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null, AlfioMetadata.empty());
             eventManager.insertCategory(event.getId(), tcm, pair.getValue());
 

--- a/src/test/java/alfio/manager/WaitingQueueSubscriptionProcessorTest.java
+++ b/src/test/java/alfio/manager/WaitingQueueSubscriptionProcessorTest.java
@@ -16,33 +16,6 @@
  */
 package alfio.manager;
 
-import static alfio.model.system.ConfigurationKeys.ENABLE_PRE_REGISTRATION;
-import static alfio.model.system.ConfigurationKeys.ENABLE_WAITING_QUEUE;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.util.Collections;
-import java.util.Date;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Stream;
-
-import org.apache.commons.lang3.tuple.Triple;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.springframework.context.MessageSource;
-import org.springframework.transaction.PlatformTransactionManager;
-
 import alfio.manager.i18n.MessageSourceManager;
 import alfio.manager.support.TemplateGenerator;
 import alfio.manager.system.ConfigurationManager;
@@ -53,6 +26,22 @@ import alfio.model.system.ConfigurationKeyValuePathLevel;
 import alfio.repository.TicketRepository;
 import alfio.repository.WaitingQueueRepository;
 import alfio.util.TemplateManager;
+import org.apache.commons.lang3.tuple.Triple;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.MessageSource;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.*;
+import java.util.stream.Stream;
+
+import static alfio.model.system.ConfigurationKeys.ENABLE_PRE_REGISTRATION;
+import static alfio.model.system.ConfigurationKeys.ENABLE_WAITING_QUEUE;
+import static alfio.test.util.IntegrationTestUtil.TEST_CLOCK;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 public class WaitingQueueSubscriptionProcessorTest {
 
@@ -131,7 +120,7 @@ public class WaitingQueueSubscriptionProcessorTest {
         when(messageSource.getMessage(anyString(), any(), eq(Locale.ENGLISH))).thenReturn("subject");
         when(subscription.getLocale()).thenReturn(Locale.ENGLISH);
         when(subscription.getEmailAddress()).thenReturn("me");
-        ZonedDateTime expiration = ZonedDateTime.now().plusDays(1);
+        ZonedDateTime expiration = ZonedDateTime.now(TEST_CLOCK).plusDays(1);
         when(waitingQueueManager.distributeSeats(eq(event))).thenReturn(Stream.of(Triple.of(subscription, reservation, expiration)));
         String reservationId = "reservation-id";
         when(ticketReservationManager.createTicketReservation(eq(event), anyList(), anyList(), any(Date.class), eq(Optional.empty()), any(Locale.class), eq(true))).thenReturn(reservationId);

--- a/src/test/java/alfio/manager/i18n/MessageSourceManagerIntegrationTest.java
+++ b/src/test/java/alfio/manager/i18n/MessageSourceManagerIntegrationTest.java
@@ -49,8 +49,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import static alfio.test.util.IntegrationTestUtil.AVAILABLE_SEATS;
-import static alfio.test.util.IntegrationTestUtil.initEvent;
+import static alfio.test.util.IntegrationTestUtil.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -83,21 +82,18 @@ public class MessageSourceManagerIntegrationTest extends BaseIntegrationTest {
 
     private Event event;
 
-    private String user;
-
     public void ensureConfiguration() {
 
         IntegrationTestUtil.ensureMinimalConfiguration(configurationRepository);
         List<TicketCategoryModification> categories = Arrays.asList(
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
-                new DateTimeModification(LocalDate.now().minusDays(1), LocalTime.now()),
-                new DateTimeModification(LocalDate.now().plusDays(1), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK).minusDays(1), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK).plusDays(1), LocalTime.now(TEST_CLOCK)),
                 Map.of("en", "desc"), BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty())
         );
         Pair<Event, String> eventAndUser = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
 
         event = eventAndUser.getKey();
-        user = eventAndUser.getValue() + "_owner";
     }
 
 

--- a/src/test/java/alfio/manager/payment/RevolutBankTransferManagerTest.java
+++ b/src/test/java/alfio/manager/payment/RevolutBankTransferManagerTest.java
@@ -37,6 +37,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static alfio.model.system.ConfigurationKeys.REVOLUT_MANUAL_REVIEW;
+import static alfio.test.util.IntegrationTestUtil.TEST_CLOCK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.*;
@@ -68,7 +69,7 @@ class RevolutBankTransferManagerTest {
         when(transaction.getId()).thenReturn(TRANSACTION_ID);
         when(transaction.getCurrency()).thenReturn("CHF");
         when(transaction.getStatus()).thenReturn(Transaction.Status.PENDING);
-        when(transaction.getTimestamp()).thenReturn(ZonedDateTime.now());
+        when(transaction.getTimestamp()).thenReturn(ZonedDateTime.now(TEST_CLOCK));
         when(first.getTransaction()).thenReturn(transaction);
 
         second = mock(TicketReservationWithTransaction.class);

--- a/src/test/java/alfio/manager/payment/SaferpayManagerTest.java
+++ b/src/test/java/alfio/manager/payment/SaferpayManagerTest.java
@@ -71,6 +71,7 @@ class SaferpayManagerTest {
     private SaferpayManager manager;
 
     @BeforeEach
+    @SuppressWarnings("unchecked")
     public void init() {
         var configurationManager = mock(ConfigurationManager.class);
         var configuration = mock(Map.class);

--- a/src/test/java/alfio/manager/payment/StripeManagerTest.java
+++ b/src/test/java/alfio/manager/payment/StripeManagerTest.java
@@ -55,7 +55,6 @@ public class StripeManagerTest {
     private CustomerName customerName;
 
     private final String paymentId = "customer#1";
-    private final String error = "errorCode";
 
     @BeforeEach
     public void setUp() {

--- a/src/test/java/alfio/manager/system/DataMigratorIntegrationTest.java
+++ b/src/test/java/alfio/manager/system/DataMigratorIntegrationTest.java
@@ -20,8 +20,6 @@ import alfio.TestConfiguration;
 import alfio.config.DataSourceConfiguration;
 import alfio.config.Initializer;
 import alfio.manager.EventManager;
-import alfio.manager.ExtensionManager;
-import alfio.manager.FileUploadManager;
 import alfio.manager.TicketReservationManager;
 import alfio.manager.user.UserManager;
 import alfio.model.*;
@@ -40,7 +38,6 @@ import alfio.repository.TicketReservationRepository;
 import alfio.repository.system.EventMigrationRepository;
 import alfio.repository.user.OrganizationRepository;
 import alfio.util.BaseIntegrationTest;
-import alfio.util.TemplateManager;
 import org.apache.commons.lang3.time.DateUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Test;
@@ -58,6 +55,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.*;
 
+import static alfio.test.util.IntegrationTestUtil.TEST_CLOCK;
 import static org.junit.Assert.*;
 
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -87,17 +85,9 @@ public class DataMigratorIntegrationTest extends BaseIntegrationTest {
     @Autowired
     private TicketCategoryRepository ticketCategoryRepository;
     @Autowired
-    private TemplateManager templateManager;
-    @Autowired
-    private FileUploadManager fileUploadManager;
-    @Autowired
     private TicketReservationRepository ticketReservationRepository;
-    @Autowired
-    private ExtensionManager extensionManager;
     @Value("${alfio.version}")
     private String currentVersion;
-    @Value("${alfio.build-ts}")
-    private String buildTimestamp;
 
     private Pair<Event, String> initEvent(List<TicketCategoryModification> categories) {
         return initEvent(categories, "display name");
@@ -121,8 +111,8 @@ public class DataMigratorIntegrationTest extends BaseIntegrationTest {
                 eventName, displayName, organization.getId(),
                 "muh location",
                 "0.0", "0.0", ZoneId.systemDefault().getId(), desc,
-                new DateTimeModification(LocalDate.now().plusDays(5), LocalTime.now()),
-                new DateTimeModification(LocalDate.now().plusDays(5), LocalTime.now().plusHours(1)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK).plusDays(5), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK).plusDays(5), LocalTime.now(TEST_CLOCK).plusHours(1)),
                 BigDecimal.TEN, "CHF", AVAILABLE_SEATS, BigDecimal.ONE, true, List.of(PaymentProxy.ON_SITE), categories, false, new LocationDescriptor("","","",""), 7, null, null, AlfioMetadata.empty());
         eventManager.createEvent(em, username);
         return Pair.of(eventManager.getSingleEvent(eventName, username), username);
@@ -132,8 +122,8 @@ public class DataMigratorIntegrationTest extends BaseIntegrationTest {
     public void testMigration() {
         List<TicketCategoryModification> categories = Collections.singletonList(
                 new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
-                        new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                        new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                        new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                        new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                         DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Pair<Event, String> eventUsername = initEvent(categories);
         Event event = eventUsername.getKey();
@@ -161,8 +151,8 @@ public class DataMigratorIntegrationTest extends BaseIntegrationTest {
     public void testMigrationWithExistingRecord() {
         List<TicketCategoryModification> categories = Collections.singletonList(
                 new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
-                        new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                        new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                        new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                        new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                         DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Pair<Event, String> eventUsername = initEvent(categories); 
         Event event = eventUsername.getKey();
@@ -190,8 +180,8 @@ public class DataMigratorIntegrationTest extends BaseIntegrationTest {
     public void testAlreadyMigratedEvent() {
         List<TicketCategoryModification> categories = Collections.singletonList(
                 new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
-                        new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                        new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                        new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                        new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                         DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Pair<Event, String> eventUsername = initEvent(categories); 
         Event event = eventUsername.getKey();
@@ -220,8 +210,8 @@ public class DataMigratorIntegrationTest extends BaseIntegrationTest {
     public void testUpdateDisplayName() {
         List<TicketCategoryModification> categories = Collections.singletonList(
                 new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
-                        new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                        new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                        new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                        new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                         DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Pair<Event, String> eventUsername = initEvent(categories, null); 
         Event event = eventUsername.getKey();
@@ -246,8 +236,8 @@ public class DataMigratorIntegrationTest extends BaseIntegrationTest {
     public void testUpdateTicketReservation() {
         List<TicketCategoryModification> categories = Collections.singletonList(
                 new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
-                        new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                        new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                        new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                        new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                         DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Pair<Event, String> eventUsername = initEvent(categories); 
         Event event = eventUsername.getKey();
@@ -270,12 +260,12 @@ public class DataMigratorIntegrationTest extends BaseIntegrationTest {
     public void testFixCategoriesSize() {
         List<TicketCategoryModification> categories = Arrays.asList(
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS -1,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()),
             new TicketCategoryModification(null, "default", 1,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Pair<Event, String> eventUsername = initEvent(categories);
         Event event = eventUsername.getKey();
@@ -293,8 +283,8 @@ public class DataMigratorIntegrationTest extends BaseIntegrationTest {
     public void testFixStuckTickets() {
         List<TicketCategoryModification> categories = Collections.singletonList(
             new TicketCategoryModification(null, "default", AVAILABLE_SEATS,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Pair<Event, String> eventUsername = initEvent(categories);
         Event event = eventUsername.getKey();

--- a/src/test/java/alfio/repository/EventRepositoryIntegrationTest.java
+++ b/src/test/java/alfio/repository/EventRepositoryIntegrationTest.java
@@ -52,8 +52,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
-import static alfio.test.util.IntegrationTestUtil.DESCRIPTION;
-import static alfio.test.util.IntegrationTestUtil.initEvent;
+import static alfio.test.util.IntegrationTestUtil.*;
 import static org.junit.Assert.*;
 
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -114,14 +113,14 @@ public class EventRepositoryIntegrationTest extends BaseIntegrationTest {
     public void testCheckInStatistics() {
         List<TicketCategoryModification> categories = Collections.singletonList(
             new TicketCategoryModification(null, "default", 0,
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
-                new DateTimeModification(LocalDate.now(), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
                 DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
         Pair<Event, String> pair = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         Event event = pair.getKey();
         TicketCategoryModification tcm = new TicketCategoryModification(null, "default", 10,
-            new DateTimeModification(LocalDate.now(), LocalTime.now()),
-            new DateTimeModification(LocalDate.now(), LocalTime.now()),
+            new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
+            new DateTimeModification(LocalDate.now(TEST_CLOCK), LocalTime.now(TEST_CLOCK)),
             DESCRIPTION, BigDecimal.TEN, false, "", true, null, null, null, null, null, 0, null, null, AlfioMetadata.empty());
         Result<Integer> result = eventManager.insertCategory(event, tcm, pair.getValue());
         assertTrue(result.isSuccess());
@@ -135,7 +134,7 @@ public class EventRepositoryIntegrationTest extends BaseIntegrationTest {
         TicketCategoryWithAdditionalInfo firstCategory = eventWithAdditionalInfo.getTicketCategories().get(0);
         List<Integer> ids = ticketRepository.selectNotAllocatedTicketsForUpdate(event.getId(), 5, Collections.singletonList(TicketRepository.FREE));
         String reservationId = "12345678";
-        ticketReservationRepository.createNewReservation(reservationId, ZonedDateTime.now(), DateUtils.addDays(new Date(), 1), null, "en", event.getId(), event.getVat(), event.isVatIncluded(), event.getCurrency());
+        ticketReservationRepository.createNewReservation(reservationId, ZonedDateTime.now(TEST_CLOCK), DateUtils.addDays(new Date(), 1), null, "en", event.getId(), event.getVat(), event.isVatIncluded(), event.getCurrency());
         int reserved = ticketRepository.reserveTickets(reservationId, ids, firstCategory.getId(), "it", 100, "CHF");
         assertEquals(5, reserved);
 

--- a/src/test/java/alfio/test/util/IntegrationTestUtil.java
+++ b/src/test/java/alfio/test/util/IntegrationTestUtil.java
@@ -97,7 +97,7 @@ public class IntegrationTestUtil {
         String eventName = UUID.randomUUID().toString();
 
         userManager.createOrganization(organizationName, "org", "email@example.com");
-        Organization organization = organizationRepository.findByName(organizationName).get();
+        Organization organization = organizationRepository.findByName(organizationName).orElseThrow();
         userManager.insertUser(organization.getId(), username, "test", "test", "test@example.com", Role.OPERATOR, User.Type.INTERNAL);
         userManager.insertUser(organization.getId(), username+"_owner", "test", "test", "test@example.com", Role.OWNER, User.Type.INTERNAL);
 
@@ -110,7 +110,7 @@ public class IntegrationTestUtil {
 
         EventModification em = new EventModification(null, Event.EventFormat.IN_PERSON, "url", "url", "url", "privacy","url", null,
                 eventName, "event display name", organization.getId(),
-                "muh location", "0.0", "0.0", ZoneId.systemDefault().getId(), desc,
+                "muh location", "0.0", "0.0", TEST_CLOCK.getZone().getId(), desc,
                 new DateTimeModification(LocalDate.now(TEST_CLOCK).plusDays(5), LocalTime.now(TEST_CLOCK)),
                 new DateTimeModification(expiration.toLocalDate(), expiration.toLocalTime()),
                 BigDecimal.TEN, "CHF", AVAILABLE_SEATS, BigDecimal.ONE, true, Collections.singletonList(PaymentProxy.OFFLINE), categories, false, new LocationDescriptor("","","",""), 7, null, additionalServices, AlfioMetadata.empty());

--- a/src/test/java/alfio/test/util/IntegrationTestUtil.java
+++ b/src/test/java/alfio/test/util/IntegrationTestUtil.java
@@ -38,15 +38,13 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Assert;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.ZoneId;
+import java.time.*;
 import java.util.*;
 
 public class IntegrationTestUtil {
 
     public static final int AVAILABLE_SEATS = 20;
+    public static final Clock TEST_CLOCK = Clock.fixed(Instant.now(), ZoneId.of("Europe/Zurich"));
 
 
     public static final Map<String, Map<String, String>> DB_CONF = new HashMap<>();

--- a/src/test/java/alfio/test/util/IntegrationTestUtil.java
+++ b/src/test/java/alfio/test/util/IntegrationTestUtil.java
@@ -101,7 +101,7 @@ public class IntegrationTestUtil {
         userManager.insertUser(organization.getId(), username, "test", "test", "test@example.com", Role.OPERATOR, User.Type.INTERNAL);
         userManager.insertUser(organization.getId(), username+"_owner", "test", "test", "test@example.com", Role.OWNER, User.Type.INTERNAL);
 
-        LocalDateTime expiration = LocalDateTime.now().plusDays(5).plusHours(1);
+        LocalDateTime expiration = LocalDateTime.now(TEST_CLOCK).plusDays(5).plusHours(1);
 
         Map<String, String> desc = new HashMap<>();
         desc.put("en", "muh description");
@@ -111,7 +111,7 @@ public class IntegrationTestUtil {
         EventModification em = new EventModification(null, Event.EventFormat.IN_PERSON, "url", "url", "url", "privacy","url", null,
                 eventName, "event display name", organization.getId(),
                 "muh location", "0.0", "0.0", ZoneId.systemDefault().getId(), desc,
-                new DateTimeModification(LocalDate.now().plusDays(5), LocalTime.now()),
+                new DateTimeModification(LocalDate.now(TEST_CLOCK).plusDays(5), LocalTime.now(TEST_CLOCK)),
                 new DateTimeModification(expiration.toLocalDate(), expiration.toLocalTime()),
                 BigDecimal.TEN, "CHF", AVAILABLE_SEATS, BigDecimal.ONE, true, Collections.singletonList(PaymentProxy.OFFLINE), categories, false, new LocationDescriptor("","","",""), 7, null, additionalServices, AlfioMetadata.empty());
         eventManager.createEvent(em, username);

--- a/src/test/java/alfio/test/util/PriceContainerImpl.java
+++ b/src/test/java/alfio/test/util/PriceContainerImpl.java
@@ -62,6 +62,7 @@ public class PriceContainerImpl implements PriceContainer {
         return Optional.ofNullable(vat);
     }
 
+    @Override
     public VatStatus getVatStatus() {
         return vatStatus;
     }

--- a/src/test/java/alfio/util/EventUtilTest.java
+++ b/src/test/java/alfio/util/EventUtilTest.java
@@ -17,7 +17,6 @@
 package alfio.util;
 
 import alfio.controller.decorator.SaleableTicketCategory;
-import alfio.manager.system.ConfigurationLevel;
 import alfio.manager.system.ConfigurationManager;
 import alfio.model.Event;
 import alfio.model.EventAndOrganizationId;
@@ -33,19 +32,17 @@ import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Predicate;
 
 import static alfio.model.system.ConfigurationKeys.*;
+import static alfio.test.util.IntegrationTestUtil.TEST_CLOCK;
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class EventUtilTest {
-
-    private static final Predicate<EventAndOrganizationId> TICKETS_AVAILABLE = (ev) -> false;
-    private static final Predicate<EventAndOrganizationId> TICKETS_NOT_AVAILABLE = (ev) -> true;
 
     private Event event;
     private SaleableTicketCategory first;
@@ -53,6 +50,13 @@ public class EventUtilTest {
     private ConfigurationManager configurationManager;
     
     private final ZoneId zone = ZoneId.systemDefault();
+
+    private static boolean ticketsAvailable(EventAndOrganizationId ev){
+        return false;
+    }
+    private static  boolean ticketsNotAvailable(EventAndOrganizationId ev){
+        return true;
+    }
 
     @BeforeEach
     void setUp() {
@@ -62,14 +66,14 @@ public class EventUtilTest {
         configurationManager = mock(ConfigurationManager.class);
         
         when(event.getZoneId()).thenReturn(zone);
-        when(last.getZonedExpiration()).thenReturn(ZonedDateTime.now().plusDays(1));
-        when(last.getUtcExpiration()).thenReturn(ZonedDateTime.now().plusDays(1));
-        when(last.getZonedInception()).thenReturn(ZonedDateTime.now().minusDays(1));
-        when(last.getUtcInception()).thenReturn(ZonedDateTime.now().minusDays(1));
+        when(last.getZonedExpiration()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(1));
+        when(last.getUtcExpiration()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(1));
+        when(last.getZonedInception()).thenReturn(ZonedDateTime.now(TEST_CLOCK).minusDays(1));
+        when(last.getUtcInception()).thenReturn(ZonedDateTime.now(TEST_CLOCK).minusDays(1));
         when(last.getAvailableTickets()).thenReturn(0);
-        when(first.getZonedInception()).thenReturn(ZonedDateTime.now().minusDays(2));
-        when(first.getUtcInception()).thenReturn(ZonedDateTime.now().minusDays(2));
-        when(first.getUtcExpiration()).thenReturn(ZonedDateTime.now().plusHours(2));
+        when(first.getZonedInception()).thenReturn(ZonedDateTime.now(TEST_CLOCK).minusDays(2));
+        when(first.getUtcInception()).thenReturn(ZonedDateTime.now(TEST_CLOCK).minusDays(2));
+        when(first.getUtcExpiration()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusHours(2));
         //when(configurationManager.getFor(eq(STOP_WAITING_QUEUE_SUBSCRIPTIONS), any())).thenReturn(buildConf(STOP_WAITING_QUEUE_SUBSCRIPTIONS));
     }
 
@@ -86,7 +90,7 @@ public class EventUtilTest {
     void displayWaitingQueueFormIfSoldOut() {
         List<SaleableTicketCategory> categories = asList(first, last);
         when(configurationManager.getFor(anyList(), any())).thenReturn(Map.of(STOP_WAITING_QUEUE_SUBSCRIPTIONS, buildConf(STOP_WAITING_QUEUE_SUBSCRIPTIONS), ENABLE_WAITING_QUEUE, buildConf(ENABLE_WAITING_QUEUE, true)));
-        assertTrue(EventUtil.displayWaitingQueueForm(event, categories, configurationManager, TICKETS_NOT_AVAILABLE));
+        assertTrue(EventUtil.displayWaitingQueueForm(event, categories, configurationManager, EventUtilTest::ticketsNotAvailable));
     }
 
     @Test
@@ -94,7 +98,7 @@ public class EventUtilTest {
     void displayWaitingQueueFormIfSoldOutReversed() {
         List<SaleableTicketCategory> categories = asList(last, first);
         when(configurationManager.getFor(anyList(), any())).thenReturn(Map.of(STOP_WAITING_QUEUE_SUBSCRIPTIONS, buildConf(STOP_WAITING_QUEUE_SUBSCRIPTIONS), ENABLE_WAITING_QUEUE, buildConf(ENABLE_WAITING_QUEUE, true)));
-        assertTrue(EventUtil.displayWaitingQueueForm(event, categories, configurationManager, TICKETS_NOT_AVAILABLE));
+        assertTrue(EventUtil.displayWaitingQueueForm(event, categories, configurationManager, EventUtilTest::ticketsNotAvailable));
     }
 
     @Test
@@ -102,7 +106,7 @@ public class EventUtilTest {
     void displayWaitingQueueFormIfSingleCategorySoldOut() {
         List<SaleableTicketCategory> categories = Collections.singletonList(last);
         when(configurationManager.getFor(anyList(), any())).thenReturn(Map.of(STOP_WAITING_QUEUE_SUBSCRIPTIONS, buildConf(STOP_WAITING_QUEUE_SUBSCRIPTIONS), ENABLE_WAITING_QUEUE, buildConf(ENABLE_WAITING_QUEUE, true)));
-        assertTrue(EventUtil.displayWaitingQueueForm(event, categories, configurationManager, TICKETS_NOT_AVAILABLE));
+        assertTrue(EventUtil.displayWaitingQueueForm(event, categories, configurationManager, EventUtilTest::ticketsNotAvailable));
     }
 
     @Test
@@ -111,36 +115,36 @@ public class EventUtilTest {
         List<SaleableTicketCategory> categories = Collections.singletonList(last);
         when(last.getAvailableTickets()).thenReturn(1);
         when(configurationManager.getFor(anyList(), any())).thenReturn(Map.of(STOP_WAITING_QUEUE_SUBSCRIPTIONS, buildConf(STOP_WAITING_QUEUE_SUBSCRIPTIONS), ENABLE_WAITING_QUEUE, buildConf(ENABLE_WAITING_QUEUE, true)));
-        assertFalse(EventUtil.displayWaitingQueueForm(event, categories, configurationManager, TICKETS_AVAILABLE));
+        assertFalse(EventUtil.displayWaitingQueueForm(event, categories, configurationManager, EventUtilTest::ticketsAvailable));
     }
 
     @Test
     @DisplayName("do not display the waiting list form if the last category is expired")
     void doNotDisplayWaitingQueueFormIfCategoryExpired() {
         List<SaleableTicketCategory> categories = asList(first, last);
-        when(last.getZonedExpiration()).thenReturn(ZonedDateTime.now().minusDays(1));
-        when(last.getUtcExpiration()).thenReturn(ZonedDateTime.now().minusDays(1));
-        when(last.getZonedInception()).thenReturn(ZonedDateTime.now().minusDays(2));
-        when(last.getUtcInception()).thenReturn(ZonedDateTime.now().minusDays(2));
+        when(last.getZonedExpiration()).thenReturn(ZonedDateTime.now(TEST_CLOCK).minusDays(1));
+        when(last.getUtcExpiration()).thenReturn(ZonedDateTime.now(TEST_CLOCK).minusDays(1));
+        when(last.getZonedInception()).thenReturn(ZonedDateTime.now(TEST_CLOCK).minusDays(2));
+        when(last.getUtcInception()).thenReturn(ZonedDateTime.now(TEST_CLOCK).minusDays(2));
         when(last.getAvailableTickets()).thenReturn(0);
-        when(first.getZonedInception()).thenReturn(ZonedDateTime.now().minusDays(2));
-        when(first.getUtcInception()).thenReturn(ZonedDateTime.now().minusDays(2));
-        when(first.getUtcExpiration()).thenReturn(ZonedDateTime.now().minusDays(1).minusHours(1));
+        when(first.getZonedInception()).thenReturn(ZonedDateTime.now(TEST_CLOCK).minusDays(2));
+        when(first.getUtcInception()).thenReturn(ZonedDateTime.now(TEST_CLOCK).minusDays(2));
+        when(first.getUtcExpiration()).thenReturn(ZonedDateTime.now(TEST_CLOCK).minusDays(1).minusHours(1));
         when(configurationManager.getFor(anyList(), any())).thenReturn(Map.of(STOP_WAITING_QUEUE_SUBSCRIPTIONS, buildConf(STOP_WAITING_QUEUE_SUBSCRIPTIONS), ENABLE_WAITING_QUEUE, buildConf(ENABLE_WAITING_QUEUE, true)));
-        assertFalse(EventUtil.displayWaitingQueueForm(event, categories, configurationManager, TICKETS_NOT_AVAILABLE));
+        assertFalse(EventUtil.displayWaitingQueueForm(event, categories, configurationManager, EventUtilTest::ticketsNotAvailable));
     }
 
     @Test
     @DisplayName("do not display the waiting list form if the only category is not expired")
     void doNotDisplayWaitingQueueFormIfCategoryNotExpired() {
         List<SaleableTicketCategory> categories = Collections.singletonList(last);
-        when(last.getZonedExpiration()).thenReturn(ZonedDateTime.now().minusDays(1));
-        when(last.getUtcExpiration()).thenReturn(ZonedDateTime.now().minusDays(1));
-        when(last.getZonedInception()).thenReturn(ZonedDateTime.now().minusDays(2));
-        when(last.getUtcInception()).thenReturn(ZonedDateTime.now().minusDays(2));
+        when(last.getZonedExpiration()).thenReturn(ZonedDateTime.now(TEST_CLOCK).minusDays(1));
+        when(last.getUtcExpiration()).thenReturn(ZonedDateTime.now(TEST_CLOCK).minusDays(1));
+        when(last.getZonedInception()).thenReturn(ZonedDateTime.now(TEST_CLOCK).minusDays(2));
+        when(last.getUtcInception()).thenReturn(ZonedDateTime.now(TEST_CLOCK).minusDays(2));
         when(last.getAvailableTickets()).thenReturn(0);
         when(configurationManager.getFor(anyList(), any())).thenReturn(Map.of(STOP_WAITING_QUEUE_SUBSCRIPTIONS, buildConf(STOP_WAITING_QUEUE_SUBSCRIPTIONS), ENABLE_WAITING_QUEUE, buildConf(ENABLE_WAITING_QUEUE, true)));
-        assertFalse(EventUtil.displayWaitingQueueForm(event, categories, configurationManager, TICKETS_NOT_AVAILABLE));
+        assertFalse(EventUtil.displayWaitingQueueForm(event, categories, configurationManager, EventUtilTest::ticketsNotAvailable));
     }
 
     @Test
@@ -148,19 +152,19 @@ public class EventUtilTest {
     void doNotDisplayWaitingQueueFormIfNoCategories() {
         List<SaleableTicketCategory> categories = Collections.emptyList();
         when(configurationManager.getFor(anyList(), any())).thenReturn(Map.of(STOP_WAITING_QUEUE_SUBSCRIPTIONS, buildConf(STOP_WAITING_QUEUE_SUBSCRIPTIONS), ENABLE_WAITING_QUEUE, buildConf(ENABLE_WAITING_QUEUE, true)));
-        assertFalse(EventUtil.displayWaitingQueueForm(event, categories, configurationManager, TICKETS_NOT_AVAILABLE));
+        assertFalse(EventUtil.displayWaitingQueueForm(event, categories, configurationManager, EventUtilTest::ticketsNotAvailable));
     }
 
     @Test
     @DisplayName("do not display the waiting list form if the waiting list is disabled")
     void doNotDisplayWaitingQueueFormIfDisabled() {
         List<SaleableTicketCategory> categories = Collections.singletonList(last);
-        when(last.getZonedExpiration()).thenReturn(ZonedDateTime.now().minusDays(1));
-        when(last.getUtcExpiration()).thenReturn(ZonedDateTime.now().minusDays(1));
-        when(last.getZonedInception()).thenReturn(ZonedDateTime.now().minusDays(2));
-        when(last.getUtcInception()).thenReturn(ZonedDateTime.now().minusDays(2));
+        when(last.getZonedExpiration()).thenReturn(ZonedDateTime.now(TEST_CLOCK).minusDays(1));
+        when(last.getUtcExpiration()).thenReturn(ZonedDateTime.now(TEST_CLOCK).minusDays(1));
+        when(last.getZonedInception()).thenReturn(ZonedDateTime.now(TEST_CLOCK).minusDays(2));
+        when(last.getUtcInception()).thenReturn(ZonedDateTime.now(TEST_CLOCK).minusDays(2));
         when(configurationManager.getFor(anyList(), any())).thenReturn(Map.of(STOP_WAITING_QUEUE_SUBSCRIPTIONS, buildConf(STOP_WAITING_QUEUE_SUBSCRIPTIONS), ENABLE_WAITING_QUEUE, buildConf(ENABLE_WAITING_QUEUE, false)));
-        assertFalse(EventUtil.displayWaitingQueueForm(event, categories, configurationManager, TICKETS_NOT_AVAILABLE));
+        assertFalse(EventUtil.displayWaitingQueueForm(event, categories, configurationManager, EventUtilTest::ticketsNotAvailable));
     }
 
     @Test
@@ -168,12 +172,12 @@ public class EventUtilTest {
     void displayWaitingQueueFormBeforeSalesStart() {
         List<SaleableTicketCategory> categories = Collections.singletonList(last);
         when(configurationManager.getFor(anyList(), any())).thenReturn(Map.of(STOP_WAITING_QUEUE_SUBSCRIPTIONS, buildConf(STOP_WAITING_QUEUE_SUBSCRIPTIONS), ENABLE_PRE_REGISTRATION, buildConf(ENABLE_PRE_REGISTRATION, true)));
-        when(last.getZonedExpiration()).thenReturn(ZonedDateTime.now().plusDays(2));
-        when(last.getUtcExpiration()).thenReturn(ZonedDateTime.now().plusDays(2));
-        when(last.getZonedInception()).thenReturn(ZonedDateTime.now().plusDays(1));
-        when(last.getUtcInception()).thenReturn(ZonedDateTime.now().plusDays(1));
+        when(last.getZonedExpiration()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(2));
+        when(last.getUtcExpiration()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(2));
+        when(last.getZonedInception()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(1));
+        when(last.getUtcInception()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(1));
         when(last.getAvailableTickets()).thenReturn(1);
-        assertTrue(EventUtil.displayWaitingQueueForm(event, categories, configurationManager, TICKETS_AVAILABLE));
+        assertTrue(EventUtil.displayWaitingQueueForm(event, categories, configurationManager, EventUtilTest::ticketsAvailable));
     }
 
     @Test
@@ -181,17 +185,17 @@ public class EventUtilTest {
     void displayWaitingQueueFormBeforeSalesStart2() {
         List<SaleableTicketCategory> categories = asList(first, last);
         when(configurationManager.getFor(anyList(), any())).thenReturn(Map.of(STOP_WAITING_QUEUE_SUBSCRIPTIONS, buildConf(STOP_WAITING_QUEUE_SUBSCRIPTIONS), ENABLE_PRE_REGISTRATION, buildConf(ENABLE_PRE_REGISTRATION, true)));
-        when(first.getZonedExpiration()).thenReturn(ZonedDateTime.now().plusDays(2));
-        when(first.getUtcExpiration()).thenReturn(ZonedDateTime.now().plusDays(2));
-        when(first.getZonedInception()).thenReturn(ZonedDateTime.now().plusDays(1));
-        when(first.getUtcInception()).thenReturn(ZonedDateTime.now().plusDays(1));
-        when(last.getZonedExpiration()).thenReturn(ZonedDateTime.now().plusDays(3));
-        when(last.getUtcExpiration()).thenReturn(ZonedDateTime.now().plusDays(3));
-        when(last.getZonedInception()).thenReturn(ZonedDateTime.now().plusDays(2));
-        when(last.getUtcInception()).thenReturn(ZonedDateTime.now().plusDays(2));
+        when(first.getZonedExpiration()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(2));
+        when(first.getUtcExpiration()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(2));
+        when(first.getZonedInception()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(1));
+        when(first.getUtcInception()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(1));
+        when(last.getZonedExpiration()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(3));
+        when(last.getUtcExpiration()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(3));
+        when(last.getZonedInception()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(2));
+        when(last.getUtcInception()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(2));
         when(last.getAvailableTickets()).thenReturn(1);
         when(first.getAvailableTickets()).thenReturn(1);
-        assertTrue(EventUtil.displayWaitingQueueForm(event, categories, configurationManager, TICKETS_AVAILABLE));
+        assertTrue(EventUtil.displayWaitingQueueForm(event, categories, configurationManager, EventUtilTest::ticketsAvailable));
     }
 
     @Test
@@ -199,12 +203,12 @@ public class EventUtilTest {
     void doNotDisplayFormBeforeStartIfPreRegistrationDisabled() {
         List<SaleableTicketCategory> categories = Collections.singletonList(last);
         when(configurationManager.getFor(anyList(), any())).thenReturn(Map.of(STOP_WAITING_QUEUE_SUBSCRIPTIONS, buildConf(STOP_WAITING_QUEUE_SUBSCRIPTIONS), ENABLE_PRE_REGISTRATION, buildConf(ENABLE_PRE_REGISTRATION, false)));
-        when(last.getZonedExpiration()).thenReturn(ZonedDateTime.now().plusDays(2));
-        when(last.getUtcExpiration()).thenReturn(ZonedDateTime.now().plusDays(2));
-        when(last.getZonedInception()).thenReturn(ZonedDateTime.now().plusDays(1));
-        when(last.getUtcInception()).thenReturn(ZonedDateTime.now().plusDays(1));
+        when(last.getZonedExpiration()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(2));
+        when(last.getUtcExpiration()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(2));
+        when(last.getZonedInception()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(1));
+        when(last.getUtcInception()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(1));
         when(last.getAvailableTickets()).thenReturn(1);
-        assertFalse(EventUtil.displayWaitingQueueForm(event, categories, configurationManager, TICKETS_AVAILABLE));
+        assertFalse(EventUtil.displayWaitingQueueForm(event, categories, configurationManager, EventUtilTest::ticketsAvailable));
     }
 
     @Test
@@ -215,12 +219,12 @@ public class EventUtilTest {
             STOP_WAITING_QUEUE_SUBSCRIPTIONS, buildConf(STOP_WAITING_QUEUE_SUBSCRIPTIONS),
             ENABLE_PRE_REGISTRATION, buildConf(ENABLE_PRE_REGISTRATION, true),
             ENABLE_WAITING_QUEUE, buildConf(ENABLE_WAITING_QUEUE)));
-        when(last.getZonedExpiration()).thenReturn(ZonedDateTime.now().plusDays(2));
-        when(last.getUtcExpiration()).thenReturn(ZonedDateTime.now().plusDays(2));
-        when(last.getZonedInception()).thenReturn(ZonedDateTime.now().minusDays(1));
-        when(last.getUtcInception()).thenReturn(ZonedDateTime.now().minusDays(1));
+        when(last.getZonedExpiration()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(2));
+        when(last.getUtcExpiration()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(2));
+        when(last.getZonedInception()).thenReturn(ZonedDateTime.now(TEST_CLOCK).minusDays(1));
+        when(last.getUtcInception()).thenReturn(ZonedDateTime.now(TEST_CLOCK).minusDays(1));
         when(last.getAvailableTickets()).thenReturn(1);
-        assertFalse(EventUtil.displayWaitingQueueForm(event, categories, configurationManager, TICKETS_AVAILABLE));
+        assertFalse(EventUtil.displayWaitingQueueForm(event, categories, configurationManager, EventUtilTest::ticketsAvailable));
     }
 
     @Test
@@ -231,25 +235,25 @@ public class EventUtilTest {
             STOP_WAITING_QUEUE_SUBSCRIPTIONS, buildConf(STOP_WAITING_QUEUE_SUBSCRIPTIONS),
             ENABLE_PRE_REGISTRATION, buildConf(ENABLE_PRE_REGISTRATION, true),
             ENABLE_WAITING_QUEUE, buildConf(ENABLE_WAITING_QUEUE, true)));
-        when(first.getZonedExpiration()).thenReturn(ZonedDateTime.now().plusDays(2));
-        when(first.getUtcExpiration()).thenReturn(ZonedDateTime.now().plusDays(2));
-        when(first.getZonedInception()).thenReturn(ZonedDateTime.now().minusDays(1));
-        when(first.getUtcInception()).thenReturn(ZonedDateTime.now().minusDays(1));
-        when(last.getZonedExpiration()).thenReturn(ZonedDateTime.now().plusDays(3));
-        when(last.getUtcExpiration()).thenReturn(ZonedDateTime.now().plusDays(3));
-        when(last.getZonedInception()).thenReturn(ZonedDateTime.now().plusDays(2));
-        when(last.getUtcInception()).thenReturn(ZonedDateTime.now().plusDays(2));
+        when(first.getZonedExpiration()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(2));
+        when(first.getUtcExpiration()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(2));
+        when(first.getZonedInception()).thenReturn(ZonedDateTime.now(TEST_CLOCK).minusDays(1));
+        when(first.getUtcInception()).thenReturn(ZonedDateTime.now(TEST_CLOCK).minusDays(1));
+        when(last.getZonedExpiration()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(3));
+        when(last.getUtcExpiration()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(3));
+        when(last.getZonedInception()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(2));
+        when(last.getUtcInception()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(2));
         when(last.getAvailableTickets()).thenReturn(1);
         when(first.getAvailableTickets()).thenReturn(1);
-        assertFalse(EventUtil.displayWaitingQueueForm(event, categories, configurationManager, TICKETS_AVAILABLE));
+        assertFalse(EventUtil.displayWaitingQueueForm(event, categories, configurationManager, EventUtilTest::ticketsAvailable));
     }
 
     @Test
     @DisplayName("recognize pre-sales period")
     void recognizePreSalesPeriod() {
         List<SaleableTicketCategory> categories = Collections.singletonList(last);
-        when(last.getZonedInception()).thenReturn(ZonedDateTime.now().plusDays(1));
-        when(last.getUtcInception()).thenReturn(ZonedDateTime.now().plusDays(1));
+        when(last.getZonedInception()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(1));
+        when(last.getUtcInception()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(1));
         when(last.getAvailableTickets()).thenReturn(0);
         assertTrue(EventUtil.isPreSales(event, categories));
     }
@@ -258,12 +262,12 @@ public class EventUtilTest {
     @DisplayName("recognize pre-sales from first category")
     void recognizePreSalesFromFirstCategory() {
         List<SaleableTicketCategory> categories = asList(first, last);
-        when(first.getZonedInception()).thenReturn(ZonedDateTime.now().plusDays(1));
-        when(first.getUtcInception()).thenReturn(ZonedDateTime.now().plusDays(1));
-        when(first.getUtcExpiration()).thenReturn(ZonedDateTime.now().plusDays(1).plusHours(1));
-        when(last.getZonedInception()).thenReturn(ZonedDateTime.now().plusDays(2));
-        when(last.getUtcInception()).thenReturn(ZonedDateTime.now().plusDays(2));
-        when(last.getUtcExpiration()).thenReturn(ZonedDateTime.now().plusDays(2).plusHours(1));
+        when(first.getZonedInception()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(1));
+        when(first.getUtcInception()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(1));
+        when(first.getUtcExpiration()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(1).plusHours(1));
+        when(last.getZonedInception()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(2));
+        when(last.getUtcInception()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(2));
+        when(last.getUtcExpiration()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(2).plusHours(1));
         when(last.getAvailableTickets()).thenReturn(5);
         when(first.getAvailableTickets()).thenReturn(5);
         assertTrue(EventUtil.isPreSales(event, categories));
@@ -273,8 +277,8 @@ public class EventUtilTest {
     @DisplayName("recognize post-sales period")
     void recognizePostSalesPeriod() {
         List<SaleableTicketCategory> categories = Collections.singletonList(last);
-        when(last.getZonedInception()).thenReturn(ZonedDateTime.now().minusDays(1));
-        when(last.getUtcInception()).thenReturn(ZonedDateTime.now().minusDays(1));
+        when(last.getZonedInception()).thenReturn(ZonedDateTime.now(TEST_CLOCK).minusDays(1));
+        when(last.getUtcInception()).thenReturn(ZonedDateTime.now(TEST_CLOCK).minusDays(1));
         when(last.getAvailableTickets()).thenReturn(5);
         assertFalse(EventUtil.isPreSales(event, categories));
     }
@@ -282,12 +286,12 @@ public class EventUtilTest {
     @Test
     void recognizePostSalesFromFirstCategory() {
         List<SaleableTicketCategory> categories = asList(first, last);
-        when(first.getZonedInception()).thenReturn(ZonedDateTime.now().minusDays(1));
-        when(first.getUtcInception()).thenReturn(ZonedDateTime.now().minusDays(1));
-        when(first.getUtcExpiration()).thenReturn(ZonedDateTime.now().plusDays(1));
-        when(last.getZonedInception()).thenReturn(ZonedDateTime.now().plusDays(2));
-        when(last.getUtcInception()).thenReturn(ZonedDateTime.now().plusDays(2));
-        when(last.getUtcExpiration()).thenReturn(ZonedDateTime.now().plusDays(3));
+        when(first.getZonedInception()).thenReturn(ZonedDateTime.now(TEST_CLOCK).minusDays(1));
+        when(first.getUtcInception()).thenReturn(ZonedDateTime.now(TEST_CLOCK).minusDays(1));
+        when(first.getUtcExpiration()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(1));
+        when(last.getZonedInception()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(2));
+        when(last.getUtcInception()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(2));
+        when(last.getUtcExpiration()).thenReturn(ZonedDateTime.now(TEST_CLOCK).plusDays(3));
         when(last.getAvailableTickets()).thenReturn(5);
         when(first.getAvailableTickets()).thenReturn(5);
         assertFalse(EventUtil.isPreSales(event, categories));

--- a/src/test/java/alfio/util/ObjectDiffTest.java
+++ b/src/test/java/alfio/util/ObjectDiffTest.java
@@ -25,9 +25,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static alfio.test.util.IntegrationTestUtil.TEST_CLOCK;
+
 public class ObjectDiffTest {
 
-    ZonedDateTime now = ZonedDateTime.now();
+    ZonedDateTime now = ZonedDateTime.now(TEST_CLOCK);
 
     Ticket preUpdateTicket = new Ticket(42, "42", now, 1, Ticket.TicketStatus.ACQUIRED.name(), 42,
         "42", "full name", "full", "name", "email@email.com",

--- a/src/test/java/alfio/util/TemplateResourceTest.java
+++ b/src/test/java/alfio/util/TemplateResourceTest.java
@@ -31,6 +31,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 
+import static alfio.test.util.IntegrationTestUtil.TEST_CLOCK;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -73,9 +74,9 @@ public class TemplateResourceTest {
     }
 
     private Pair<ZonedDateTime, ZonedDateTime> getDates() {
-        ZonedDateTime eventBegin = ZonedDateTime.now().plusDays(1);
-        ZonedDateTime eventEnd = ZonedDateTime.now().plusDays(3);
-        ZonedDateTime validityStart = ZonedDateTime.now().plusDays(2);
+        ZonedDateTime eventBegin = ZonedDateTime.now(TEST_CLOCK).plusDays(1);
+        ZonedDateTime eventEnd = ZonedDateTime.now(TEST_CLOCK).plusDays(3);
+        ZonedDateTime validityStart = ZonedDateTime.now(TEST_CLOCK).plusDays(2);
 
         when(event.getBegin()).thenReturn(eventBegin);
         when(event.getZoneId()).thenReturn(ZoneId.systemDefault());

--- a/src/test/java/alfio/util/ValidatorTest.java
+++ b/src/test/java/alfio/util/ValidatorTest.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import static alfio.test.util.IntegrationTestUtil.TEST_CLOCK;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.*;
@@ -43,8 +44,8 @@ import static org.mockito.Mockito.when;
 
 public class ValidatorTest {
 
-    private static final DateTimeModification VALID_EXPIRATION = DateTimeModification.fromZonedDateTime(ZonedDateTime.now().plusHours(1L));
-    private static final DateTimeModification VALID_INCEPTION = DateTimeModification.fromZonedDateTime(ZonedDateTime.now().minusDays(1L));
+    private static final DateTimeModification VALID_EXPIRATION = DateTimeModification.fromZonedDateTime(ZonedDateTime.now(TEST_CLOCK).plusHours(1L));
+    private static final DateTimeModification VALID_INCEPTION = DateTimeModification.fromZonedDateTime(ZonedDateTime.now(TEST_CLOCK).minusDays(1L));
 
     private EventModification eventModification;
     private Errors errors;


### PR DESCRIPTION
Fix ErrorProne warnings by adding a "fixed" time zone, Europe/Zurich
We can evaluate afterwards to set an application-wide Clock in order to have a constant instant in the tests