### PR TITLE
Promo code usage details

### DIFF
--- a/src/main/java/alfio/controller/api/admin/PromoCodeDiscountApiController.java
+++ b/src/main/java/alfio/controller/api/admin/PromoCodeDiscountApiController.java
@@ -31,7 +31,6 @@ import org.springframework.web.bind.annotation.*;
 import java.security.Principal;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
-import java.util.ArrayList;
 import java.util.List;
 
 @RestController

--- a/src/main/java/alfio/controller/api/admin/PromoCodeDiscountApiController.java
+++ b/src/main/java/alfio/controller/api/admin/PromoCodeDiscountApiController.java
@@ -31,6 +31,7 @@ import org.springframework.web.bind.annotation.*;
 import java.security.Principal;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.util.ArrayList;
 import java.util.List;
 
 @RestController

--- a/src/main/java/alfio/controller/api/admin/PromoCodeDiscountApiController.java
+++ b/src/main/java/alfio/controller/api/admin/PromoCodeDiscountApiController.java
@@ -17,23 +17,21 @@
 package alfio.controller.api.admin;
 
 import alfio.manager.EventManager;
+import alfio.manager.PromoCodeRequestManager;
 import alfio.model.PromoCodeDiscount;
+import alfio.model.PromoCodeUsageResult;
 import alfio.model.modification.PromoCodeDiscountModification;
 import alfio.model.modification.PromoCodeDiscountWithFormattedTimeAndAmount;
 import alfio.repository.EventRepository;
-import alfio.repository.PromoCodeDiscountRepository;
-import alfio.util.ClockProvider;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 import org.springframework.web.bind.annotation.*;
 
+import java.security.Principal;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.util.List;
-import java.util.Optional;
-
-import static alfio.model.PromoCodeDiscount.categoriesOrNull;
 
 @RestController
 @RequestMapping("/admin/api")
