### PR TITLE
Generate tickets automatically for subscription owners

### DIFF
--- a/src/main/java/alfio/config/DataSourceConfiguration.java
+++ b/src/main/java/alfio/config/DataSourceConfiguration.java
@@ -21,6 +21,7 @@ import alfio.config.support.EnumTypeColumnMapper;
 import alfio.config.support.JSONColumnMapper;
 import alfio.config.support.PlatformProvider;
 import alfio.job.Jobs;
+import alfio.job.executor.AssignTicketToSubscriberJobExecutor;
 import alfio.job.executor.BillingDocumentJobExecutor;
 import alfio.job.executor.ReservationJobExecutor;
 import alfio.manager.*;
@@ -29,6 +30,8 @@ import alfio.manager.system.AdminJobManager;
 import alfio.manager.system.ConfigurationManager;
 import alfio.repository.EventDeleterRepository;
 import alfio.repository.EventRepository;
+import alfio.repository.SubscriptionRepository;
+import alfio.repository.TicketCategoryRepository;
 import alfio.repository.system.AdminJobQueueRepository;
 import alfio.repository.system.ConfigurationRepository;
 import alfio.repository.user.OrganizationRepository;
@@ -245,9 +248,10 @@ public class DataSourceConfiguration {
                                     PlatformTransactionManager transactionManager,
                                     ClockProvider clockProvider,
                                     ReservationJobExecutor reservationJobExecutor,
-                                    BillingDocumentJobExecutor billingDocumentJobExecutor) {
+                                    BillingDocumentJobExecutor billingDocumentJobExecutor,
+                                    AssignTicketToSubscriberJobExecutor assignTicketToSubscriberJobExecutor) {
         return new AdminJobManager(
-            List.of(reservationJobExecutor, billingDocumentJobExecutor),
+            List.of(reservationJobExecutor, billingDocumentJobExecutor, assignTicketToSubscriberJobExecutor),
             adminJobQueueRepository,
             transactionManager,
             clockProvider);
@@ -265,6 +269,21 @@ public class DataSourceConfiguration {
                                                           NotificationManager notificationManager,
                                                           OrganizationRepository organizationRepository) {
         return new BillingDocumentJobExecutor(billingDocumentManager, ticketReservationManager, eventRepository, notificationManager, organizationRepository);
+    }
+
+    @Bean
+    AssignTicketToSubscriberJobExecutor assignTicketToSubscriberJobExecutor(AdminReservationRequestManager requestManager,
+                                                                            ConfigurationManager configurationManager,
+                                                                            SubscriptionRepository subscriptionRepository,
+                                                                            EventRepository eventRepository,
+                                                                            ClockProvider clockProvider,
+                                                                            TicketCategoryRepository ticketCategoryRepository) {
+        return new AssignTicketToSubscriberJobExecutor(requestManager,
+            configurationManager,
+            subscriptionRepository,
+            eventRepository,
+            clockProvider,
+            ticketCategoryRepository);
     }
 
     @Bean

--- a/src/main/java/alfio/controller/api/v2/user/ReservationApiV2Controller.java
+++ b/src/main/java/alfio/controller/api/v2/user/ReservationApiV2Controller.java
@@ -36,10 +36,8 @@ import alfio.manager.payment.StripeCreditCardManager;
 import alfio.manager.support.PaymentResult;
 import alfio.manager.support.response.ValidatedResponse;
 import alfio.manager.system.ConfigurationManager;
-import alfio.manager.system.ReservationPriceCalculator;
 import alfio.manager.user.PublicUserManager;
 import alfio.model.*;
-import alfio.model.TicketCategory.TicketAccessType;
 import alfio.model.PurchaseContext.PurchaseContextType;
 import alfio.model.subscription.Subscription;
 import alfio.model.subscription.SubscriptionUsageExceeded;
@@ -58,36 +56,27 @@ import org.springframework.context.MessageSourceResolvable;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.util.Assert;
 import org.springframework.util.MultiValueMap;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.Errors;
-import org.springframework.validation.ValidationUtils;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.math.BigDecimal;
 import java.security.Principal;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.function.BiFunction;
-import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import static alfio.model.PriceContainer.VatStatus.*;
-import static alfio.model.system.ConfigurationKeys.*;
-import static alfio.util.MonetaryUtil.unitToCents;
-import static java.util.stream.Collectors.groupingBy;
+import static alfio.model.system.ConfigurationKeys.ENABLE_ITALY_E_INVOICING;
+import static alfio.model.system.ConfigurationKeys.FORCE_TICKET_OWNER_ASSIGNMENT_AT_RESERVATION;
 import static java.util.stream.Collectors.toMap;
-import static org.apache.commons.lang3.StringUtils.trimToNull;
 
 @RestController
 @AllArgsConstructor
@@ -620,7 +609,7 @@ public class ReservationApiV2Controller {
             return ResponseEntity.badRequest().build();
         }
 
-        Optional<ResponseEntity<TransactionInitializationToken>> responseEntity = getEventReservationPair(reservationId)
+        Optional<ResponseEntity<TransactionInitializationToken>> responseEntity = purchaseContextManager.getReservationWithPurchaseContext(reservationId)
             .map(pair -> {
                 var event = pair.getLeft();
                 return ticketReservationManager.initTransaction(event, reservationId, paymentMethod, allParams)
@@ -637,7 +626,7 @@ public class ReservationApiV2Controller {
     public ResponseEntity<Boolean> removeToken(@PathVariable("eventName") String eventName,
                                                @PathVariable("reservationId") String reservationId) {
 
-        var res = getEventReservationPair(reservationId).map(et -> paymentManager.removePaymentTokenReservation(et.getRight().getId())).orElse(false);
+        var res = purchaseContextManager.getReservationWithPurchaseContext(reservationId).map(et -> paymentManager.removePaymentTokenReservation(et.getRight().getId())).orElse(false);
         return ResponseEntity.ok(res);
     }
 
@@ -647,16 +636,8 @@ public class ReservationApiV2Controller {
     })
     public ResponseEntity<Boolean> deletePaymentAttempt(@PathVariable("reservationId") String reservationId) {
 
-        var res = getEventReservationPair(reservationId).map(et -> ticketReservationManager.cancelPendingPayment(et.getRight().getId(), et.getLeft())).orElse(false);
+        var res = purchaseContextManager.getReservationWithPurchaseContext(reservationId).map(et -> ticketReservationManager.cancelPendingPayment(et.getRight().getId(), et.getLeft())).orElse(false);
         return ResponseEntity.ok(res);
-    }
-
-    //FIXME: rename ->getPurchaseContextReservationPair
-    private Optional<Pair<PurchaseContext, TicketReservation>> getEventReservationPair(String reservationId) {
-        return purchaseContextManager.findByReservationId(reservationId)
-            .map(event -> Pair.of(event, ticketReservationManager.findById(reservationId)))
-            .filter(pair -> pair.getRight().isPresent())
-            .map(pair -> Pair.of(pair.getLeft(), pair.getRight().orElseThrow()));
     }
 
     @GetMapping({
@@ -673,7 +654,7 @@ public class ReservationApiV2Controller {
             return ResponseEntity.badRequest().build();
         }
 
-        return getEventReservationPair(reservationId)
+        return purchaseContextManager.getReservationWithPurchaseContext(reservationId)
             .flatMap(pair -> paymentManager.getTransactionStatus(pair.getRight(), paymentMethod))
             .map(pr -> ResponseEntity.ok(new ReservationPaymentResult(pr.isSuccessful(), pr.isRedirect(), pr.getRedirectUrl(), pr.isFailed(), pr.getGatewayIdOrNull())))
             .orElseGet(() -> ResponseEntity.notFound().build());
@@ -684,57 +665,14 @@ public class ReservationApiV2Controller {
         if(reservationCodeForm.getType() != ReservationCodeForm.ReservationCodeType.SUBSCRIPTION) {
             throw new IllegalStateException(reservationCodeForm.getType() + " not supported");
         }
-        boolean res = getEventReservationPair(reservationId).map(et -> {
-            boolean isUUID = reservationCodeForm.isCodeUUID();
-            log.trace("is code UUID {}", isUUID);
-            var pin = reservationCodeForm.getCode();
-            if (!isUUID && !PinGenerator.isPinValid(pin, Subscription.PIN_LENGTH)) {
-                bindingResult.reject("error.restrictedValue");
-                return false;
-            }
-
-            //ensure pin length, as we will do a like concat(pin,'%'), it could be dangerous to have an empty string...
-            Assert.isTrue(pin.length() >= Subscription.PIN_LENGTH, "Pin must have a length of at least 8 characters");
-
-            var partialUuid = !isUUID ? PinGenerator.pinToPartialUuid(pin, Subscription.PIN_LENGTH) : pin;
-            var email = reservationCodeForm.getEmail();
-            var requireEmail = false;
-            int count;
-            if (isUUID) {
-                count = subscriptionRepository.countSubscriptionById(UUID.fromString(pin));
-            } else {
-                count = subscriptionRepository.countSubscriptionByPartialUuid(partialUuid);
-                if (count > 1) {
-                    count = subscriptionRepository.countSubscriptionByPartialUuidAndEmail(partialUuid, email);
-                    requireEmail = true;
-                }
-            }
-            log.trace("code count is {}", count);
-            if (count == 0) {
-                bindingResult.reject(isUUID ? "subscription.uuid.not.found" : "subscription.pin.not.found");
-            }
-            if (count > 1) {
-                bindingResult.reject("subscription.code.insert.full");
-            }
-
-            if (bindingResult.hasErrors()) {
-                return false;
-            }
-
-            var subscriptionId = isUUID ? UUID.fromString(pin) : requireEmail ? subscriptionRepository.getSubscriptionIdByPartialUuidAndEmail(partialUuid, email) : subscriptionRepository.getSubscriptionIdByPartialUuid(partialUuid);
-            var subscriptionDescriptor = subscriptionRepository.findDescriptorBySubscriptionId(subscriptionId);
-            var subscription = subscriptionRepository.findSubscriptionById(subscriptionId);
-            subscription.isValid(Optional.of(bindingResult));
-            if (bindingResult.hasErrors()) {
-                return false;
-            }
-            try {
-                return ticketReservationManager.applySubscriptionCode(((Event)et.getLeft()).getId(), et.getRight(), subscriptionDescriptor, subscriptionId);
-            } catch (SubscriptionUsageExceeded | SubscriptionUsageExceededForEvent ex) {
-                bindingResult.reject(ex instanceof SubscriptionUsageExceeded ? "subscription.max-usage-reached" : "subscription.max-usage-reached-per-event");
-                return false;
-            }
-        }).orElse(false);
+        boolean res = purchaseContextManager.getReservationWithPurchaseContext(reservationId)
+            .map(et -> ticketReservationManager.validateAndApplySubscriptionCode(et.getLeft(),
+                et.getRight(),
+                reservationCodeForm.getCodeAsUUID(),
+                reservationCodeForm.getCode(),
+                reservationCodeForm.getEmail(),
+                bindingResult))
+            .orElse(false);
         return ResponseEntity.ok(ValidatedResponse.toResponse(bindingResult, res));
     }
 
@@ -742,7 +680,7 @@ public class ReservationApiV2Controller {
     public ResponseEntity<Boolean> removeCode(@PathVariable("reservationId") String reservationId, @RequestParam("type") ReservationCodeForm.ReservationCodeType type) {
         boolean res = false;
         if (type == ReservationCodeForm.ReservationCodeType.SUBSCRIPTION) {
-            res = getEventReservationPair(reservationId).map(et -> ticketReservationManager.removeSubscription(et.getRight())).orElse(false);
+            res = purchaseContextManager.getReservationWithPurchaseContext(reservationId).map(et -> ticketReservationManager.removeSubscription(et.getRight())).orElse(false);
         }
         return ResponseEntity.ok(res);
     }

--- a/src/main/java/alfio/controller/form/ReservationCodeForm.java
+++ b/src/main/java/alfio/controller/form/ReservationCodeForm.java
@@ -19,6 +19,7 @@ package alfio.controller.form;
 import lombok.Data;
 
 import java.io.Serializable;
+import java.util.Optional;
 import java.util.UUID;
 
 @Data
@@ -34,12 +35,11 @@ public class ReservationCodeForm implements Serializable {
         SUBSCRIPTION
     }
 
-    public boolean isCodeUUID() {
+    public Optional<UUID> getCodeAsUUID() {
         try {
-            UUID.fromString(code);
-            return true;
+            return Optional.of(UUID.fromString(code));
         } catch (IllegalArgumentException e) {
-            return false;
+            return Optional.empty();
         }
     }
 }

--- a/src/main/java/alfio/job/Jobs.java
+++ b/src/main/java/alfio/job/Jobs.java
@@ -95,6 +95,16 @@ public class Jobs {
         }
     }
 
+    @Scheduled(cron = "#{environment.acceptsProfiles('dev') ? '0 * * * * *' : '0 0 0/1 * * ?'}")
+    public void assignTicketsToSubscribers() {
+        log.trace("running job assignTicketsToSubscribers");
+        try {
+            adminJobManager.scheduleExecution(AdminJobExecutor.JobName.ASSIGN_TICKETS_TO_SUBSCRIBERS, Map.of());
+        } finally {
+            log.trace("end job sendOfflinePaymentReminderToEventOrganizers");
+        }
+    }
+
 
     @Scheduled(fixedRate = FIVE_SECONDS)
     public void sendEmails() {

--- a/src/main/java/alfio/job/executor/AssignTicketToSubscriberJobExecutor.java
+++ b/src/main/java/alfio/job/executor/AssignTicketToSubscriberJobExecutor.java
@@ -1,0 +1,152 @@
+/**
+ * This file is part of alf.io.
+ *
+ * alf.io is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * alf.io is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with alf.io.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package alfio.job.executor;
+
+import alfio.manager.AdminReservationRequestManager;
+import alfio.manager.system.AdminJobExecutor;
+import alfio.manager.system.ConfigurationManager;
+import alfio.model.Event;
+import alfio.model.TicketCategory;
+import alfio.model.modification.AdminReservationModification;
+import alfio.model.modification.AdminReservationModification.Attendee;
+import alfio.model.modification.AdminReservationModification.Category;
+import alfio.model.modification.AdminReservationModification.CustomerData;
+import alfio.model.modification.AdminReservationModification.TicketsInfo;
+import alfio.model.modification.DateTimeModification;
+import alfio.model.subscription.AvailableSubscriptionsByEvent;
+import alfio.model.system.AdminJobSchedule;
+import alfio.repository.EventRepository;
+import alfio.repository.SubscriptionRepository;
+import alfio.repository.TicketCategoryRepository;
+import alfio.util.ClockProvider;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static alfio.model.system.ConfigurationKeys.GENERATE_TICKETS_FOR_SUBSCRIPTIONS;
+
+@Component
+public class AssignTicketToSubscriberJobExecutor implements AdminJobExecutor {
+
+    private final AdminReservationRequestManager requestManager;
+    private final ConfigurationManager configurationManager;
+    private final SubscriptionRepository subscriptionRepository;
+    private final EventRepository eventRepository;
+    private final ClockProvider clockProvider;
+    private final TicketCategoryRepository ticketCategoryRepository;
+
+    public AssignTicketToSubscriberJobExecutor(AdminReservationRequestManager requestManager,
+                                               ConfigurationManager configurationManager,
+                                               SubscriptionRepository subscriptionRepository,
+                                               EventRepository eventRepository,
+                                               ClockProvider clockProvider,
+                                               TicketCategoryRepository ticketCategoryRepository) {
+        this.requestManager = requestManager;
+        this.configurationManager = configurationManager;
+        this.subscriptionRepository = subscriptionRepository;
+        this.eventRepository = eventRepository;
+        this.clockProvider = clockProvider;
+        this.ticketCategoryRepository = ticketCategoryRepository;
+    }
+
+    @Override
+    public Set<JobName> getJobNames() {
+        return EnumSet.of(JobName.ASSIGN_TICKETS_TO_SUBSCRIBERS);
+    }
+
+    @Override
+    public String process(AdminJobSchedule schedule) {
+        // 1. Find all subscriptions bought until now. Filters:
+        //     - subscription_descriptor_fk is linked to the current event
+        //     - id does not have any reservations attached to the current event
+        //     - validity_from is <= now()
+        //     - validity_to is null or > now()
+        //     - status = 'ACQUIRED'
+        var subscriptionsByEvent = subscriptionRepository.loadAvailableSubscriptionsByEvent()
+            .stream()
+            .collect(Collectors.groupingBy(AvailableSubscriptionsByEvent::getEventId));
+        if (!subscriptionsByEvent.isEmpty()) {
+            eventRepository.findByIds(subscriptionsByEvent.keySet()).forEach(event -> {
+                // 2. for each event check if the flag is active
+                boolean generationEnabled = configurationManager.getFor(GENERATE_TICKETS_FOR_SUBSCRIPTIONS, event.getConfigurationLevel())
+                    .getValueAsBooleanOrDefault();
+                if (generationEnabled) {
+                    var subscriptions = subscriptionsByEvent.get(event.getId());
+                    var categories = ticketCategoryRepository.findAllTicketCategories(event.getId());
+                    if (!categories.isEmpty()) {
+                        var category = categories.get(0);
+                        // 3. create reservation import request for the subscribers. ID is "AUTO_${eventShortName}_${now_ISO}"
+                        var requestId = String.format("AUTO_%s_%s", event.getShortName(), LocalDateTime.now(clockProvider.getClock()).format(DateTimeFormatter.ISO_DATE_TIME));
+                        requestManager.insertRequest(requestId,
+                            buildBody(event, subscriptions, category),
+                            event,
+                            false,
+                            "admin");
+
+                    }
+                }
+            });
+        }
+        return null;
+    }
+
+    private AdminReservationModification buildBody(Event event,
+                                                   List<AvailableSubscriptionsByEvent> subscriptions,
+                                                   TicketCategory category) {
+        var clock = clockProvider.getClock();
+        return new AdminReservationModification(
+            new DateTimeModification(LocalDate.now(clock), LocalTime.now(clock).plus(5L, ChronoUnit.MINUTES)),
+            new CustomerData("", "", "", null, "", null, null, null, null),
+            List.of(new TicketsInfo(
+                new Category(category.getId(), category.getName(), category.getPrice(), category.getTicketAccessType()),
+                toAttendees(subscriptions),
+                false,
+                false
+            )),
+            event.getContentLanguages().get(0).getLanguage(),
+            false,
+            false,
+            null,
+            null,
+            null,
+            null
+        );
+    }
+
+    private List<Attendee> toAttendees(List<AvailableSubscriptionsByEvent> subscriptions) {
+        return subscriptions.stream()
+            .map(s -> new Attendee(null,
+                s.getFirstName(),
+                s.getLastName(),
+                s.getEmailAddress(),
+                s.getUserLanguage(),
+                false,
+                s.getSubscriptionId() + "_auto",
+                s.getSubscriptionId(),
+                Map.of())
+            ).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/alfio/job/executor/AssignTicketToSubscriberJobExecutor.java
+++ b/src/main/java/alfio/job/executor/AssignTicketToSubscriberJobExecutor.java
@@ -22,10 +22,7 @@ import alfio.manager.system.ConfigurationManager;
 import alfio.model.Event;
 import alfio.model.TicketCategory;
 import alfio.model.modification.AdminReservationModification;
-import alfio.model.modification.AdminReservationModification.Attendee;
-import alfio.model.modification.AdminReservationModification.Category;
-import alfio.model.modification.AdminReservationModification.CustomerData;
-import alfio.model.modification.AdminReservationModification.TicketsInfo;
+import alfio.model.modification.AdminReservationModification.*;
 import alfio.model.modification.DateTimeModification;
 import alfio.model.subscription.AvailableSubscriptionsByEvent;
 import alfio.model.system.AdminJobSchedule;
@@ -130,7 +127,7 @@ public class AssignTicketToSubscriberJobExecutor implements AdminJobExecutor {
             false,
             false,
             null,
-            null,
+            new Notification(false, true),
             null,
             null
         );

--- a/src/main/java/alfio/manager/PurchaseContextManager.java
+++ b/src/main/java/alfio/manager/PurchaseContextManager.java
@@ -18,11 +18,13 @@ package alfio.manager;
 
 import alfio.manager.system.ConfigurationLevel;
 import alfio.model.PurchaseContext;
+import alfio.model.TicketReservation;
 import alfio.repository.EventRepository;
 import alfio.repository.SubscriptionRepository;
 import alfio.repository.TicketReservationRepository;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -85,5 +87,10 @@ public class PurchaseContextManager {
             log.warn("error while loading ConfigurationLevel", ex);
             return Optional.empty();
         }
+    }
+
+    public Optional<Pair<PurchaseContext, TicketReservation>> getReservationWithPurchaseContext(String reservationId) {
+        return findByReservationId(reservationId)
+            .map(event -> Pair.of(event, ticketReservationRepository.findReservationById(reservationId)));
     }
 }

--- a/src/main/java/alfio/manager/system/AdminJobExecutor.java
+++ b/src/main/java/alfio/manager/system/AdminJobExecutor.java
@@ -29,7 +29,8 @@ public interface AdminJobExecutor {
         SEND_OFFLINE_PAYMENT_REMINDER,
         UNKNOWN,
         SEND_OFFLINE_PAYMENT_TO_ORGANIZER,
-        REGENERATE_INVOICES;
+        REGENERATE_INVOICES,
+        ASSIGN_TICKETS_TO_SUBSCRIBERS;
 
         public static JobName safeValueOf(String value) {
             return Arrays.stream(values())

--- a/src/main/java/alfio/model/modification/AdminReservationModification.java
+++ b/src/main/java/alfio/model/modification/AdminReservationModification.java
@@ -45,6 +45,7 @@ public class AdminReservationModification implements Serializable {
     private final AdvancedBillingOptions advancedBillingOptions;
     private final Notification notification;
     private final SubscriptionDetails subscriptionDetails;
+    private final UUID linkedSubscriptionId;
 
     @JsonCreator
     public AdminReservationModification(@JsonProperty("expiration") DateTimeModification expiration,
@@ -55,7 +56,8 @@ public class AdminReservationModification implements Serializable {
                                         @JsonProperty("updateAdvancedBillingOptions") Boolean updateAdvancedBillingOptions,
                                         @JsonProperty("advancedBillingOptions") AdvancedBillingOptions advancedBillingOptions,
                                         @JsonProperty("notification") Notification notification,
-                                        @JsonProperty("subscriptionDetails") SubscriptionDetails subscriptionDetails) {
+                                        @JsonProperty("subscriptionDetails") SubscriptionDetails subscriptionDetails,
+                                        @JsonProperty("linkedSubscriptionId") UUID linkedSubscriptionId) {
         this.expiration = expiration;
         this.customerData = customerData;
         this.ticketsInfo = ticketsInfo;
@@ -65,6 +67,7 @@ public class AdminReservationModification implements Serializable {
         this.advancedBillingOptions = advancedBillingOptions;
         this.notification = notification;
         this.subscriptionDetails = subscriptionDetails;
+        this.linkedSubscriptionId = linkedSubscriptionId;
     }
 
     @Getter
@@ -166,6 +169,7 @@ public class AdminReservationModification implements Serializable {
         private final String language;
         private final boolean reassignmentForbidden;
         private final String reference;
+        private final UUID subscriptionId;
         private final Map<String, List<String>> additionalInfo;
 
         @JsonCreator
@@ -176,6 +180,7 @@ public class AdminReservationModification implements Serializable {
                         @JsonProperty("language") String language,
                         @JsonProperty("forbidReassignment") Boolean reassignmentForbidden,
                         @JsonProperty("reference") String reference,
+                        @JsonProperty("subscriptionId") UUID subscriptionId,
                         @JsonProperty("additionalInfo") Map<String, List<String>> additionalInfo) {
             this.ticketId = ticketId;
             this.firstName = trimToEmpty(firstName);
@@ -184,6 +189,7 @@ public class AdminReservationModification implements Serializable {
             this.language = language;
             this.reassignmentForbidden = Optional.ofNullable(reassignmentForbidden).orElse(false);
             this.reference = reference;
+            this.subscriptionId = subscriptionId;
             this.additionalInfo = Optional.ofNullable(additionalInfo).orElse(Collections.emptyMap());
         }
 
@@ -257,10 +263,27 @@ public class AdminReservationModification implements Serializable {
             List<TicketsInfo> ticketsInfo = src.ticketsInfo.stream().map(ti -> {
                 List<Attendee> attendees = ti.getAttendees()
                     .stream()
-                    .map(a -> new Attendee(a.ticketId, placeholderIfNotEmpty(a.firstName), placeholderIfNotEmpty(a.lastName), placeholderIfNotEmpty(a.emailAddress), a.language, a.reassignmentForbidden, a.reference,singletonMap("hasAdditionalInfo", singletonList(String.valueOf(a.additionalInfo.isEmpty()))))).collect(toList());
+                    .map(a -> new Attendee(a.ticketId,
+                        placeholderIfNotEmpty(a.firstName),
+                        placeholderIfNotEmpty(a.lastName),
+                        placeholderIfNotEmpty(a.emailAddress),
+                        a.language,
+                        a.reassignmentForbidden,
+                        a.reference,
+                        a.subscriptionId,
+                        singletonMap("hasAdditionalInfo", singletonList(String.valueOf(a.additionalInfo.isEmpty()))))).collect(toList());
                 return new TicketsInfo(ti.getCategory(), attendees, ti.isAddSeatsIfNotAvailable(), ti.isUpdateAttendees());
             }).collect(toList());
-            return Json.toJson(new AdminReservationModification(src.expiration, summaryForCustomerData(src.customerData), ticketsInfo, src.getLanguage(), src.updateContactData, src.updateAdvancedBillingOptions, src.advancedBillingOptions, src.notification, src.subscriptionDetails));
+            return Json.toJson(new AdminReservationModification(src.expiration,
+                summaryForCustomerData(src.customerData),
+                ticketsInfo,
+                src.getLanguage(),
+                src.updateContactData,
+                src.updateAdvancedBillingOptions,
+                src.advancedBillingOptions,
+                src.notification,
+                src.subscriptionDetails,
+                src.linkedSubscriptionId));
         } catch(Exception e) {
             return e.toString();
         }

--- a/src/main/java/alfio/model/subscription/AvailableSubscriptionsByEvent.java
+++ b/src/main/java/alfio/model/subscription/AvailableSubscriptionsByEvent.java
@@ -1,0 +1,68 @@
+/**
+ * This file is part of alf.io.
+ *
+ * alf.io is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * alf.io is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with alf.io.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package alfio.model.subscription;
+
+import ch.digitalfondue.npjt.ConstructorAnnotationRowMapper.Column;
+
+import java.util.UUID;
+
+public class AvailableSubscriptionsByEvent {
+    private final int eventId;
+    private final UUID subscriptionId;
+    private final String emailAddress;
+    private final String firstName;
+    private final String lastName;
+    private final String userLanguage;
+
+    public AvailableSubscriptionsByEvent(@Column("event_id") int eventId,
+                                         @Column("subscription_id") UUID subscriptionId,
+                                         @Column("email_address") String emailAddress,
+                                         @Column("first_name") String firstName,
+                                         @Column("last_name") String lastName,
+                                         @Column("user_language") String userLanguage) {
+        this.eventId = eventId;
+        this.subscriptionId = subscriptionId;
+        this.emailAddress = emailAddress;
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.userLanguage = userLanguage;
+    }
+
+    public int getEventId() {
+        return eventId;
+    }
+
+    public UUID getSubscriptionId() {
+        return subscriptionId;
+    }
+
+    public String getEmailAddress() {
+        return emailAddress;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public String getUserLanguage() {
+        return userLanguage;
+    }
+}

--- a/src/main/java/alfio/model/system/ConfigurationKeys.java
+++ b/src/main/java/alfio/model/system/ConfigurationKeys.java
@@ -256,7 +256,9 @@ public enum ConfigurationKeys {
     DESCRIPTION_MAXLENGTH("Max characters in descriptions (default 4000)", false, SettingCategory.GENERAL, ComponentType.TEXT, false, EnumSet.of(SYSTEM)),
 
     OPENID_PUBLIC_ENABLED("Enable OpenID for public users (default: false)", false, SettingCategory.OPENID, ComponentType.BOOLEAN, false, EnumSet.of(SYSTEM), "false"),
-    OPENID_CONFIGURATION_JSON("OpenID configuration", false, SettingCategory.OPENID, ComponentType.TEXTAREA, false, EnumSet.of(SYSTEM))
+    OPENID_CONFIGURATION_JSON("OpenID configuration", false, SettingCategory.OPENID, ComponentType.TEXTAREA, false, EnumSet.of(SYSTEM)),
+
+    GENERATE_TICKETS_FOR_SUBSCRIPTIONS("Generate and send tickets automatically to subscription holders for compatible events (default: false)", false, SettingCategory.SUBSCRIPTIONS, ComponentType.BOOLEAN, false, EnumSet.of(SYSTEM, ORGANIZATION), "false")
     ;
 
     @Getter
@@ -278,7 +280,8 @@ public enum ConfigurationKeys {
         PASS_INTEGRATION("Pass Integration"),
         WAITING_LIST("Waiting List"),
         IMPORT_ATTENDEE("Import Attendees"),
-        OPENID("Public users Authentication");
+        OPENID("Public users Authentication"),
+        SUBSCRIPTIONS("Subscriptions");
 
         private final String description;
         SettingCategory(String description) {

--- a/src/main/java/alfio/repository/AdminReservationRequestRepository.java
+++ b/src/main/java/alfio/repository/AdminReservationRequestRepository.java
@@ -49,6 +49,9 @@ public interface AdminReservationRequestRepository {
     @Query("select id from admin_reservation_request where status = 'PENDING' order by request_id limit :limit for update skip locked")
     List<Long> findPendingForUpdate(@Bind("limit") int limit);
 
+    @Query("select count(*) from admin_reservation_request where status = 'PENDING'")
+    Integer countPending();
+
     @Query("select * from admin_reservation_request where id = :id")
     AdminReservationRequest fetchCompleteById(@Bind("id") long id);
 

--- a/src/main/java/alfio/repository/SubscriptionRepository.java
+++ b/src/main/java/alfio/repository/SubscriptionRepository.java
@@ -18,13 +18,10 @@ package alfio.repository;
 
 import alfio.model.AllocationStatus;
 import alfio.model.PriceContainer.VatStatus;
-import alfio.model.subscription.EventSubscriptionLink;
-import alfio.model.subscription.Subscription;
-import alfio.model.subscription.SubscriptionDescriptor;
+import alfio.model.subscription.*;
 import alfio.model.subscription.SubscriptionDescriptor.SubscriptionTimeUnit;
 import alfio.model.subscription.SubscriptionDescriptor.SubscriptionUsageType;
 import alfio.model.subscription.SubscriptionDescriptor.SubscriptionValidityType;
-import alfio.model.subscription.SubscriptionDescriptorWithStatistics;
 import alfio.model.support.Array;
 import alfio.model.support.JSONData;
 import alfio.model.transaction.PaymentProxy;
@@ -162,6 +159,12 @@ public interface SubscriptionRepository {
     @Query("select * from subscription_descriptor_statistics where sd_organization_id_fk = :organizationId")
     List<SubscriptionDescriptorWithStatistics> findAllWithStatistics(@Bind("organizationId") int organizationId);
 
+    @Query("select exists (select 1 from subscription_event where event_id_fk = :eventId" +
+        " and subscription_descriptor_id_fk = :subscriptionDescriptorId::uuid and organization_id_fk = :organizationId)")
+    boolean isSubscriptionLinkedToEvent(@Bind("eventId") int eventId,
+                                        @Bind("subscriptionDescriptorId") UUID subscriptionDescriptorId,
+                                        @Bind("organizationId") int organizationId);
+
     @Query(INSERT_SUBSCRIPTION_LINK)
     int linkSubscriptionAndEvent(@Bind("subscriptionId") UUID subscriptionId,
                                  @Bind("eventId") int eventId,
@@ -293,4 +296,7 @@ public interface SubscriptionRepository {
 
     @Query("update subscription set status = 'CANCELLED' where reservation_id_fk = :reservationId")
     int cancelSubscriptions(@Bind("reservationId") String reservationId);
+
+    @Query("select * from available_subscriptions_by_event")
+    List<AvailableSubscriptionsByEvent> loadAvailableSubscriptionsByEvent();
 }

--- a/src/main/java/alfio/repository/TicketCategoryRepository.java
+++ b/src/main/java/alfio/repository/TicketCategoryRepository.java
@@ -91,6 +91,7 @@ public interface TicketCategoryRepository {
         "    and tcs.is_expired is FALSE" +
         "    and tcs.access_restricted is FALSE" +
         "    and (tcs.bounded is FALSE or tcs.not_sold_tickets > 0)" +
+        " order by tc.inception, tc.expiration, tc.id" +
         " limit 1")
     Optional<TicketCategory> findFirstWithAvailableTickets(@Bind("eventId") int eventId);
 

--- a/src/main/java/alfio/repository/TicketCategoryRepository.java
+++ b/src/main/java/alfio/repository/TicketCategoryRepository.java
@@ -85,6 +85,15 @@ public interface TicketCategoryRepository {
     @Query("select * from ticket_category_with_currency where event_id = :eventId  and tc_status = 'ACTIVE' order by ordinal asc, inception asc, expiration asc, id asc")
     List<TicketCategory> findAllTicketCategories(@Bind("eventId") int eventId);
 
+    @Query("select tc.* from ticket_category_with_currency tc" +
+        "    join ticket_category_statistics tcs on tc.id = tcs.ticket_category_id" +
+        "    where tc.event_id = :eventId" +
+        "    and tcs.is_expired is FALSE" +
+        "    and tcs.access_restricted is FALSE" +
+        "    and (tcs.bounded is FALSE or tcs.not_sold_tickets > 0)" +
+        " limit 1")
+    Optional<TicketCategory> findFirstWithAvailableTickets(@Bind("eventId") int eventId);
+
     default Map<Integer, TicketCategory> findByEventIdAsMap(int eventId) {
         return findAllTicketCategories(eventId).stream().collect(Collectors.toMap(TicketCategory::getId, Function.identity()));
     }

--- a/src/main/java/alfio/repository/TicketRepository.java
+++ b/src/main/java/alfio/repository/TicketRepository.java
@@ -43,7 +43,7 @@ public interface TicketRepository {
     String REVERT_TO_FREE = "update ticket set status = 'FREE' where status = 'RELEASED' and event_id = :eventId";
     String SORT_TICKETS = "order by category_id asc, uuid asc";
 
-    String RESET_TICKET = " TICKETS_RESERVATION_ID = null, FULL_NAME = null, EMAIL_ADDRESS = null, SPECIAL_PRICE_ID_FK = null, LOCKED_ASSIGNMENT = false, USER_LANGUAGE = null, REMINDER_SENT = false, SRC_PRICE_CTS = 0, FINAL_PRICE_CTS = 0, VAT_CTS = 0, DISCOUNT_CTS = 0, FIRST_NAME = null, LAST_NAME = null, EXT_REFERENCE = null, TAGS = array[]::text[], VAT_STATUS = null ";
+    String RESET_TICKET = " TICKETS_RESERVATION_ID = null, FULL_NAME = null, EMAIL_ADDRESS = null, SPECIAL_PRICE_ID_FK = null, LOCKED_ASSIGNMENT = false, USER_LANGUAGE = null, REMINDER_SENT = false, SRC_PRICE_CTS = 0, FINAL_PRICE_CTS = 0, VAT_CTS = 0, DISCOUNT_CTS = 0, FIRST_NAME = null, LAST_NAME = null, EXT_REFERENCE = null, TAGS = array[]::text[], VAT_STATUS = null, METADATA = '{}'::jsonb ";
     String RELEASE_TICKET_QUERY = "update ticket set status = 'RELEASED', uuid = :newUuid, " + RESET_TICKET + " where id = :ticketId and status in('ACQUIRED', 'PENDING', 'TO_BE_PAID') and tickets_reservation_id = :reservationId and event_id = :eventId";
 
 

--- a/src/main/resources/alfio/db/PGSQL/V204_2.0.0.41__CREATE_INDEX_SUBSCRIPTIONS.sql
+++ b/src/main/resources/alfio/db/PGSQL/V204_2.0.0.41__CREATE_INDEX_SUBSCRIPTIONS.sql
@@ -1,0 +1,24 @@
+--
+-- This file is part of alf.io.
+--
+-- alf.io is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- alf.io is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with alf.io.  If not, see <http://www.gnu.org/licenses/>.
+--
+
+create index idx_subscription_validity_to
+    on subscription (validity_to)
+    where (validity_to IS NOT NULL);
+
+create index idx_subscription_validity_from
+    on subscription (validity_from)
+    where (validity_from IS NOT NULL);

--- a/src/main/resources/alfio/db/PGSQL/afterMigrate__000_VIEW_drops.sql
+++ b/src/main/resources/alfio/db/PGSQL/afterMigrate__000_VIEW_drops.sql
@@ -30,3 +30,4 @@ drop view if exists basic_event_with_optional_subscription;
 drop view if exists reservation_and_subscription_and_tx;
 drop view if exists extension_capabilities;
 drop view if exists reservation_with_purchase_context;
+drop view if exists available_subscriptions_by_event;

--- a/src/main/resources/alfio/db/PGSQL/afterMigrate__015_VIEW_available_subscriptions_by_event.sql
+++ b/src/main/resources/alfio/db/PGSQL/afterMigrate__015_VIEW_available_subscriptions_by_event.sql
@@ -1,0 +1,51 @@
+--
+-- This file is part of alf.io.
+--
+-- alf.io is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- alf.io is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with alf.io.  If not, see <http://www.gnu.org/licenses/>.
+--
+
+create view available_subscriptions_by_event as (
+    with usage_by_subscription_id as (
+        select s.id subscription_id,
+               sum(case when t.subscription_id_fk is not null then 1 else 0 end) usage
+        from subscription s
+                 left join tickets_reservation t on t.subscription_id_fk = s.id
+        group by 1
+    ), subscription_expiration as (
+        select id,
+               coalesce(s.validity_from, 'yesterday'::timestamp) inception,
+               coalesce(s.validity_to, 'tomorrow'::timestamp) expiration
+        from subscription s
+    )
+    select e.id event_id,
+           s.id as subscription_id,
+           s.email_address as email_address,
+           s.first_name as first_name,
+           s.last_name as last_name,
+           r.user_language as user_language
+    from event e
+             join subscription_event se on se.event_id_fk = e.id
+             join subscription_descriptor sd on se.subscription_descriptor_id_fk = sd.id
+             join subscription s on sd.id = s.subscription_descriptor_fk
+             join usage_by_subscription_id u on s.id = u.subscription_id
+             join subscription_expiration exp on s.id = exp.id
+             join tickets_reservation r on r.id = s.reservation_id_fk
+    where e.end_ts > now() -- make sure that event is not in the past
+      and s.status = 'ACQUIRED'
+      and not exists(select id from tickets_reservation tr where tr.subscription_id_fk = s.id and tr.event_id_fk = e.id)
+      and exp.inception <= now()
+      and exp.expiration > now()
+      and (s.max_usage = -1 or s.max_usage > u.usage)
+    order by e.id
+);

--- a/src/main/webapp/resources/angular-templates/admin/partials/configuration/system.html
+++ b/src/main/webapp/resources/angular-templates/admin/partials/configuration/system.html
@@ -274,11 +274,20 @@
             </div>
         </div>
 
-        <div class="page-header">
+        <div class="page-header" id="IMPORT_ATTENDEES">
             <h2>Import Attendees</h2>
         </div>
         <div>
             <div data-ng-repeat="setting in systemConf.importAttendee.settings">
+                <setting data-obj="setting" data-display-delete-if-needed="true" data-delete-handler="systemConf.delete(config)"></setting>
+            </div>
+        </div>
+
+        <div class="page-header" id="SUBSCRIPTIONS">
+            <h2>Subscriptions</h2>
+        </div>
+        <div>
+            <div data-ng-repeat="setting in systemConf.subscriptions.settings">
                 <setting data-obj="setting" data-display-delete-if-needed="true" data-delete-handler="systemConf.delete(config)"></setting>
             </div>
         </div>

--- a/src/main/webapp/resources/js/admin/directive/admin-directive.js
+++ b/src/main/webapp/resources/js/admin/directive/admin-directive.js
@@ -1217,6 +1217,14 @@
                             {
                                 id: 'PAYMENT',
                                 name: 'Payment'
+                            },
+                            {
+                                id: 'IMPORT_ATTENDEES',
+                                name: 'Import Attendees'
+                            },
+                            {
+                                id: 'SUBSCRIPTIONS',
+                                name: 'Subscriptions'
                             }
                         ];
                     });

--- a/src/test/java/alfio/controller/api/v2/user/reservation/BaseReservationFlowTest.java
+++ b/src/test/java/alfio/controller/api/v2/user/reservation/BaseReservationFlowTest.java
@@ -1205,7 +1205,7 @@ public abstract class BaseReservationFlowTest extends BaseIntegrationTest {
     protected void testAddSubscription(ReservationFlowContext context, int numberOfTickets) {
         var form = new ReservationForm();
         var ticketReservation = new TicketReservationModification();
-        ticketReservation.setAmount(numberOfTickets);
+        ticketReservation.setQuantity(numberOfTickets);
         var categoriesResponse = eventApiV2Controller.getTicketCategories(context.event.getShortName(), null);
         assertTrue(categoriesResponse.getStatusCode().is2xxSuccessful());
         assertNotNull(categoriesResponse.getBody());

--- a/src/test/java/alfio/job/executor/AssignTicketToSubscriberJobExecutorIntegrationTest.java
+++ b/src/test/java/alfio/job/executor/AssignTicketToSubscriberJobExecutorIntegrationTest.java
@@ -1,0 +1,218 @@
+/**
+ * This file is part of alf.io.
+ *
+ * alf.io is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * alf.io is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with alf.io.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package alfio.job.executor;
+
+import alfio.TestConfiguration;
+import alfio.config.DataSourceConfiguration;
+import alfio.config.Initializer;
+import alfio.controller.api.ControllerConfiguration;
+import alfio.manager.AdminReservationRequestManager;
+import alfio.manager.EventManager;
+import alfio.manager.FileUploadManager;
+import alfio.manager.SubscriptionManager;
+import alfio.manager.user.UserManager;
+import alfio.model.Event;
+import alfio.model.Ticket;
+import alfio.model.TicketCategory;
+import alfio.model.TicketReservation;
+import alfio.model.metadata.AlfioMetadata;
+import alfio.model.modification.DateTimeModification;
+import alfio.model.modification.TicketCategoryModification;
+import alfio.model.modification.UploadBase64FileModification;
+import alfio.model.system.ConfigurationKeys;
+import alfio.model.transaction.PaymentProxy;
+import alfio.model.user.Role;
+import alfio.model.user.User;
+import alfio.repository.*;
+import alfio.repository.system.ConfigurationRepository;
+import alfio.repository.user.AuthorityRepository;
+import alfio.repository.user.OrganizationRepository;
+import alfio.repository.user.UserRepository;
+import alfio.test.util.IntegrationTestUtil;
+import alfio.util.BaseIntegrationTest;
+import alfio.util.ClockProvider;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static alfio.test.util.IntegrationTestUtil.*;
+import static alfio.test.util.IntegrationTestUtil.confirmAndLinkSubscription;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@ContextConfiguration(classes = {DataSourceConfiguration.class, TestConfiguration.class, ControllerConfiguration.class})
+@ActiveProfiles({Initializer.PROFILE_DEV, Initializer.PROFILE_DISABLE_JOBS, Initializer.PROFILE_INTEGRATION_TEST})
+@Transactional
+class AssignTicketToSubscriberJobExecutorIntegrationTest {
+
+    private static final Map<String, String> DESCRIPTION = Collections.singletonMap("en", "desc");
+    private static final String FIRST_CATEGORY_NAME = "default";
+
+    private final EventManager eventManager;
+    private final UserManager userManager;
+    private final SubscriptionManager subscriptionManager;
+    private final SubscriptionRepository subscriptionRepository;
+    private final FileUploadManager fileUploadManager;
+    private final ConfigurationRepository configurationRepository;
+    private final OrganizationRepository organizationRepository;
+    private final EventRepository eventRepository;
+    private final TicketReservationRepository ticketReservationRepository;
+    private final AssignTicketToSubscriberJobExecutor executor;
+    private final AdminReservationRequestRepository adminReservationRequestRepository;
+    private final AdminReservationRequestManager adminReservationRequestManager;
+    private final UserRepository userRepository;
+    private final AuthorityRepository authorityRepository;
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+    private final TicketRepository ticketRepository;
+    private final TicketCategoryRepository ticketCategoryRepository;
+
+    private Event event;
+    private String userId;
+
+    @Autowired
+    AssignTicketToSubscriberJobExecutorIntegrationTest(EventManager eventManager,
+                                                       UserManager userManager,
+                                                       SubscriptionManager subscriptionManager,
+                                                       SubscriptionRepository subscriptionRepository,
+                                                       FileUploadManager fileUploadManager,
+                                                       ConfigurationRepository configurationRepository,
+                                                       OrganizationRepository organizationRepository,
+                                                       EventRepository eventRepository,
+                                                       TicketReservationRepository ticketReservationRepository,
+                                                       AssignTicketToSubscriberJobExecutor executor,
+                                                       AdminReservationRequestRepository adminReservationRequestRepository,
+                                                       AdminReservationRequestManager adminReservationRequestManager,
+                                                       UserRepository userRepository,
+                                                       AuthorityRepository authorityRepository,
+                                                       NamedParameterJdbcTemplate jdbcTemplate,
+                                                       TicketRepository ticketRepository,
+                                                       TicketCategoryRepository ticketCategoryRepository) {
+        this.eventManager = eventManager;
+        this.userManager = userManager;
+        this.subscriptionManager = subscriptionManager;
+        this.subscriptionRepository = subscriptionRepository;
+        this.fileUploadManager = fileUploadManager;
+        this.configurationRepository = configurationRepository;
+        this.organizationRepository = organizationRepository;
+        this.eventRepository = eventRepository;
+        this.ticketReservationRepository = ticketReservationRepository;
+        this.executor = executor;
+        this.adminReservationRequestRepository = adminReservationRequestRepository;
+        this.adminReservationRequestManager = adminReservationRequestManager;
+        this.userRepository = userRepository;
+        this.authorityRepository = authorityRepository;
+        this.jdbcTemplate = jdbcTemplate;
+        this.ticketRepository = ticketRepository;
+        this.ticketCategoryRepository = ticketCategoryRepository;
+    }
+
+    @BeforeEach
+    void setUp() {
+        IntegrationTestUtil.ensureMinimalConfiguration(configurationRepository);
+        List<TicketCategoryModification> categories = Arrays.asList(
+            new TicketCategoryModification(null, FIRST_CATEGORY_NAME, TicketCategory.TicketAccessType.INHERIT, AVAILABLE_SEATS,
+                new DateTimeModification(LocalDate.now(ClockProvider.clock()).minusDays(1), LocalTime.now(ClockProvider.clock())),
+                new DateTimeModification(LocalDate.now(ClockProvider.clock()).plusDays(1), LocalTime.now(ClockProvider.clock())),
+                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()),
+            new TicketCategoryModification(null, "hidden", TicketCategory.TicketAccessType.INHERIT, 2,
+                new DateTimeModification(LocalDate.now(ClockProvider.clock()).minusDays(1), LocalTime.now(ClockProvider.clock())),
+                new DateTimeModification(LocalDate.now(ClockProvider.clock()).plusDays(1), LocalTime.now(ClockProvider.clock())),
+                DESCRIPTION, BigDecimal.ONE, true, "", true, null, null, null, null, null, 0, null, null, AlfioMetadata.empty())
+        );
+        Pair<Event, String> eventAndUser = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
+        var uploadFileForm = new UploadBase64FileModification();
+        uploadFileForm.setFile(BaseIntegrationTest.ONE_PIXEL_BLACK_GIF);
+        uploadFileForm.setName("my-image.gif");
+        uploadFileForm.setType("image/gif");
+        String fileBlobId = fileUploadManager.insertFile(uploadFileForm);
+        assertNotNull(fileBlobId);
+        this.event = eventAndUser.getLeft();
+        this.userId = eventAndUser.getRight();
+        // init admin user
+        userRepository.create(UserManager.ADMIN_USERNAME, "", "The", "Administrator", "admin@localhost", true, User.Type.INTERNAL, null, null);
+        authorityRepository.create(UserManager.ADMIN_USERNAME, Role.ADMIN.getRoleName());
+    }
+
+    @AfterEach
+    void tearDown() {
+        try {
+            eventManager.deleteEvent(event.getId(), userId);
+        } catch(Exception ex) {
+            //ignore exception because the transaction might be aborted
+        }
+    }
+
+    @Test
+    void process() {
+        int maxEntries = 2;
+        var descriptorId = createSubscriptionDescriptor(event.getOrganizationId(), fileUploadManager, subscriptionManager, maxEntries);
+        var subscriptionIdAndPin = confirmAndLinkSubscription(descriptorId, event.getOrganizationId(), subscriptionRepository, ticketReservationRepository, maxEntries);
+        subscriptionRepository.linkSubscriptionAndEvent(descriptorId, event.getId(), 0, event.getOrganizationId());
+        assertEquals(1, subscriptionRepository.loadAvailableSubscriptionsByEvent().size());
+        // trigger job schedule with flag not active
+        executor.process(null);
+        assertEquals(1, subscriptionRepository.loadAvailableSubscriptionsByEvent().size());
+        assertEquals(0, adminReservationRequestRepository.countPending());
+
+        // try again with flag active
+        configurationRepository.insert(ConfigurationKeys.GENERATE_TICKETS_FOR_SUBSCRIPTIONS.name(), "true", "");
+        executor.process(null);
+        assertEquals(1, subscriptionRepository.loadAvailableSubscriptionsByEvent().size());
+        assertEquals(1, adminReservationRequestRepository.countPending());
+
+        // trigger reservation processing
+        var result = adminReservationRequestManager.processPendingReservations();
+        assertEquals(1, result.getLeft()); //  1 success
+        assertEquals(0, result.getRight()); // 0 failures
+        assertEquals(0, subscriptionRepository.loadAvailableSubscriptionsByEvent().size());
+
+        // check ticket
+        var ticketUuid = jdbcTemplate.queryForObject("select uuid from ticket where event_id = :eventId and ext_reference = :ref",
+            Map.of("eventId", event.getId(), "ref", subscriptionIdAndPin.getLeft() + "_auto"),
+            String.class);
+        assertNotNull(ticketUuid);
+
+        // check category
+        var ticket = ticketRepository.findByUUID(ticketUuid);
+        assertEquals(Ticket.TicketStatus.ACQUIRED, ticket.getStatus());
+        var category = ticketCategoryRepository.getByIdAndActive(ticket.getCategoryId());
+        assertTrue(category.isPresent());
+        assertEquals(FIRST_CATEGORY_NAME, category.get().getName());
+
+        // check reservation
+        var reservation = ticketReservationRepository.findReservationById(ticket.getTicketsReservationId());
+        assertEquals(TicketReservation.TicketReservationStatus.COMPLETE, reservation.getStatus());
+        assertEquals(PaymentProxy.ADMIN, reservation.getPaymentMethod());
+        assertEquals(BigDecimal.ZERO, reservation.getFinalPrice());
+
+    }
+}

--- a/src/test/java/alfio/job/executor/AssignTicketToSubscriberJobExecutorIntegrationTest.java
+++ b/src/test/java/alfio/job/executor/AssignTicketToSubscriberJobExecutorIntegrationTest.java
@@ -53,13 +53,11 @@ import org.springframework.transaction.annotation.Transactional;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 import static alfio.test.util.IntegrationTestUtil.*;
-import static alfio.test.util.IntegrationTestUtil.confirmAndLinkSubscription;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
@@ -135,15 +133,15 @@ class AssignTicketToSubscriberJobExecutorIntegrationTest {
     @BeforeEach
     void setUp() {
         IntegrationTestUtil.ensureMinimalConfiguration(configurationRepository);
-        List<TicketCategoryModification> categories = Arrays.asList(
-            new TicketCategoryModification(null, FIRST_CATEGORY_NAME, TicketCategory.TicketAccessType.INHERIT, AVAILABLE_SEATS,
-                new DateTimeModification(LocalDate.now(ClockProvider.clock()).minusDays(1), LocalTime.now(ClockProvider.clock())),
-                new DateTimeModification(LocalDate.now(ClockProvider.clock()).plusDays(1), LocalTime.now(ClockProvider.clock())),
-                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()),
+        List<TicketCategoryModification> categories = List.of(
             new TicketCategoryModification(null, "hidden", TicketCategory.TicketAccessType.INHERIT, 2,
                 new DateTimeModification(LocalDate.now(ClockProvider.clock()).minusDays(1), LocalTime.now(ClockProvider.clock())),
                 new DateTimeModification(LocalDate.now(ClockProvider.clock()).plusDays(1), LocalTime.now(ClockProvider.clock())),
-                DESCRIPTION, BigDecimal.ONE, true, "", true, null, null, null, null, null, 0, null, null, AlfioMetadata.empty())
+                DESCRIPTION, BigDecimal.ONE, true, "", true, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()),
+            new TicketCategoryModification(null, FIRST_CATEGORY_NAME, TicketCategory.TicketAccessType.INHERIT, AVAILABLE_SEATS,
+                new DateTimeModification(LocalDate.now(ClockProvider.clock()).minusDays(1), LocalTime.now(ClockProvider.clock())),
+                new DateTimeModification(LocalDate.now(ClockProvider.clock()).plusDays(1), LocalTime.now(ClockProvider.clock())),
+                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty())
         );
         Pair<Event, String> eventAndUser = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         var uploadFileForm = new UploadBase64FileModification();

--- a/src/test/java/alfio/manager/AdminReservationManagerIntegrationTest.java
+++ b/src/test/java/alfio/manager/AdminReservationManagerIntegrationTest.java
@@ -179,7 +179,7 @@ public class AdminReservationManagerIntegrationTest extends BaseIntegrationTest 
         Category category = new Category(null, "name", new BigDecimal("100.00"), null);
         int attendees = AVAILABLE_SEATS;
         List<TicketsInfo> ticketsInfoList = Collections.singletonList(new TicketsInfo(category, generateAttendees(attendees), true, false));
-        AdminReservationModification modification = new AdminReservationModification(expiration, customerData, ticketsInfoList, "en", false, false, null, null, null);
+        AdminReservationModification modification = new AdminReservationModification(expiration, customerData, ticketsInfoList, "en", false, false, null, null, null, null);
         Result<Pair<TicketReservation, List<Ticket>>> result = adminReservationManager.createReservation(modification, event.getShortName(), username);
         assertTrue(result.isSuccess());
         Pair<TicketReservation, List<Ticket>> data = result.getData();
@@ -218,7 +218,7 @@ public class AdminReservationManagerIntegrationTest extends BaseIntegrationTest 
         Category resNewCategory = new Category(null, "name", new BigDecimal("100.00"), null);
         int attendees = 1;
         List<TicketsInfo> ticketsInfoList = Arrays.asList(new TicketsInfo(resExistingCategory, generateAttendees(attendees), false, false), new TicketsInfo(resNewCategory, generateAttendees(attendees), false, false),new TicketsInfo(resExistingCategory, generateAttendees(attendees), false, false));
-        AdminReservationModification modification = new AdminReservationModification(expiration, customerData, ticketsInfoList, "en", false,false, null, null, null);
+        AdminReservationModification modification = new AdminReservationModification(expiration, customerData, ticketsInfoList, "en", false,false, null, null, null, null);
         Result<Pair<TicketReservation, List<Ticket>>> result = adminReservationManager.createReservation(modification, event.getShortName(), username);
         assertTrue(result.isSuccess());
         Pair<TicketReservation, List<Ticket>> data = result.getData();
@@ -306,7 +306,7 @@ public class AdminReservationManagerIntegrationTest extends BaseIntegrationTest 
                 allAttendees.addAll(attendees);
                 return new TicketsInfo(category, attendees, addSeatsIfNotAvailable, false);
             }).collect(toList());
-        AdminReservationModification modification = new AdminReservationModification(expiration, customerData, ticketsInfoList, "en", false,false, null, null, null);
+        AdminReservationModification modification = new AdminReservationModification(expiration, customerData, ticketsInfoList, "en", false,false, null, null, null, null);
 
         if(reservedTickets > 0) {
             TicketReservationModification trm = new TicketReservationModification();
@@ -362,7 +362,7 @@ public class AdminReservationManagerIntegrationTest extends BaseIntegrationTest 
 
     private List<Attendee> generateAttendees(int count) {
         return IntStream.range(0, count)
-            .mapToObj(i -> new Attendee(null, "Attendee "+i, "Test" + i, "attendee"+i+"@test.ch", "en",false, null, Collections.emptyMap()))
+            .mapToObj(i -> new Attendee(null, "Attendee "+i, "Test" + i, "attendee"+i+"@test.ch", "en",false, null, null, Collections.emptyMap()))
             .collect(toList());
     }
 }


### PR DESCRIPTION
This new feature will enable organizers to generate and send tickets automatically to subscription owners for a given event.

The feature is not active by default and must be activated at system, organization or event level by enabling the following flag

![image](https://user-images.githubusercontent.com/3385346/144381084-e4fd1f07-3f10-4f6d-90d9-3f7cf097f1f8.png)

**implementation note**

- Tickets are generated in a batch job, run every hour
- All active subscribers will get **one** ticket from the **first available category** . This might change in the future


