### PR TITLE
load deja vu sans font from cached file

### DIFF
--- a/src/main/java/alfio/controller/support/TemplateProcessor.java
+++ b/src/main/java/alfio/controller/support/TemplateProcessor.java
@@ -21,13 +21,11 @@ import alfio.manager.FileUploadManager;
 import alfio.manager.support.PartialTicketTextGenerator;
 import alfio.model.*;
 import alfio.model.user.Organization;
+import alfio.util.ImageUtil;
 import alfio.util.TemplateManager;
 import alfio.util.TemplateResource;
 import ch.digitalfondue.jfiveparse.Parser;
 import ch.digitalfondue.jfiveparse.W3CDom;
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
-import com.github.benmanes.caffeine.cache.RemovalCause;
 import com.openhtmltopdf.extend.FSStream;
 import com.openhtmltopdf.extend.FSStreamFactory;
 import com.openhtmltopdf.pdfboxout.PdfBoxRenderer;
@@ -48,15 +46,6 @@ import java.util.stream.Collectors;
 
 @Log4j2
 public final class TemplateProcessor {
-
-    private static final Cache<String, File> FONT_CACHE = Caffeine.newBuilder()
-        .removalListener((String key, File value, RemovalCause cause) -> {
-            if(value != null) {
-                boolean result = value.delete();
-                log.trace("value {} deleted: {}", key, result);
-            }
-        })
-        .build();
 
     private TemplateProcessor() {}
 
@@ -127,32 +116,12 @@ public final class TemplateProcessor {
 
         builder.withW3cDocument(W3CDom.toW3CDocument(parser.parse(page)), "");
         try (PdfBoxRenderer renderer = builder.buildPdfRenderer()) {
-            File defaultFont = FONT_CACHE.get(DEJA_VU_SANS, TemplateProcessor::loadDejaVuFont);
-            if (defaultFont != null && !defaultFont.exists()) { // fallback, the cached font will not be shared though
-                FONT_CACHE.invalidate(DEJA_VU_SANS);
-                defaultFont = loadDejaVuFont(DEJA_VU_SANS);
-            }
+            File defaultFont = ImageUtil.getDejaVuSansMonoFont();
             if (defaultFont != null) {
                 renderer.getFontResolver().addFont(defaultFont, "DejaVu Sans Mono", null, null, false);
             }
             renderer.layout();
             renderer.createPDF();
-        }
-    }
-
-    private static final String DEJA_VU_SANS = "/alfio/font/DejaVuSansMono.ttf";
-
-    private static File loadDejaVuFont(String classPathResource) {
-        try {
-            File cachedFile = File.createTempFile("font-cache", ".tmp");
-            cachedFile.deleteOnExit();
-            try (InputStream is = new ClassPathResource(DEJA_VU_SANS).getInputStream(); OutputStream tmpOs = new FileOutputStream(cachedFile)) {
-                is.transferTo(tmpOs);
-            }
-            return cachedFile;
-        } catch (IOException e) {
-            log.warn("error while loading DejaVuSansMono.ttf font", e);
-            return null;
         }
     }
 


### PR DESCRIPTION
Should avoid the creation of too many temporary files when calling Font.createFont.