### PR TITLE
Fix duplicate slug check

### DIFF
--- a/.github/workflows/build-on-push.yml
+++ b/.github/workflows/build-on-push.yml
@@ -39,7 +39,7 @@ jobs:
                   java-version: 11
             - name: Set up DB
               run: |
-                  apt-get install --yes postgresql-client
+                  sudo apt-get install --yes postgresql-client
                   psql -h 127.0.0.1 -U postgres postgres -c 'create database alfio;' -f src/test/init-db-user.sql
               env:
                   PGPASSWORD: postgres

--- a/.github/workflows/build-on-push.yml
+++ b/.github/workflows/build-on-push.yml
@@ -40,7 +40,7 @@ jobs:
             - name: Set up DB
               run: |
                   sudo apt-get install --yes postgresql-client
-                  psql -h 127.0.0.1 -U postgres postgres -c 'create database alfio;' -f src/test/init-db-user.sql
+                  psql -h 127.0.0.1 -U postgres postgres -c 'create database alfio;' -f src/test/resources/init-db-user.sql
               env:
                   PGPASSWORD: postgres
             - name: Build with Gradle

--- a/.github/workflows/build-on-push.yml
+++ b/.github/workflows/build-on-push.yml
@@ -7,14 +7,14 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                postgresql: ['9.6','13']
+                postgresql: ['9.6','14']
         services:
             postgres:
                 image: postgres:${{ matrix.postgresql }}
                 env:
                     POSTGRES_USER: postgres
                     POSTGRES_PASSWORD: postgres
-                    POSTGRES_DB: alfio
+                    POSTGRES_DB: postgres
                 ports:
                     - 5432:5432
                 # needed because the postgres container does not provide a healthcheck
@@ -37,6 +37,10 @@ jobs:
               uses: actions/setup-java@v1
               with:
                   java-version: 11
+            - name: Set up DB
+              uses: akanieski/setup-postgres-cli@v1
+              with:
+                commands: psql postgres -c 'create database alfio;' -f src/test/init-db-user.sql
             - name: Build with Gradle
               run: ./gradlew build distribution jacocoTestReport -Dspring.profiles.active=travis -Ddbenv=PGSQL-TRAVIS -Dpgsql${{ matrix.postgresql }}
 #            - name: upload-to-coveralls

--- a/.github/workflows/build-on-push.yml
+++ b/.github/workflows/build-on-push.yml
@@ -38,9 +38,11 @@ jobs:
               with:
                   java-version: 11
             - name: Set up DB
-              uses: akanieski/setup-postgres-cli@v1
-              with:
-                commands: psql postgres -c 'create database alfio;' -f src/test/init-db-user.sql
+              run: |
+                  apt-get install --yes postgresql-client
+                  psql -h 127.0.0.1 -U postgres postgres -c 'create database alfio;' -f src/test/init-db-user.sql
+              env:
+                  PGPASSWORD: postgres
             - name: Build with Gradle
               run: ./gradlew build distribution jacocoTestReport -Dspring.profiles.active=travis -Ddbenv=PGSQL-TRAVIS -Dpgsql${{ matrix.postgresql }}
 #            - name: upload-to-coveralls