@@ -41,9 +39,8 @@ import static alfio.model.PromoCodeDiscount.categoriesOrNull;
 public class PromoCodeDiscountApiController {
 
     private final EventRepository eventRepository;
-    private final PromoCodeDiscountRepository promoCodeRepository;
     private final EventManager eventManager;
-    private final ClockProvider clockProvider;
+    private final PromoCodeRequestManager promoCodeRequestManager;
 
     @PostMapping("/promo-code")
     public void addPromoCode(@RequestBody PromoCodeDiscountModification promoCode) {
@@ -65,7 +62,7 @@ public class PromoCodeDiscountApiController {
 
     @PostMapping("/promo-code/{promoCodeId}")
     public void updatePromoCode(@PathVariable("promoCodeId") int promoCodeId, @RequestBody PromoCodeDiscountModification promoCode) {
-        PromoCodeDiscount pcd = promoCodeRepository.findById(promoCodeId);
+        PromoCodeDiscount pcd = promoCodeRequestManager.findById(promoCodeId).orElseThrow();
         ZoneId zoneId = zoneIdFromEventId(pcd.getEventId(), promoCode.getUtcOffset());
         eventManager.updatePromoCode(promoCodeId, promoCode.getStart().toZonedDateTime(zoneId),
             promoCode.getEnd().toZonedDateTime(zoneId), promoCode.getMaxUsage(), promoCode.getCategories(),
@@ -97,15 +94,22 @@ public class PromoCodeDiscountApiController {
     
     @PostMapping("/promo-code/{promoCodeId}/disable")
     public void disablePromoCode(@PathVariable("promoCodeId") int promoCodeId) {
-        promoCodeRepository.updateEventPromoCodeEnd(promoCodeId, ZonedDateTime.now(clockProvider.getClock()));
+        promoCodeRequestManager.disablePromoCode(promoCodeId);
     }
     
     @GetMapping("/promo-code/{promoCodeId}/count-use")
     public int countPromoCodeUse(@PathVariable("promoCodeId") int promoCodeId) {
-        Optional<PromoCodeDiscount> code = promoCodeRepository.findOptionalById(promoCodeId);
-        if(code.isEmpty()) {
-            return 0;
+        return promoCodeRequestManager.countUsage(promoCodeId);
+    }
+
+    @GetMapping("/promo-code/{promoCodeId}/detailed-usage")
+    public List<PromoCodeUsageResult> retrieveDetailedUsage(@PathVariable("promoCodeId") int promoCodeId,
+                                                            @RequestParam(value = "eventShortName", required = false) String eventShortName,
+                                                            Principal principal) {
+        Integer eventId = null;
+        if (StringUtils.isNotBlank(eventShortName)) {
+            eventId = eventManager.getEventAndOrganizationId(eventShortName, principal.getName()).getId();
         }
-        return promoCodeRepository.countConfirmedPromoCode(promoCodeId, categoriesOrNull(code.get()), null, categoriesOrNull(code.get()) != null ? "X" : null);
+        return promoCodeRequestManager.retrieveDetailedUsage(promoCodeId, eventId);
     }
 }

--- a/src/main/java/alfio/manager/PromoCodeRequestManager.java
+++ b/src/main/java/alfio/manager/PromoCodeRequestManager.java
@@ -20,6 +20,7 @@ import alfio.controller.form.ReservationForm;
 import alfio.manager.support.response.ValidatedResponse;
 import alfio.model.Event;
 import alfio.model.PromoCodeDiscount;
+import alfio.model.PromoCodeUsageResult;
 import alfio.model.SpecialPrice;
 import alfio.model.modification.TicketReservationModification;
 import alfio.model.result.ValidationResult;
@@ -44,6 +45,7 @@ import java.security.Principal;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.function.BiConsumer;
@@ -210,6 +212,28 @@ public class PromoCodeRequestManager {
                                                      Principal principal) {
         return ReservationUtil.validateCreateRequest(reservation, bindingResult, ticketReservationManager, eventManager, promoCodeDiscount.orElse(null), event)
             .flatMap(selected -> ticketReservationManager.createTicketReservation(event, selected.getLeft(), selected.getRight(), promoCodeDiscount, locale, bindingResult, principal));
+    }
+
+    public Optional<PromoCodeDiscount> findById(int id) {
+        return promoCodeRepository.findOptionalById(id);
+    }
+
+    public void disablePromoCode(int promoCodeId) {
+        promoCodeRepository.updateEventPromoCodeEnd(promoCodeId, ZonedDateTime.now(clockProvider.getClock()));
+    }
+
+    public int countUsage(int promoCodeId) {
+        Optional<PromoCodeDiscount> code = findById(promoCodeId);
+        if(code.isEmpty()) {
+            return 0;
+        }
+        return promoCodeRepository.countConfirmedPromoCode(promoCodeId, categoriesOrNull(code.get()), null, categoriesOrNull(code.get()) != null ? "X" : null);
+    }
+
+    public List<PromoCodeUsageResult> retrieveDetailedUsage(int promoCodeId, Integer eventId) {
+        return findById(promoCodeId)
+            .map(pc -> promoCodeRepository.findDetailedUsage(pc.getPromoCode(), eventId))
+            .orElse(List.of());
     }
 
 }

--- a/src/main/java/alfio/model/PromoCodeUsageResult.java
+++ b/src/main/java/alfio/model/PromoCodeUsageResult.java
@@ -1,0 +1,177 @@
+/**
+ * This file is part of alf.io.
+ *
+ * alf.io is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * alf.io is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with alf.io.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package alfio.model;
+
+import alfio.model.transaction.PaymentProxy;
+import alfio.util.Json;
+import alfio.util.MonetaryUtil;
+import ch.digitalfondue.npjt.ConstructorAnnotationRowMapper.Column;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import java.util.List;
+
+public class PromoCodeUsageResult {
+
+    private final String promoCode;
+    private final EventInfo event;
+    private final List<ReservationInfo> reservations;
+
+    public PromoCodeUsageResult(@Column("promo_code") String promoCode,
+                                @Column("event_short_name") String eventShortName,
+                                @Column("event_display_name") String eventDisplayName,
+                                @Column("reservations") String reservationsJson) {
+        this.promoCode = promoCode;
+        this.event = new EventInfo(eventShortName, eventDisplayName);
+        this.reservations = Json.fromJson(reservationsJson, new TypeReference<>() {});
+    }
+
+    public String getPromoCode() {
+        return promoCode;
+    }
+
+    public EventInfo getEvent() {
+        return event;
+    }
+
+    public List<ReservationInfo> getReservations() {
+        return reservations;
+    }
+
+    public static class ReservationInfo {
+        private final String id;
+        private final String invoiceNumber;
+        private final String firstName;
+        private final String lastName;
+        private final String email;
+        private final PaymentProxy paymentType;
+        private final Integer finalPriceCts;
+        private final String currency;
+        private final List<TicketInfo> tickets;
+
+        @JsonCreator
+        ReservationInfo(@JsonProperty("id") String id,
+                        @JsonProperty("invoiceNumber") String invoiceNumber,
+                        @JsonProperty("firstName") String firstName,
+                        @JsonProperty("lastName") String lastName,
+                        @JsonProperty("email") String email,
+                        @JsonProperty("paymentType") PaymentProxy paymentType,
+                        @JsonProperty("finalPriceCts") Integer finalPriceCts,
+                        @JsonProperty("currency") String currency,
+                        @JsonProperty("tickets") List<TicketInfo> tickets) {
+            this.id = id;
+            this.invoiceNumber = invoiceNumber;
+            this.firstName = firstName;
+            this.lastName = lastName;
+            this.email = email;
+            this.paymentType = paymentType;
+            this.finalPriceCts = finalPriceCts;
+            this.currency = currency;
+            this.tickets = tickets;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public String getInvoiceNumber() {
+            return invoiceNumber;
+        }
+
+        public String getFirstName() {
+            return firstName;
+        }
+
+        public String getLastName() {
+            return lastName;
+        }
+
+        public String getEmail() {
+            return email;
+        }
+
+        public PaymentProxy getPaymentType() {
+            return paymentType;
+        }
+
+        public String getFormattedAmount() {
+            if (finalPriceCts == null) {
+                return "";
+            }
+            return MonetaryUtil.formatCents(finalPriceCts, currency);
+        }
+
+        public List<TicketInfo> getTickets() {
+            return tickets;
+        }
+    }
+
+    public static class EventInfo {
+        private final String shortName;
+        private final String displayName;
+
+        @JsonCreator
+        private EventInfo(@JsonProperty("shortName") String shortName,
+                          @JsonProperty("displayName") String displayName) {
+            this.shortName = shortName;
+            this.displayName = displayName;
+        }
+
+        public String getShortName() {
+            return shortName;
+        }
+
+        public String getDisplayName() {
+            return displayName;
+        }
+    }
+
+    public static class TicketInfo {
+        private final String id;
+        private final String firstName;
+        private final String lastName;
+        private final String type;
+
+        @JsonCreator
+        private TicketInfo(@JsonProperty("id") String id,
+                           @JsonProperty("firstName") String firstName,
+                           @JsonProperty("lastName") String lastName,
+                           @JsonProperty("type") String type) {
+            this.id = id;
+            this.firstName = firstName;
+            this.lastName = lastName;
+            this.type = type;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public String getFirstName() {
+            return firstName;
+        }
+
+        public String getLastName() {
+            return lastName;
+        }
+
+        public String getType() {
+            return type;
+        }
+    }
+}

--- a/src/main/java/alfio/model/PromoCodeUsageResult.java
+++ b/src/main/java/alfio/model/PromoCodeUsageResult.java
@@ -24,7 +24,9 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class PromoCodeUsageResult {
 
@@ -38,7 +40,10 @@ public class PromoCodeUsageResult {
                                 @Column("reservations") String reservationsJson) {
         this.promoCode = promoCode;
         this.event = new EventInfo(eventShortName, eventDisplayName);
-        this.reservations = Json.fromJson(reservationsJson, new TypeReference<>() {});
+        List<ReservationInfo> parsed = Json.fromJson(reservationsJson, new TypeReference<>() {});
+        this.reservations = parsed.stream()
+            .sorted(Comparator.comparing(ReservationInfo::getConfirmationTimestamp))
+            .collect(Collectors.toList());
     }
 
     public String getPromoCode() {
@@ -62,6 +67,7 @@ public class PromoCodeUsageResult {
         private final PaymentProxy paymentType;
         private final Integer finalPriceCts;
         private final String currency;
+        private final String confirmationTimestamp;
         private final List<TicketInfo> tickets;
 
         @JsonCreator
@@ -73,6 +79,7 @@ public class PromoCodeUsageResult {
                         @JsonProperty("paymentType") PaymentProxy paymentType,
                         @JsonProperty("finalPriceCts") Integer finalPriceCts,
                         @JsonProperty("currency") String currency,
+                        @JsonProperty("confirmationTimestamp") String confirmationTimestamp,
                         @JsonProperty("tickets") List<TicketInfo> tickets) {
             this.id = id;
             this.invoiceNumber = invoiceNumber;
@@ -82,6 +89,7 @@ public class PromoCodeUsageResult {
             this.paymentType = paymentType;
             this.finalPriceCts = finalPriceCts;
             this.currency = currency;
+            this.confirmationTimestamp = confirmationTimestamp;
             this.tickets = tickets;
         }
 
@@ -116,6 +124,14 @@ public class PromoCodeUsageResult {
             return MonetaryUtil.formatCents(finalPriceCts, currency);
         }
 
+        public String getCurrency() {
+            return currency;
+        }
+
+        public String getConfirmationTimestamp() {
+            return confirmationTimestamp;
+        }
+
         public List<TicketInfo> getTickets() {
             return tickets;
         }
@@ -138,6 +154,10 @@ public class PromoCodeUsageResult {
 
         public String getDisplayName() {
             return displayName;
+        }
+
+        public String getPublicIdentifier() {
+            return getShortName();
         }
     }
 

--- a/src/main/java/alfio/repository/PromoCodeDiscountRepository.java
+++ b/src/main/java/alfio/repository/PromoCodeDiscountRepository.java
@@ -17,6 +17,7 @@
 package alfio.repository;
 
 import alfio.model.PromoCodeDiscount;
+import alfio.model.PromoCodeUsageResult;
 import ch.digitalfondue.npjt.Bind;
 import ch.digitalfondue.npjt.Query;
 import ch.digitalfondue.npjt.QueryRepository;
@@ -114,4 +115,9 @@ public interface PromoCodeDiscountRepository {
 
     @Query("select id from promo_code where code_type = 'ACCESS' and id = :id for update")
     Integer lockAccessCodeForUpdate(@Bind("id") int id);
+
+    @Query("select * from promocode_usage_details where promo_code = :promoCode" +
+        " and (:eventId is null or :eventId = event_id)")
+    List<PromoCodeUsageResult> findDetailedUsage(@Bind("promoCode") String promoCode,
+                                                 @Bind("eventId") Integer eventId);
 }

--- a/src/main/resources/alfio/db/PGSQL/afterMigrate__000_VIEW_drops.sql
+++ b/src/main/resources/alfio/db/PGSQL/afterMigrate__000_VIEW_drops.sql
@@ -31,3 +31,4 @@ drop view if exists reservation_and_subscription_and_tx;
 drop view if exists extension_capabilities;
 drop view if exists reservation_with_purchase_context;
 drop view if exists available_subscriptions_by_event;
+drop view if exists promocode_usage_details;

--- a/src/main/resources/alfio/db/PGSQL/afterMigrate__016_VIEW_promocode_usage_details.sql
+++ b/src/main/resources/alfio/db/PGSQL/afterMigrate__016_VIEW_promocode_usage_details.sql
@@ -1,0 +1,53 @@
+--
+-- This file is part of alf.io.
+--
+-- alf.io is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- alf.io is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with alf.io.  If not, see <http://www.gnu.org/licenses/>.
+--
+
+create view promocode_usage_details as (
+with tickets as (
+    select t.tickets_reservation_id, json_agg(jsonb_build_object(
+            'id', t.uuid,
+            'firstName', t.first_name,
+            'lastName', t.last_name,
+            'type', tc.name
+    )) items
+    from ticket t
+    join ticket_category tc on t.category_id = tc.id
+    group by t.tickets_reservation_id
+),
+reservations as (
+    select pc.promo_code, tr.event_id_fk,
+           jsonb_agg(jsonb_build_object(
+                   'id', tr.id,
+                   'invoiceNumber', tr.invoice_number,
+                   'firstName', tr.first_name,
+                   'lastName', tr.last_name,
+                   'email', tr.email_address,
+                   'paymentType', tr.payment_method,
+                   'finalPriceCts', tr.final_price_cts,
+                   'currency', tr.currency_code,
+                   'tickets', t.items
+               )) as agg
+    from tickets_reservation tr
+    join promo_code pc ON tr.promo_code_id_fk = pc.id and tr.event_id_fk = pc.event_id_fk
+    join tickets t on t.tickets_reservation_id = tr.id
+    where tr.promo_code_id_fk is not null and tr.status in ('OFFLINE_PAYMENT', 'DEFERRED_OFFLINE_PAYMENT', 'COMPLETE', 'CANCELLED')
+    group by pc.promo_code, tr.event_id_fk
+)
+select r.promo_code, e.id as event_id, e.short_name event_short_name, e.display_name event_display_name, r.agg reservations
+from event e
+    join reservations r on r.event_id_fk = e.id
+    order by 1
+);

--- a/src/main/resources/alfio/db/PGSQL/afterMigrate__016_VIEW_promocode_usage_details.sql
+++ b/src/main/resources/alfio/db/PGSQL/afterMigrate__016_VIEW_promocode_usage_details.sql
@@ -38,11 +38,13 @@ reservations as (
                    'paymentType', tr.payment_method,
                    'finalPriceCts', tr.final_price_cts,
                    'currency', tr.currency_code,
-                   'confirmationTimestamp', to_char(tr.confirmation_ts, 'YYYY-MM-DD') || 'T' || to_char(tr.confirmation_ts, 'HH24:MI:SS.MSZ'),
+                   'confirmationTimestamp', to_char(tr.confirmation_ts at time zone 'UTC', 'YYYY-MM-DD') || 'T' || to_char(tr.confirmation_ts at time zone 'UTC', 'HH24:MI:SS.MSZ'),
                    'tickets', t.items
                )) as agg
     from tickets_reservation tr
-    join promo_code pc ON tr.promo_code_id_fk = pc.id and tr.event_id_fk = pc.event_id_fk
+    join promo_code pc ON tr.promo_code_id_fk = pc.id and
+                          pc.organization_id_fk = tr.organization_id_fk and
+                          (pc.event_id_fk is null or tr.event_id_fk = pc.event_id_fk)
     join tickets t on t.tickets_reservation_id = tr.id
     where tr.promo_code_id_fk is not null and tr.status in ('OFFLINE_PAYMENT', 'DEFERRED_OFFLINE_PAYMENT', 'COMPLETE', 'CANCELLED')
     group by pc.promo_code, tr.event_id_fk

--- a/src/main/resources/alfio/db/PGSQL/afterMigrate__016_VIEW_promocode_usage_details.sql
+++ b/src/main/resources/alfio/db/PGSQL/afterMigrate__016_VIEW_promocode_usage_details.sql
@@ -38,6 +38,7 @@ reservations as (
                    'paymentType', tr.payment_method,
                    'finalPriceCts', tr.final_price_cts,
                    'currency', tr.currency_code,
+                   'confirmationTimestamp', to_char(tr.confirmation_ts, 'YYYY-MM-DD') || 'T' || to_char(tr.confirmation_ts, 'HH24:MI:SS.MSZ'),
                    'tickets', t.items
                )) as agg
     from tickets_reservation tr

--- a/src/main/webapp/resources/css/admin.css
+++ b/src/main/webapp/resources/css/admin.css
@@ -839,3 +839,15 @@ span.path {
 .bg-white {
     background-color: white;
 }
+
+.bg-gray {
+    background-color: #f9f9f9;
+}
+
+table.table.transparent {
+    background-color: transparent;
+}
+
+table.usage-details.tbody:not(:first-of-type) {
+    margin-top: 15px;
+}

--- a/src/main/webapp/resources/js/admin/feature/promo-codes/list.html
+++ b/src/main/webapp/resources/js/admin/feature/promo-codes/list.html
@@ -16,7 +16,7 @@
         </thead>
         <tbody>
         <tr data-ng-repeat="promocode in $ctrl.promocodes" data-ng-class="{'text-muted': promocode.expired}">
-            <td ng-if="promocode.useCount > 0"><a data-ui-sref="events.single.reservationsList({eventName: $ctrl.event.shortName, search: promocode.promoCode})" title="Find all reservations">{{::promocode.promoCode}}</a> <span data-ng-if="promocode.expired">(Expired)</span></td>
+            <td ng-if="promocode.useCount > 0"><a ng-click="$ctrl.openPromoCodeDetails(promocode)" title="Open usage details">{{::promocode.promoCode}}</a> <span data-ng-if="promocode.expired">(Expired)</span></td>
             <td ng-if="!promocode.useCount || promocode.useCount === 0">{{::promocode.promoCode}} <span data-ng-if="promocode.expired">(Expired)</span><span data-ng-if="!promocode.expired && promocode.codeType === 'DYNAMIC'">(auto)</span></td>
             <td class="text-right">{{promocode.useCount}}</td>
             <td class="text-right">{{promocode.maxUsage}}</td>

--- a/src/main/webapp/resources/js/admin/feature/promo-codes/promo-codes.js
+++ b/src/main/webapp/resources/js/admin/feature/promo-codes/promo-codes.js
@@ -13,7 +13,7 @@
             }
         })
         .component('promoCodeList', {
-            controller: [PromoCodeListCtrl],
+            controller: ['$uibModal', 'PromoCodeService', 'NotificationHandler', PromoCodeListCtrl],
             templateUrl: window.ALFIO_CONTEXT_PATH + '/resources/js/admin/feature/promo-codes/list.html',
             bindings: {
                 forEvent: '<',
@@ -28,7 +28,34 @@
             }
         });
 
-    function PromoCodeListCtrl() {}
+    function PromoCodeListCtrl($uibModal, PromoCodeService, NotificationHandler) {
+        var ctrl = this;
+        ctrl.openPromoCodeDetails = openPromoCodeDetails;
+
+        function openPromoCodeDetails(promoCode) {
+            PromoCodeService.getUsageDetails(promoCode.id, ctrl.event ? ctrl.event.shortName : '')
+                .then(function(result) {
+                    var data = result.data;
+                    if (data.length === 0) {
+                        NotificationHandler.showError('No reservations found.');
+                    } else {
+                        $uibModal.open({
+                            size: 'lg',
+                            templateUrl: window.ALFIO_CONTEXT_PATH + '/resources/js/admin/feature/promo-codes/usage-details.html',
+                            backdrop: 'static',
+                            controllerAs: '$ctrl',
+                            bindToController: true,
+                            controller: function($scope) {
+                                this.data = data;
+                                this.close = function() {
+                                    $scope.$dismiss();
+                                }
+                            }
+                        });
+                    }
+                });
+        }
+    }
 
     function PromoCodeCtrl($window, $uibModal, $q, PromoCodeService, ConfigurationService, UtilsService) {
         var ctrl = this;

--- a/src/main/webapp/resources/js/admin/feature/promo-codes/usage-details.html
+++ b/src/main/webapp/resources/js/admin/feature/promo-codes/usage-details.html
@@ -1,0 +1,61 @@
+<div class="modal-content">
+
+    <div class="modal-body">
+        <div ng-repeat="detail in $ctrl.data">
+            <div class="page-header">
+                <h3>Event: <em>{{detail.event.displayName}}</em></h3>
+            </div>
+
+            <table class="table usage-details">
+                <caption class="sr-only">Reservations for event detail</caption>
+                <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>Customer</th>
+                        <th>Payment</th>
+                        <th>Amount</th>
+                        <th>Confirmation</th>
+                    </tr>
+                </thead>
+                <tbody ng-repeat="reservation in detail.reservations" ng-class-odd="'bg-gray'">
+                    <tr>
+                        <td><a ui-sref="events.single.view-reservation({ eventName : detail.event.shortName, reservationId: reservation.id})" target="_blank"><reservation-identifier purchase-context="detail.event" purchase-context-type="'event'" reservation="reservation"></reservation-identifier></a></td>
+                        <td>{{reservation.firstName}} {{reservation.lastName}} &lt;{{reservation.email}}&gt;</td>
+                        <td>{{reservation.paymentType}}</td>
+                        <td><span ng-if="reservation.paymentType !== 'NONE'">{{reservation.currency}} {{reservation.formattedAmount}}</span></td>
+                        <td>{{reservation.confirmationTimestamp | formatDate}}</td>
+                    </tr>
+                    <tr>
+                        <td>&nbsp;</td>
+                        <td colspan="4">
+                            <table class="table transparent">
+                                <caption class="sr-only">Tickets</caption>
+                                <thead>
+                                    <tr>
+                                        <th style="font-weight: normal">Ticket ID</th>
+                                        <th style="font-weight: normal">Attendee</th>
+                                        <th style="font-weight: normal">Type</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                <tr ng-repeat="ticket in reservation.tickets">
+                                    <td>{{ticket.id | limitTo:8 | uppercase}}</td>
+                                    <td>{{ticket.firstName}} {{ticket.lastName}}</td>
+                                    <td>{{ticket.type}}</td>
+                                </tr>
+                                </tbody>
+                            </table>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+    <div class="modal-footer">
+        <div class="row">
+            <div class="col-md-4 col-md-push-8 col-xs-12">
+                <button class="btn btn-lg btn-warning btn-block" style="margin-bottom: 10px" ng-click="$ctrl.close()">Close</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/main/webapp/resources/js/admin/service/service.js
+++ b/src/main/webapp/resources/js/admin/service/service.js
@@ -719,6 +719,13 @@
                 update: function(promoCodeId, toUpdate) {
                     addUtfOffsetIfNecessary(toUpdate);
                     return $http.post('/admin/api/promo-code/' + promoCodeId, toUpdate);
+                },
+                getUsageDetails: function(promoCodeId, eventShortName) {
+                    return $http.get('/admin/api/promo-code/' + promoCodeId + '/detailed-usage', {
+                        params: {
+                            eventShortName
+                        }
+                    });
                 }
         };
     });

--- a/src/test/java/alfio/controller/api/v2/user/reservation/DiscountedReservationFlowIntegrationTest.java
+++ b/src/test/java/alfio/controller/api/v2/user/reservation/DiscountedReservationFlowIntegrationTest.java
@@ -1,0 +1,208 @@
+/**
+ * This file is part of alf.io.
+ *
+ * alf.io is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * alf.io is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with alf.io.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package alfio.controller.api.v2.user.reservation;
+
+import alfio.TestConfiguration;
+import alfio.config.DataSourceConfiguration;
+import alfio.config.Initializer;
+import alfio.controller.IndexController;
+import alfio.controller.api.ControllerConfiguration;
+import alfio.controller.api.admin.AdditionalServiceApiController;
+import alfio.controller.api.admin.CheckInApiController;
+import alfio.controller.api.admin.EventApiController;
+import alfio.controller.api.admin.UsersApiController;
+import alfio.controller.api.v1.AttendeeApiController;
+import alfio.controller.api.v2.InfoApiController;
+import alfio.controller.api.v2.TranslationsApiController;
+import alfio.controller.api.v2.model.ReservationInfo;
+import alfio.controller.api.v2.user.EventApiV2Controller;
+import alfio.controller.api.v2.user.ReservationApiV2Controller;
+import alfio.controller.api.v2.user.TicketApiV2Controller;
+import alfio.extension.ExtensionService;
+import alfio.manager.*;
+import alfio.manager.user.UserManager;
+import alfio.model.Event;
+import alfio.model.TicketCategory;
+import alfio.model.metadata.AlfioMetadata;
+import alfio.model.modification.DateTimeModification;
+import alfio.model.modification.TicketCategoryModification;
+import alfio.repository.*;
+import alfio.repository.audit.ScanAuditRepository;
+import alfio.repository.system.ConfigurationRepository;
+import alfio.repository.user.OrganizationRepository;
+import alfio.repository.user.UserRepository;
+import alfio.util.ClockProvider;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.security.Principal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static alfio.test.util.IntegrationTestUtil.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+@SpringBootTest
+@ContextConfiguration(classes = {DataSourceConfiguration.class, TestConfiguration.class, ControllerConfiguration.class})
+@ActiveProfiles({Initializer.PROFILE_DEV, Initializer.PROFILE_DISABLE_JOBS, Initializer.PROFILE_INTEGRATION_TEST})
+@Transactional
+class DiscountedReservationFlowIntegrationTest extends BaseReservationFlowTest {
+
+    private final OrganizationRepository organizationRepository;
+    private final UserManager userManager;
+
+    @Autowired
+    public DiscountedReservationFlowIntegrationTest(ConfigurationRepository configurationRepository,
+                                                    EventManager eventManager,
+                                                    EventRepository eventRepository,
+                                                    EventStatisticsManager eventStatisticsManager,
+                                                    TicketCategoryRepository ticketCategoryRepository,
+                                                    TicketReservationRepository ticketReservationRepository,
+                                                    EventApiController eventApiController,
+                                                    TicketRepository ticketRepository,
+                                                    TicketFieldRepository ticketFieldRepository,
+                                                    AdditionalServiceApiController additionalServiceApiController,
+                                                    SpecialPriceTokenGenerator specialPriceTokenGenerator,
+                                                    SpecialPriceRepository specialPriceRepository,
+                                                    CheckInApiController checkInApiController,
+                                                    AttendeeApiController attendeeApiController,
+                                                    UsersApiController usersApiController,
+                                                    ScanAuditRepository scanAuditRepository,
+                                                    AuditingRepository auditingRepository,
+                                                    AdminReservationManager adminReservationManager,
+                                                    TicketReservationManager ticketReservationManager,
+                                                    InfoApiController infoApiController,
+                                                    TranslationsApiController translationsApiController,
+                                                    EventApiV2Controller eventApiV2Controller,
+                                                    ReservationApiV2Controller reservationApiV2Controller,
+                                                    TicketApiV2Controller ticketApiV2Controller,
+                                                    IndexController indexController,
+                                                    NamedParameterJdbcTemplate jdbcTemplate,
+                                                    ExtensionLogRepository extensionLogRepository,
+                                                    ExtensionService extensionService,
+                                                    PollRepository pollRepository,
+                                                    ClockProvider clockProvider,
+                                                    NotificationManager notificationManager,
+                                                    UserRepository userRepository,
+                                                    OrganizationDeleter organizationDeleter,
+                                                    PromoCodeDiscountRepository promoCodeDiscountRepository,
+                                                    PromoCodeRequestManager promoCodeRequestManager,
+                                                    OrganizationRepository organizationRepository,
+                                                    UserManager userManager) {
+        super(configurationRepository,
+            eventManager,
+            eventRepository,
+            eventStatisticsManager,
+            ticketCategoryRepository,
+            ticketReservationRepository,
+            eventApiController,
+            ticketRepository,
+            ticketFieldRepository,
+            additionalServiceApiController,
+            specialPriceTokenGenerator,
+            specialPriceRepository,
+            checkInApiController,
+            attendeeApiController,
+            usersApiController,
+            scanAuditRepository,
+            auditingRepository,
+            adminReservationManager,
+            ticketReservationManager,
+            infoApiController,
+            translationsApiController,
+            eventApiV2Controller,
+            reservationApiV2Controller,
+            ticketApiV2Controller,
+            indexController,
+            jdbcTemplate,
+            extensionLogRepository,
+            extensionService,
+            pollRepository,
+            clockProvider,
+            notificationManager,
+            userRepository,
+            organizationDeleter,
+            promoCodeDiscountRepository,
+            promoCodeRequestManager);
+        this.organizationRepository = organizationRepository;
+        this.userManager = userManager;
+    }
+
+    @Test
+    void discountedInPersonEvent() throws Exception {
+        super.testBasicFlow(() -> {
+            List<TicketCategoryModification> categories = Arrays.asList(
+                new TicketCategoryModification(null, "default", TicketCategory.TicketAccessType.INHERIT, AVAILABLE_SEATS,
+                    new DateTimeModification(LocalDate.now(clockProvider.getClock()).minusDays(1), LocalTime.now(clockProvider.getClock())),
+                    new DateTimeModification(LocalDate.now(clockProvider.getClock()).plusDays(1), LocalTime.now(clockProvider.getClock())),
+                    DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()),
+                new TicketCategoryModification(null, "hidden", TicketCategory.TicketAccessType.INHERIT, 2,
+                    new DateTimeModification(LocalDate.now(clockProvider.getClock()).minusDays(1), LocalTime.now(clockProvider.getClock())),
+                    new DateTimeModification(LocalDate.now(clockProvider.getClock()).plusDays(1), LocalTime.now(clockProvider.getClock())),
+                    DESCRIPTION, BigDecimal.ONE, true, "", true, URL_CODE_HIDDEN, null, null, null, null, 0, null, null, AlfioMetadata.empty())
+            );
+            Pair<Event, String> eventAndUser = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
+            return new ReservationFlowContext(eventAndUser.getLeft(), eventAndUser.getRight() + "_owner", null, null, null, null, true, true);
+        });
+    }
+
+    @Override
+    protected void checkOrderSummary(ReservationInfo reservation) {
+        var orderSummary = reservation.getOrderSummary();
+        assertTrue(orderSummary.isNotYetPaid());
+        assertEquals("9.00", orderSummary.getTotalPrice());
+        assertEquals("0.09", orderSummary.getTotalVAT());
+        assertEquals("1.00", orderSummary.getVatPercentage());
+    }
+
+    protected void validatePayment(String eventName, String reservationIdentifier, ReservationFlowContext context) {
+        Principal principal = mock(Principal.class);
+        Mockito.when(principal.getName()).thenReturn(context.userId);
+        var reservation = ticketReservationRepository.findReservationById(reservationIdentifier);
+        assertEquals(900, reservation.getFinalPriceCts());
+        assertEquals(1000, reservation.getSrcPriceCts());
+        assertEquals(9, reservation.getVatCts());
+        assertEquals(100, reservation.getDiscountCts());
+        assertEquals(1, eventApiController.getPendingPayments(eventName).size());
+        assertEquals("OK", eventApiController.confirmPayment(eventName, reservationIdentifier, principal));
+        assertEquals(0, eventApiController.getPendingPayments(eventName).size());
+        assertEquals(900, eventRepository.getGrossIncome(context.event.getId()));
+    }
+
+    @Override
+    protected void checkDiscountUsage(String reservationId, int promoCodeId, ReservationFlowContext context) {
+        var promoCodeUsage = promoCodeRequestManager.retrieveDetailedUsage(promoCodeId, context.event.getId());
+        assertEquals(1, promoCodeUsage.size());
+        var usageDetail = promoCodeUsage.get(0);
+        assertEquals(PROMO_CODE, usageDetail.getPromoCode());
+        assertEquals(1, usageDetail.getReservations().size());
+        assertEquals(reservationId, usageDetail.getReservations().get(0).getId());
+        assertEquals(1, usageDetail.getReservations().get(0).getTickets().size());
+    }
+}

--- a/src/test/java/alfio/controller/api/v2/user/reservation/HybridEventReservationFlowIntegrationTest.java
+++ b/src/test/java/alfio/controller/api/v2/user/reservation/HybridEventReservationFlowIntegrationTest.java
@@ -107,7 +107,9 @@ class HybridEventReservationFlowIntegrationTest extends BaseReservationFlowTest 
                                                      PollRepository pollRepository,
                                                      NotificationManager notificationManager,
                                                      UserRepository userRepository,
-                                                     OrganizationDeleter organizationDeleter) {
+                                                     OrganizationDeleter organizationDeleter,
+                                                     PromoCodeDiscountRepository promoCodeDiscountRepository,
+                                                     PromoCodeRequestManager promoCodeRequestManager) {
         super(configurationRepository,
             eventManager,
             eventRepository,
@@ -140,7 +142,9 @@ class HybridEventReservationFlowIntegrationTest extends BaseReservationFlowTest 
             clockProvider,
             notificationManager,
             userRepository,
-            organizationDeleter);
+            organizationDeleter,
+            promoCodeDiscountRepository,
+            promoCodeRequestManager);
         this.organizationRepository = organizationRepository;
         this.userManager = userManager;
     }

--- a/src/test/java/alfio/controller/api/v2/user/reservation/OnlineEventReservationFlowIntegrationTest.java
+++ b/src/test/java/alfio/controller/api/v2/user/reservation/OnlineEventReservationFlowIntegrationTest.java
@@ -107,7 +107,9 @@ public class OnlineEventReservationFlowIntegrationTest extends BaseReservationFl
                                                      PollRepository pollRepository,
                                                      NotificationManager notificationManager,
                                                      UserRepository userRepository,
-                                                     OrganizationDeleter organizationDeleter) {
+                                                     OrganizationDeleter organizationDeleter,
+                                                     PromoCodeDiscountRepository promoCodeDiscountRepository,
+                                                     PromoCodeRequestManager promoCodeRequestManager) {
         super(configurationRepository,
             eventManager,
             eventRepository,
@@ -140,7 +142,9 @@ public class OnlineEventReservationFlowIntegrationTest extends BaseReservationFl
             clockProvider,
             notificationManager,
             userRepository,
-            organizationDeleter);
+            organizationDeleter,
+            promoCodeDiscountRepository,
+            promoCodeRequestManager);
         this.organizationRepository = organizationRepository;
         this.userManager = userManager;
     }
@@ -157,7 +161,7 @@ public class OnlineEventReservationFlowIntegrationTest extends BaseReservationFl
                 DESCRIPTION, BigDecimal.ONE, true, "", true, URL_CODE_HIDDEN, null, null, null, null, 0, null, null, AlfioMetadata.empty())
         );
         Pair<Event, String> eventAndUser = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository, null, Event.EventFormat.ONLINE);
-        return new ReservationFlowContext(eventAndUser.getLeft(), eventAndUser.getRight() + "_owner", null, null, null, null, false);
+        return new ReservationFlowContext(eventAndUser.getLeft(), eventAndUser.getRight() + "_owner", null, null, null, null, false, false);
     }
 
     @Test

--- a/src/test/java/alfio/controller/api/v2/user/reservation/ReservationFlowAuthenticatedUserIntegrationTest.java
+++ b/src/test/java/alfio/controller/api/v2/user/reservation/ReservationFlowAuthenticatedUserIntegrationTest.java
@@ -118,7 +118,9 @@ public class ReservationFlowAuthenticatedUserIntegrationTest extends BaseReserva
                                                            NotificationManager notificationManager,
                                                            UserRepository userRepository,
                                                            UserApiV2Controller publicUserApiController,
-                                                           OrganizationDeleter organizationDeleter) {
+                                                           OrganizationDeleter organizationDeleter,
+                                                           PromoCodeDiscountRepository promoCodeDiscountRepository,
+                                                           PromoCodeRequestManager promoCodeRequestManager) {
         super(configurationRepository,
             eventManager,
             eventRepository,
@@ -151,7 +153,9 @@ public class ReservationFlowAuthenticatedUserIntegrationTest extends BaseReserva
             clockProvider,
             notificationManager,
             userRepository,
-            organizationDeleter);
+            organizationDeleter,
+            promoCodeDiscountRepository,
+            promoCodeRequestManager);
         this.organizationRepository = organizationRepository;
         this.userManager = userManager;
         this.publicUserApiController = publicUserApiController;
@@ -171,7 +175,7 @@ public class ReservationFlowAuthenticatedUserIntegrationTest extends BaseReserva
         Pair<Event, String> eventAndUser = initEvent(categories, organizationRepository, userManager, eventManager, eventRepository);
         publicUserName = UUID.randomUUID().toString();
         var userIdContainer = userRepository.create(publicUserName, UUID.randomUUID().toString(), "First", "Last", "email@example.org", true, User.Type.PUBLIC, null, "");
-        return new ReservationFlowContext(eventAndUser.getLeft(), eventAndUser.getRight() + "_owner", null, null, publicUserName, userIdContainer.getKey(), true);
+        return new ReservationFlowContext(eventAndUser.getLeft(), eventAndUser.getRight() + "_owner", null, null, publicUserName, userIdContainer.getKey(), true, false);
     }
 
     @BeforeEach

--- a/src/test/java/alfio/controller/api/v2/user/reservation/ReservationFlowContext.java
+++ b/src/test/java/alfio/controller/api/v2/user/reservation/ReservationFlowContext.java
@@ -32,17 +32,18 @@ class ReservationFlowContext {
     final String publicUsername;
     final Integer publicUserId;
     final boolean checkInStationsEnabled;
+    final boolean applyDiscount;
     private final Authentication authentication;
 
     ReservationFlowContext(Event event, String userId) {
-        this(event, userId, null, null, null, null, true);
+        this(event, userId, null, null, null, null, true, false);
     }
 
     ReservationFlowContext(Event event, String userId, UUID subscriptionId, String subscriptionPin) {
-        this(event, userId, subscriptionId, subscriptionPin, null, null, true);
+        this(event, userId, subscriptionId, subscriptionPin, null, null, true, false);
     }
 
-    ReservationFlowContext(Event event, String userId, UUID subscriptionId, String subscriptionPin, String publicUsername, Integer publicUserId, boolean checkInStationsEnabled) {
+    ReservationFlowContext(Event event, String userId, UUID subscriptionId, String subscriptionPin, String publicUsername, Integer publicUserId, boolean checkInStationsEnabled, boolean applyDiscount) {
         this.event = event;
         this.userId = userId;
         this.subscriptionId = subscriptionId;
@@ -55,6 +56,7 @@ class ReservationFlowContext {
             this.authentication = null;
         }
         this.checkInStationsEnabled = checkInStationsEnabled;
+        this.applyDiscount = applyDiscount;
     }
 
     Principal getPublicUser() {

--- a/src/test/java/alfio/controller/api/v2/user/reservation/ReservationFlowIntegrationTest.java
+++ b/src/test/java/alfio/controller/api/v2/user/reservation/ReservationFlowIntegrationTest.java
@@ -59,12 +59,9 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
-import static alfio.test.util.IntegrationTestUtil.AVAILABLE_SEATS;
-import static alfio.test.util.IntegrationTestUtil.initEvent;
+import static alfio.test.util.IntegrationTestUtil.*;
 
 @SpringBootTest
 @ContextConfiguration(classes = {DataSourceConfiguration.class, TestConfiguration.class, ControllerConfiguration.class})
@@ -74,8 +71,6 @@ class ReservationFlowIntegrationTest extends BaseReservationFlowTest {
 
     private final OrganizationRepository organizationRepository;
     private final UserManager userManager;
-
-    private static final Map<String, String> DESCRIPTION = Collections.singletonMap("en", "desc");
 
     @Autowired
     public ReservationFlowIntegrationTest(OrganizationRepository organizationRepository,
@@ -112,7 +107,9 @@ class ReservationFlowIntegrationTest extends BaseReservationFlowTest {
                                           PollRepository pollRepository,
                                           NotificationManager notificationManager,
                                           UserRepository userRepository,
-                                          OrganizationDeleter organizationDeleter) {
+                                          OrganizationDeleter organizationDeleter,
+                                          PromoCodeDiscountRepository promoCodeDiscountRepository,
+                                          PromoCodeRequestManager promoCodeRequestManager) {
         super(configurationRepository,
             eventManager,
             eventRepository,
@@ -145,7 +142,9 @@ class ReservationFlowIntegrationTest extends BaseReservationFlowTest {
             clockProvider,
             notificationManager,
             userRepository,
-            organizationDeleter);
+            organizationDeleter,
+            promoCodeDiscountRepository,
+            promoCodeRequestManager);
         this.organizationRepository = organizationRepository;
         this.userManager = userManager;
     }

--- a/src/test/java/alfio/controller/api/v2/user/reservation/ReservationFlowWithSubscriptionIntegrationTest.java
+++ b/src/test/java/alfio/controller/api/v2/user/reservation/ReservationFlowWithSubscriptionIntegrationTest.java
@@ -135,7 +135,9 @@ class ReservationFlowWithSubscriptionIntegrationTest extends BaseReservationFlow
                                                           FileUploadManager fileUploadManager,
                                                           UserRepository userRepository,
                                                           PlatformTransactionManager platformTransactionManager,
-                                                          OrganizationDeleter organizationDeleter) {
+                                                          OrganizationDeleter organizationDeleter,
+                                                          PromoCodeDiscountRepository promoCodeDiscountRepository,
+                                                          PromoCodeRequestManager promoCodeRequestManager) {
         super(configurationRepository,
             eventManager,
             eventRepository,
@@ -168,7 +170,9 @@ class ReservationFlowWithSubscriptionIntegrationTest extends BaseReservationFlow
             clockProvider,
             notificationManager,
             userRepository,
-            organizationDeleter);
+            organizationDeleter,
+            promoCodeDiscountRepository,
+            promoCodeRequestManager);
         this.organizationRepository = organizationRepository;
         this.userManager = userManager;
         this.subscriptionManager = subscriptionManager;


### PR DESCRIPTION
This PR will introduce a new contextual view for promo codes.

Given a promo code which has already been used

![image](https://user-images.githubusercontent.com/3385346/198840193-bee9dfe4-9fc0-4420-a528-3d26b4d06c7d.png)

organizers can see the details of the reservations made using that particular promo code by clicking on its name:

![image](https://user-images.githubusercontent.com/3385346/198840224-1df3ec82-202c-4477-b65c-dde9eb905475.png)
