### PR TITLE
fix issue #967, re-save the html in the email_message table when updating the status from SENT to WAITING, as it's removed after sending as a  space saving measure.

### DIFF
--- a/src/main/java/alfio/manager/NotificationManager.java
+++ b/src/main/java/alfio/manager/NotificationManager.java
@@ -244,7 +244,8 @@ public class NotificationManager {
         
         tx.execute(status -> {
             emailMessageRepository.findIdByEventIdAndChecksum(event.getId(), checksum).ifPresentOrElse(
-                id -> emailMessageRepository.updateStatus(event.getId(), WAITING.name(), id),
+                // see issue #967
+                id -> emailMessageRepository.updateStatusToWaitingWithHtml(event.getId(), id, renderedTemplate.getHtmlPart()),
                 () -> emailMessageRepository.insert(event.getId(), reservation.getId(), recipient, null, subject, renderedTemplate.getTextPart(), renderedTemplate.getHtmlPart(), encodedAttachments, checksum, ZonedDateTime.now(clockProvider.getClock()))
             );
             return null;
@@ -282,7 +283,10 @@ public class NotificationManager {
         //in order to minimize the database size, it is worth checking if there is already another message in the table
         Optional<Integer> existing = emailMessageRepository.findIdByEventIdAndChecksum(event.getId(), checksum);
 
-        existing.ifPresentOrElse(id -> emailMessageRepository.updateStatus(event.getId(), WAITING.name(), id),
+        existing.ifPresentOrElse(id ->
+            //see issue #967
+            emailMessageRepository.updateStatusToWaitingWithHtml(event.getId(), id, renderedTemplate.getHtmlPart())
+            ,
             () -> emailMessageRepository.insert(event.getId(), reservationId, recipient, encodedCC, subject, renderedTemplate.getTextPart(), renderedTemplate.getHtmlPart(), encodedAttachments, checksum, ZonedDateTime.now(clockProvider.getClock())));
     }
 

--- a/src/main/java/alfio/repository/EmailMessageRepository.java
+++ b/src/main/java/alfio/repository/EmailMessageRepository.java
@@ -55,8 +55,8 @@ public interface EmailMessageRepository {
     @Query("update email_message set status = :status where event_id = :eventId and checksum = :checksum and status in (:expectedStatuses)")
     int updateStatus(@Bind("eventId") int eventId, @Bind("checksum") String checksum, @Bind("status") String status, @Bind("expectedStatuses") List<String> expectedStatuses);
 
-    @Query("update email_message set status = :status where id = :messageId and event_id = :eventId")
-    int updateStatus(@Bind("eventId") int eventId, @Bind("status") String status, @Bind("messageId") int messageId);
+    @Query("update email_message set status = 'WAITING', html_message = :htmlMessage where id = :messageId and event_id = :eventId")
+    int updateStatusToWaitingWithHtml(@Bind("eventId") int eventId, @Bind("messageId") int messageId, @Bind("htmlMessage") String htmlMessage);
 
     @Query("update email_message set status = :status, attempts = :attempts where id = :messageId and status in (:expectedStatuses) ")
     int updateStatusAndAttempts(@Bind("messageId") int messageId, @Bind("status") String status, @Bind("attempts") int attempts, @Bind("expectedStatuses") List<String> expectedStatuses);


### PR DESCRIPTION
fix issue #967, re-save the html in the email_message table when updating the status from SENT to WAITING, as it's removed after sending as a  space saving measure.