--- a/src/main/java/alfio/config/DataSourceConfiguration.java
+++ b/src/main/java/alfio/config/DataSourceConfiguration.java
@@ -119,7 +119,7 @@ public class DataSourceConfiguration {
             // check
             boolean isSuperAdmin = Boolean.TRUE.equals(new NamedParameterJdbcTemplate(dataSource)
                 .queryForObject("select usesuper from pg_user where usename = CURRENT_USER",
-                    new EmptySqlParameterSource(),
+                    EmptySqlParameterSource.INSTANCE,
                     Boolean.class));
 
             if (isSuperAdmin) {

--- a/src/main/java/alfio/manager/EventNameManager.java
+++ b/src/main/java/alfio/manager/EventNameManager.java
@@ -16,7 +16,7 @@
  */
 package alfio.manager;
 
-import alfio.repository.EventRepository;
+import alfio.repository.EventAdminRepository;
 import lombok.AllArgsConstructor;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -40,7 +40,7 @@ public class EventNameManager {
     private static final Pattern NUMBER_MATCHER = Pattern.compile("^\\d+$");
     private static final String SPACES_AND_PUNCTUATION = "[\\s\\p{Punct}]";
     private static final String FIND_EVIL_CHARACTERS = "[^\\sA-Z\\-a-z0-9]";
-    private final EventRepository eventRepository;
+    private final EventAdminRepository eventAdminRepository;
 
     /**
      * Generates and returns a short name based on the given display name.<br>
@@ -100,6 +100,6 @@ public class EventNameManager {
     }
 
     public boolean isUnique(String shortName) {
-        return eventRepository.countByShortName(shortName) == 0;
+        return !eventAdminRepository.existsBySlug(shortName);
     }
 }

--- a/src/main/java/alfio/manager/system/DataMigrator.java
+++ b/src/main/java/alfio/manager/system/DataMigrator.java
@@ -266,7 +266,7 @@ public class DataMigrator {
 
     void fillReservationsLanguage() {
         transactionTemplate.execute(s -> {
-            jdbc.queryForList("select id from tickets_reservation where user_language is null", new EmptySqlParameterSource(), String.class)
+            jdbc.queryForList("select id from tickets_reservation where user_language is null", EmptySqlParameterSource.INSTANCE, String.class)
                     .forEach(id -> {
                         MapSqlParameterSource param = new MapSqlParameterSource("reservationId", id);
                         String language = optionally(() -> jdbc.queryForObject("select user_language from ticket where tickets_reservation_id = :reservationId limit 1", param, String.class)).orElse("en");

--- a/src/main/java/alfio/repository/EventAdminRepository.java
+++ b/src/main/java/alfio/repository/EventAdminRepository.java
@@ -37,9 +37,9 @@ public interface EventAdminRepository {
      */
     default boolean existsBySlug(String slug) {
         var jdbcTemplate = getJdbcTemplate();
-        boolean rlsEnabled = Boolean.TRUE.equals(jdbcTemplate.queryForObject("select coalesce(current_setting('alfio.checkRowAccess', true), 'false')", new EmptySqlParameterSource(), Boolean.class));
+        boolean rlsEnabled = Boolean.TRUE.equals(jdbcTemplate.queryForObject("select coalesce(current_setting('alfio.checkRowAccess', true), 'false')", EmptySqlParameterSource.INSTANCE, Boolean.class));
         if (rlsEnabled) {
-            jdbcTemplate.queryForObject("select set_config('alfio.checkRowAccess', 'false', true)", new EmptySqlParameterSource(), Boolean.class);
+            jdbcTemplate.queryForObject("select set_config('alfio.checkRowAccess', 'false', true)", EmptySqlParameterSource.INSTANCE, Boolean.class);
         }
         boolean exists = Boolean.TRUE.equals(jdbcTemplate.queryForObject(
             "select exists(select 1 from event where short_name = :slug)",
@@ -47,7 +47,7 @@ public interface EventAdminRepository {
             Boolean.class));
 
         if (rlsEnabled) {
-            jdbcTemplate.queryForObject("select set_config('alfio.checkRowAccess', 'true', true)", new EmptySqlParameterSource(), Boolean.class);
+            jdbcTemplate.queryForObject("select set_config('alfio.checkRowAccess', 'true', true)", EmptySqlParameterSource.INSTANCE, Boolean.class);
         }
         return exists;
     }

--- a/src/main/java/alfio/repository/EventAdminRepository.java
+++ b/src/main/java/alfio/repository/EventAdminRepository.java
@@ -1,0 +1,56 @@
+/**
+ * This file is part of alf.io.
+ *
+ * alf.io is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * alf.io is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with alf.io.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package alfio.repository;
+
+import ch.digitalfondue.npjt.QueryRepository;
+import org.springframework.jdbc.core.namedparam.EmptySqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+import java.util.Map;
+
+/**
+ * This repository is specific to backoffice/admin operations.
+ * It **must** be used from backoffice/admin components.
+ */
+@QueryRepository
+public interface EventAdminRepository {
+    /**
+     * Checks if an event with the given "slug" already exists.
+     * This method will temporarily deactivate Row Level Security in order to perform the check.
+     *
+     * @param slug the generated (or specified) slug
+     * @return true if the event exists
+     */
+    default boolean existsBySlug(String slug) {
+        var jdbcTemplate = getJdbcTemplate();
+        boolean rlsEnabled = Boolean.TRUE.equals(jdbcTemplate.queryForObject("select coalesce(current_setting('alfio.checkRowAccess', true), 'false')", new EmptySqlParameterSource(), Boolean.class));
+        if (rlsEnabled) {
+            jdbcTemplate.queryForObject("select set_config('alfio.checkRowAccess', 'false', true)", new EmptySqlParameterSource(), Boolean.class);
+        }
+        boolean exists = Boolean.TRUE.equals(jdbcTemplate.queryForObject(
+            "select exists(select 1 from event where short_name = :slug)",
+            Map.of("slug", slug),
+            Boolean.class));
+
+        if (rlsEnabled) {
+            jdbcTemplate.queryForObject("select set_config('alfio.checkRowAccess', 'true', true)", new EmptySqlParameterSource(), Boolean.class);
+        }
+        return exists;
+    }
+
+    NamedParameterJdbcTemplate getJdbcTemplate();
+}

--- a/src/main/java/alfio/repository/EventRepository.java
+++ b/src/main/java/alfio/repository/EventRepository.java
@@ -21,6 +21,9 @@ import alfio.model.*;
 import alfio.model.metadata.AlfioMetadata;
 import alfio.model.support.JSONData;
 import ch.digitalfondue.npjt.*;
+import org.springframework.jdbc.core.namedparam.EmptySqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.simple.SimpleJdbcCall;
 
 import java.math.BigDecimal;
 import java.time.ZoneId;
@@ -156,9 +159,6 @@ public interface EventRepository {
 
     @Query("update event set display_name = short_name where id = :eventId and display_name is null")
     int fillDisplayNameIfRequired(@Bind("eventId") int eventId);
-
-    @Query("select count(*) from event where short_name = :shortName")
-    Integer countByShortName(@Bind("shortName") String shortName);
 
     @Query("select id from event where end_ts > :now")
     List<Integer> findAllActiveIds(@Bind("now") ZonedDateTime now);

--- a/src/test/java/alfio/config/DataSourceConfigurationTest.java
+++ b/src/test/java/alfio/config/DataSourceConfigurationTest.java
@@ -28,7 +28,7 @@ import static org.mockito.Mockito.when;
 public class DataSourceConfigurationTest {
 
     private Environment environment;
-    private DataSourceConfiguration configuration = new DataSourceConfiguration();
+    private final DataSourceConfiguration configuration = new DataSourceConfiguration();
 
     @BeforeEach
     void init() {

--- a/src/test/java/alfio/manager/EventNameManagerIntegrationTest.java
+++ b/src/test/java/alfio/manager/EventNameManagerIntegrationTest.java
@@ -80,6 +80,12 @@ public class EventNameManagerIntegrationTest  extends BaseIntegrationTest {
 
     @BeforeEach
     void setUp() {
+
+        // ensure that the current user is not a superuser
+        assertEquals(Boolean.FALSE, jdbcTemplate.queryForObject("select usesuper from pg_user where usename = CURRENT_USER",
+                EmptySqlParameterSource.INSTANCE,
+                Boolean.class));
+
         List<TicketCategoryModification> categories = Collections.singletonList(
             new TicketCategoryModification(null, "default", TicketCategory.TicketAccessType.INHERIT, AVAILABLE_SEATS,
                 new DateTimeModification(LocalDate.now(clockProvider.getClock()), LocalTime.now(clockProvider.getClock())),
@@ -94,14 +100,14 @@ public class EventNameManagerIntegrationTest  extends BaseIntegrationTest {
 
     @Test
     void testValidSlug() {
-        assertEquals(Boolean.TRUE, jdbcTemplate.queryForObject("select set_config('alfio.checkRowAccess', 'true', true)", new EmptySqlParameterSource(), Boolean.class));
+        assertEquals(Boolean.TRUE, jdbcTemplate.queryForObject("select set_config('alfio.checkRowAccess', 'true', true)", EmptySqlParameterSource.INSTANCE, Boolean.class));
         assertEquals(String.valueOf(secondOrgId), jdbcTemplate.queryForObject("select set_config('alfio.currentUserOrgs', :orgs, true)", new MapSqlParameterSource("orgs", String.valueOf(secondOrgId)), String.class));
         assertTrue(eventNameManager.isUnique(event.getShortName() + "1"));
     }
 
     @Test
     void testAlreadyUsedSlug() {
-        assertEquals(Boolean.TRUE, jdbcTemplate.queryForObject("select set_config('alfio.checkRowAccess', 'true', true)", new EmptySqlParameterSource(), Boolean.class));
+        assertEquals(Boolean.TRUE, jdbcTemplate.queryForObject("select set_config('alfio.checkRowAccess', 'true', true)", EmptySqlParameterSource.INSTANCE, Boolean.class));
         assertEquals(String.valueOf(secondOrgId), jdbcTemplate.queryForObject("select set_config('alfio.currentUserOrgs', :orgs, true)", new MapSqlParameterSource("orgs", String.valueOf(secondOrgId)), String.class));
         assertFalse(eventNameManager.isUnique(event.getShortName()));
     }

--- a/src/test/java/alfio/manager/EventNameManagerIntegrationTest.java
+++ b/src/test/java/alfio/manager/EventNameManagerIntegrationTest.java
@@ -1,0 +1,108 @@
+/**
+ * This file is part of alf.io.
+ *
+ * alf.io is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * alf.io is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with alf.io.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package alfio.manager;
+
+import alfio.TestConfiguration;
+import alfio.config.DataSourceConfiguration;
+import alfio.config.Initializer;
+import alfio.manager.user.UserManager;
+import alfio.model.Event;
+import alfio.model.TicketCategory;
+import alfio.model.metadata.AlfioMetadata;
+import alfio.model.modification.DateTimeModification;
+import alfio.model.modification.TicketCategoryModification;
+import alfio.model.user.User;
+import alfio.repository.EventRepository;
+import alfio.repository.user.OrganizationRepository;
+import alfio.repository.user.UserRepository;
+import alfio.util.BaseIntegrationTest;
+import alfio.util.ClockProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.EmptySqlParameterSource;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static alfio.test.util.IntegrationTestUtil.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@ContextConfiguration(classes = {DataSourceConfiguration.class, TestConfiguration.class})
+@ActiveProfiles({Initializer.PROFILE_DEV, Initializer.PROFILE_DISABLE_JOBS, Initializer.PROFILE_INTEGRATION_TEST})
+@Transactional
+public class EventNameManagerIntegrationTest  extends BaseIntegrationTest {
+
+    @Autowired
+    private EventRepository eventRepository;
+    @Autowired
+    private EventManager eventManager;
+    @Autowired
+    private OrganizationRepository organizationRepository;
+    @Autowired
+    private UserManager userManager;
+    @Autowired
+    private ClockProvider clockProvider;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private NamedParameterJdbcTemplate jdbcTemplate;
+    @Autowired
+    private EventNameManager eventNameManager;
+
+    private Event event;
+    private Integer secondOrgId;
+
+    @BeforeEach
+    void setUp() {
+        List<TicketCategoryModification> categories = Collections.singletonList(
+            new TicketCategoryModification(null, "default", TicketCategory.TicketAccessType.INHERIT, AVAILABLE_SEATS,
+                new DateTimeModification(LocalDate.now(clockProvider.getClock()), LocalTime.now(clockProvider.getClock())),
+                new DateTimeModification(LocalDate.now(clockProvider.getClock()), LocalTime.now(clockProvider.getClock())),
+                DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));
+        var eventAndUsername = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
+        event = eventAndUsername.getKey();
+        String username = UUID.randomUUID().toString();
+        userRepository.create(username, "password", "", "", "", true, User.Type.INTERNAL, null, "");
+        secondOrgId = BaseIntegrationTest.createNewOrg(username, jdbcTemplate);
+    }
+
+    @Test
+    void testValidSlug() {
+        assertEquals(Boolean.TRUE, jdbcTemplate.queryForObject("select set_config('alfio.checkRowAccess', 'true', true)", new EmptySqlParameterSource(), Boolean.class));
+        assertEquals(String.valueOf(secondOrgId), jdbcTemplate.queryForObject("select set_config('alfio.currentUserOrgs', :orgs, true)", new MapSqlParameterSource("orgs", String.valueOf(secondOrgId)), String.class));
+        assertTrue(eventNameManager.isUnique(event.getShortName() + "1"));
+    }
+
+    @Test
+    void testAlreadyUsedSlug() {
+        assertEquals(Boolean.TRUE, jdbcTemplate.queryForObject("select set_config('alfio.checkRowAccess', 'true', true)", new EmptySqlParameterSource(), Boolean.class));
+        assertEquals(String.valueOf(secondOrgId), jdbcTemplate.queryForObject("select set_config('alfio.currentUserOrgs', :orgs, true)", new MapSqlParameterSource("orgs", String.valueOf(secondOrgId)), String.class));
+        assertFalse(eventNameManager.isUnique(event.getShortName()));
+    }
+}

--- a/src/test/java/alfio/manager/EventNameManagerTest.java
+++ b/src/test/java/alfio/manager/EventNameManagerTest.java
@@ -16,7 +16,7 @@
  */
 package alfio.manager;
 
-import alfio.repository.EventRepository;
+import alfio.repository.EventAdminRepository;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -26,8 +26,8 @@ import static org.mockito.Mockito.*;
 
 public class EventNameManagerTest {
 
-    private EventRepository eventRepository = mock(EventRepository.class);
-    private EventNameManager eventNameManager = new EventNameManager(eventRepository);
+    private final EventAdminRepository eventAdminRepository = mock(EventAdminRepository.class);
+    private final EventNameManager eventNameManager = new EventNameManager(eventAdminRepository);
 
     @Test
     public void testSingleWord() {
@@ -36,22 +36,22 @@ public class EventNameManagerTest {
 
     @Test
     public void dashedLowerCaseIfLessThan15Chars() {
-        when(eventRepository.countByShortName("my-event-2015")).thenReturn(0);
+        when(eventAdminRepository.existsBySlug("my-event-2015")).thenReturn(false);
         assertEquals("my-event-2015", eventNameManager.generateShortName("my Event 2015"));
     }
 
     @Test
     public void croppedNameIfMoreThan15Chars() {
-        when(eventRepository.countByShortName("vdt2016")).thenReturn(0);
-        when(eventRepository.countByShortName("vdz2016")).thenReturn(0);
+        when(eventAdminRepository.existsBySlug("vdt2016")).thenReturn(false);
+        when(eventAdminRepository.existsBySlug("vdz2016")).thenReturn(false);
         assertEquals("vdt2016", eventNameManager.generateShortName("Voxxed Days Ticino 2016"));
         assertEquals("vdz2016", eventNameManager.generateShortName("Voxxed Days Zürich 2016"));
     }
 
     @Test
     public void randomNameIfCroppedNotAvailable() {
-        when(eventRepository.countByShortName("vdt2016")).thenReturn(1);
-        when(eventRepository.countByShortName("vdz2016")).thenReturn(1);
+        when(eventAdminRepository.existsBySlug("vdt2016")).thenReturn(true);
+        when(eventAdminRepository.existsBySlug("vdz2016")).thenReturn(true);
         Assertions.assertNotEquals("vdt2016", eventNameManager.generateShortName("Voxxed Days Ticino 2016"));
         Assertions.assertNotEquals("vdz2016", eventNameManager.generateShortName("Voxxed Days Zürich 2016"));
     }
@@ -63,9 +63,9 @@ public class EventNameManagerTest {
 
     @Test
     public void giveUpAfter5Times() {
-        when(eventRepository.countByShortName(anyString())).thenReturn(1);
+        when(eventAdminRepository.existsBySlug(anyString())).thenReturn(true);
         assertEquals("", eventNameManager.generateShortName("Pippo Baudo and Friends 2017"));
-        verify(eventRepository, times(6)).countByShortName(anyString());
+        verify(eventAdminRepository, times(6)).existsBySlug(anyString());
     }
 
     @Test

--- a/src/test/java/alfio/test/util/IntegrationTestUtil.java
+++ b/src/test/java/alfio/test/util/IntegrationTestUtil.java
@@ -60,7 +60,7 @@ public class IntegrationTestUtil {
 
     static {
         DB_CONF.put("PGSQL", generateDBConfig("jdbc:postgresql://localhost:5432/alfio", "postgres", "password"));
-        DB_CONF.put("PGSQL-TRAVIS", generateDBConfig("jdbc:postgresql://localhost:5432/alfio", "postgres", "postgres"));
+        DB_CONF.put("PGSQL-TRAVIS", generateDBConfig("jdbc:postgresql://localhost:5432/alfio", "alfio_user", "password"));
     }
 
     public static Map<String, String> generateDBConfig(String url, String username, String password) {

--- a/src/test/resources/init-db-user.sql
+++ b/src/test/resources/init-db-user.sql
@@ -16,5 +16,4 @@
 --
 
 create role alfio_user with NOSUPERUSER NOINHERIT LOGIN ENCRYPTED PASSWORD 'password';
--- create database alfio;
 alter database alfio owner to alfio_user;

--- a/src/test/resources/init-db-user.sql
+++ b/src/test/resources/init-db-user.sql
@@ -1,0 +1,20 @@
+--
+-- This file is part of alf.io.
+--
+-- alf.io is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- alf.io is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with alf.io.  If not, see <http://www.gnu.org/licenses/>.
+--
+
+create role alfio_user with NOSUPERUSER NOINHERIT LOGIN ENCRYPTED PASSWORD 'password';
+-- create database alfio;
+alter database alfio owner to alfio_user;


### PR DESCRIPTION
In the context of a multi-tenant alf.io instance, we need to bypass the Row Security Policy when checking if a given "event slug" has been already defined