### PR TITLE
Manage multiple sponsors scan

### DIFF
--- a/src/main/java/alfio/controller/api/admin/EventApiController.java
+++ b/src/main/java/alfio/controller/api/admin/EventApiController.java
@@ -434,6 +434,7 @@ public class EventApiController {
         header.addAll(fields.stream().map(TicketFieldConfiguration::getName).collect(toList()));
         header.add("Sponsor notes");
         header.add("Lead Status");
+        header.add("Operator");
 
         Stream<String[]> sponsorScans = userManager.findAllEnabledUsers(principal.getName()).stream()
             .map(u -> Pair.of(u, userManager.getUserRole(u)))
@@ -460,6 +461,7 @@ public class EventApiController {
 
             line.add(sponsorScan.getNotes());
             line.add(sponsorScan.getLeadStatus().name());
+            line.add(sponsorScan.getOperator());
             return line.toArray(new String[0]);
         });
 

--- a/src/main/java/alfio/controller/api/v1/AttendeeApiController.java
+++ b/src/main/java/alfio/controller/api/v1/AttendeeApiController.java
@@ -51,6 +51,7 @@ import static alfio.util.Wrappers.optionally;
 @Log4j2
 public class AttendeeApiController {
 
+    public static final String ALFIO_OPERATOR_HEADER = "Alfio-Operator";
     private final AttendeeManager attendeeManager;
 
     @Autowired
@@ -72,15 +73,19 @@ public class AttendeeApiController {
 
 
     @PostMapping("/sponsor-scan")
-    public ResponseEntity<TicketAndCheckInResult> scanBadge(@RequestBody SponsorScanRequest request, Principal principal) {
-        return ResponseEntity.ok(attendeeManager.registerSponsorScan(request.eventName, request.ticketIdentifier, request.notes, request.leadStatus, principal.getName()));
+    public ResponseEntity<TicketAndCheckInResult> scanBadge(@RequestBody SponsorScanRequest request,
+                                                            Principal principal,
+                                                            @RequestHeader(name = ALFIO_OPERATOR_HEADER, required = false) String operator) {
+        return ResponseEntity.ok(attendeeManager.registerSponsorScan(request.eventName, request.ticketIdentifier, request.notes, request.leadStatus, principal.getName(), operator));
     }
 
     @PostMapping("/sponsor-scan/bulk")
-    public ResponseEntity<List<TicketAndCheckInResult>> scanBadges(@RequestBody List<SponsorScanRequest> requests, Principal principal) {
+    public ResponseEntity<List<TicketAndCheckInResult>> scanBadges(@RequestBody List<SponsorScanRequest> requests,
+                                                                   Principal principal,
+                                                                   @RequestHeader(name = ALFIO_OPERATOR_HEADER, required = false) String operator) {
         String username = principal.getName();
         return ResponseEntity.ok(requests.stream()
-            .map(request -> attendeeManager.registerSponsorScan(request.eventName, request.ticketIdentifier, request.notes, request.leadStatus, username))
+            .map(request -> attendeeManager.registerSponsorScan(request.eventName, request.ticketIdentifier, request.notes, request.leadStatus, username, operator))
             .collect(Collectors.toList()));
     }
 

--- a/src/main/java/alfio/model/DetailedScanData.java
+++ b/src/main/java/alfio/model/DetailedScanData.java
@@ -60,12 +60,13 @@ public class DetailedScanData {
                             @Column("s_event_id") int scanEventId,
                             @Column("s_ticket_id") int scanTicketId,
                             @Column("s_notes") String notes,
-                            @Column("s_lead_status") SponsorScan.LeadStatus leadStatus) {
+                            @Column("s_lead_status") SponsorScan.LeadStatus leadStatus,
+                            @Column("s_operator") String operator) {
         this.ticket = new Ticket(ticketId, ticketUuid, ticketCreation, ticketCategoryId,
             ticketStatus, ticketEventId, ticketsReservationId, ticketFullName, ticketFirstName,
             ticketLastName, ticketEmail, ticketLockedAssignment, ticketUserLanguage, ticketSrcPriceCts,
             ticketFinalPriceCts, ticketVatCts, ticketDiscountCts, extReference, currencyCode, ticketTags,
             ticketSubscriptionId, ticketVatStatus);
-        this.sponsorScan = new SponsorScan(scanUserId, scanTimestamp, scanEventId, scanTicketId, notes, leadStatus);
+        this.sponsorScan = new SponsorScan(scanUserId, scanTimestamp, scanEventId, scanTicketId, notes, leadStatus, operator);
     }
 }

--- a/src/main/java/alfio/model/SponsorScan.java
+++ b/src/main/java/alfio/model/SponsorScan.java
@@ -34,6 +34,7 @@ public class SponsorScan {
     private final int ticketId;
     private final String notes;
     private final LeadStatus leadStatus;
+    private final String operator;
 
 
     public SponsorScan(@Column("user_id") int userId,
@@ -41,12 +42,14 @@ public class SponsorScan {
                        @Column("event_id") int eventId,
                        @Column("ticket_id") int ticketId,
                        @Column("notes") String notes,
-                       @Column("lead_status") LeadStatus leadStatus) {
+                       @Column("lead_status") LeadStatus leadStatus,
+                       @Column("operator") String operator) {
         this.userId = userId;
         this.timestamp = timestamp;
         this.eventId = eventId;
         this.ticketId = ticketId;
         this.notes = notes;
         this.leadStatus = leadStatus;
+        this.operator = operator;
     }
 }

--- a/src/main/java/alfio/repository/SponsorScanRepository.java
+++ b/src/main/java/alfio/repository/SponsorScanRepository.java
@@ -33,29 +33,31 @@ public interface SponsorScanRepository {
 
     ZonedDateTime DEFAULT_TIMESTAMP = ZonedDateTime.ofInstant(Instant.EPOCH, ZoneOffset.UTC);
 
-    @Query("select creation from sponsor_scan where user_id = :userId and event_id = :eventId and ticket_id = :ticketId")
-    Optional<ZonedDateTime> getRegistrationTimestamp(@Bind("userId") int userId, @Bind("eventId") int eventId, @Bind("ticketId") int ticketId);
+    @Query("select creation from sponsor_scan where user_id = :userId and event_id = :eventId and ticket_id = :ticketId and operator = :operator")
+    Optional<ZonedDateTime> getRegistrationTimestamp(@Bind("userId") int userId, @Bind("eventId") int eventId, @Bind("ticketId") int ticketId, @Bind("operator") String operator);
 
-    @Query("insert into sponsor_scan (user_id, creation, event_id, ticket_id, notes, lead_status) values(:userId, :creation, :eventId, :ticketId, :notes, :leadStatus)")
+    @Query("insert into sponsor_scan (user_id, creation, event_id, ticket_id, notes, lead_status, operator) values(:userId, :creation, :eventId, :ticketId, :notes, :leadStatus, :operator)")
     int insert(@Bind("userId") int userId,
                @Bind("creation") ZonedDateTime creation,
                @Bind("eventId") int eventId,
                @Bind("ticketId") int ticketId,
                @Bind("notes") String notes,
-               @Bind("leadStatus") SponsorScan.LeadStatus leadStatus);
+               @Bind("leadStatus") SponsorScan.LeadStatus leadStatus,
+               @Bind("operator") String operator);
 
-    @Query("update sponsor_scan set notes = :notes, lead_status = :leadStatus where user_id = :userId and event_id = :eventId and ticket_id = :ticketId")
+    @Query("update sponsor_scan set notes = :notes, lead_status = :leadStatus where user_id = :userId and event_id = :eventId and ticket_id = :ticketId and operator = :operator")
     int updateNotesAndLeadStatus(@Bind("userId") int userId,
                                  @Bind("eventId") int eventId,
                                  @Bind("ticketId") int ticketId,
                                  @Bind("notes") String notes,
-                                 @Bind("leadStatus") SponsorScan.LeadStatus leadStatus);
+                                 @Bind("leadStatus") SponsorScan.LeadStatus leadStatus,
+                                 @Bind("operator") String operator);
 
     @Query("select t.id t_id, t.uuid t_uuid, t.creation t_creation, t.category_id t_category_id, t.status t_status, t.event_id t_event_id," +
         " t.src_price_cts t_src_price_cts, t.final_price_cts t_final_price_cts, t.vat_cts t_vat_cts, t.discount_cts t_discount_cts, t.tickets_reservation_id t_tickets_reservation_id," +
         " t.full_name t_full_name, t.first_name t_first_name, t.last_name t_last_name, t.email_address t_email_address, t.locked_assignment t_locked_assignment," +
         " t.user_language t_user_language, t.ext_reference t_ext_reference, t.currency_code t_currency_code, t.tags t_tags, t.subscription_id_fk t_subscription_id, t.vat_status t_vat_status," +
-        " s.user_id s_user_id, s.creation s_creation, s.event_id s_event_id, s.ticket_id s_ticket_id, s.notes s_notes, s.lead_status s_lead_status, " +
+        " s.user_id s_user_id, s.creation s_creation, s.event_id s_event_id, s.ticket_id s_ticket_id, s.notes s_notes, s.lead_status s_lead_status, s.operator s_operator, " +
         " (case when s.lead_status = 'HOT' then 2 when s.lead_status = 'WARM' then 1 else 0 end) as priority"+
         " from sponsor_scan s, ticket t where s.event_id = :eventId and s.user_id = :userId and s.creation > :start and s.ticket_id = t.id order by priority desc, s.creation")
     List<DetailedScanData> loadSponsorData(@Bind("eventId") int eventId,

--- a/src/main/resources/alfio/db/PGSQL/V204_2.0.0.49.5__SPONSOR_SCAN_OPERATOR.sql
+++ b/src/main/resources/alfio/db/PGSQL/V204_2.0.0.49.5__SPONSOR_SCAN_OPERATOR.sql
@@ -1,0 +1,21 @@
+--
+-- This file is part of alf.io.
+--
+-- alf.io is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- alf.io is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with alf.io.  If not, see <http://www.gnu.org/licenses/>.
+--
+
+alter table sponsor_scan add column operator text not null default '__DEFAULT__';
+alter table sponsor_scan drop constraint "spsc_unique_ticket";
+alter table sponsor_scan add constraint "spsc_unique_ticket" unique(event_id, ticket_id, user_id, operator);
+

--- a/src/test/java/alfio/controller/api/v2/user/reservation/BaseReservationFlowTest.java
+++ b/src/test/java/alfio/controller/api/v2/user/reservation/BaseReservationFlowTest.java
@@ -39,6 +39,7 @@ import alfio.extension.ExtensionService;
 import alfio.manager.*;
 import alfio.manager.support.CheckInStatus;
 import alfio.manager.support.IncompatibleStateException;
+import alfio.manager.support.SponsorAttendeeData;
 import alfio.manager.support.TicketAndCheckInResult;
 import alfio.manager.support.extension.ExtensionEvent;
 import alfio.model.*;
@@ -1059,9 +1060,9 @@ public abstract class BaseReservationFlowTest extends BaseIntegrationTest {
                 Mockito.when(sponsorPrincipal.getName()).thenReturn(sponsorUser.getUsername());
 
                 // check failures
-                assertEquals(CheckInStatus.EVENT_NOT_FOUND, attendeeApiController.scanBadge(new AttendeeApiController.SponsorScanRequest("not-existing-event", "not-existing-ticket", null, null), sponsorPrincipal).getBody().getResult().getStatus());
-                assertEquals(CheckInStatus.TICKET_NOT_FOUND, attendeeApiController.scanBadge(new AttendeeApiController.SponsorScanRequest(eventName, "not-existing-ticket", null, null), sponsorPrincipal).getBody().getResult().getStatus());
-                assertEquals(CheckInStatus.INVALID_TICKET_STATE, attendeeApiController.scanBadge(new AttendeeApiController.SponsorScanRequest(eventName, ticketIdentifier, null, null), sponsorPrincipal).getBody().getResult().getStatus());
+                assertEquals(CheckInStatus.EVENT_NOT_FOUND, attendeeApiController.scanBadge(new AttendeeApiController.SponsorScanRequest("not-existing-event", "not-existing-ticket", null, null), sponsorPrincipal, null).getBody().getResult().getStatus());
+                assertEquals(CheckInStatus.TICKET_NOT_FOUND, attendeeApiController.scanBadge(new AttendeeApiController.SponsorScanRequest(eventName, "not-existing-ticket", null, null), sponsorPrincipal, null).getBody().getResult().getStatus());
+                assertEquals(CheckInStatus.INVALID_TICKET_STATE, attendeeApiController.scanBadge(new AttendeeApiController.SponsorScanRequest(eventName, ticketIdentifier, null, null), sponsorPrincipal, null).getBody().getResult().getStatus());
                 //
 
 
@@ -1118,7 +1119,9 @@ public abstract class BaseReservationFlowTest extends BaseIntegrationTest {
 
                     // check register sponsor scan success flow
                     assertTrue(attendeeApiController.getScannedBadges(context.event.getShortName(), EventUtil.JSON_DATETIME_FORMATTER.format(LocalDateTime.of(1970, 1, 1, 0, 0)), sponsorPrincipal).getBody().isEmpty());
-                    assertEquals(CheckInStatus.SUCCESS, attendeeApiController.scanBadge(new AttendeeApiController.SponsorScanRequest(eventName, ticketwc.getUuid(), null, null), sponsorPrincipal).getBody().getResult().getStatus());
+                    assertEquals(CheckInStatus.SUCCESS, attendeeApiController.scanBadge(new AttendeeApiController.SponsorScanRequest(eventName, ticketwc.getUuid(), null, null), sponsorPrincipal, null).getBody().getResult().getStatus());
+                    assertEquals(CheckInStatus.SUCCESS, attendeeApiController.scanBadge(new AttendeeApiController.SponsorScanRequest(eventName, ticketwc.getUuid(), null, null), sponsorPrincipal, null).getBody().getResult().getStatus());
+                    // scanned badges returns only unique values for a limited subset of columns
                     assertEquals(1, attendeeApiController.getScannedBadges(context.event.getShortName(), EventUtil.JSON_DATETIME_FORMATTER.format(LocalDateTime.of(1970, 1, 1, 0, 0)), sponsorPrincipal).getBody().size());
 
                     // check export
@@ -1133,14 +1136,18 @@ public abstract class BaseReservationFlowTest extends BaseIntegrationTest {
                     assertEquals("testmctest@test.com", csvSponsorScan.get(1)[4]);
                     assertEquals("", csvSponsorScan.get(1)[8]);
                     assertEquals(SponsorScan.LeadStatus.WARM.name(), csvSponsorScan.get(1)[9]);
+                    assertEquals(AttendeeManager.DEFAULT_OPERATOR_ID, csvSponsorScan.get(1)[10]);
                     //
 
                     // check update notes
-                    assertEquals(CheckInStatus.SUCCESS, attendeeApiController.scanBadge(new AttendeeApiController.SponsorScanRequest(eventName, ticket.getUuid(), "this is a very good lead!", "HOT"), sponsorPrincipal).getBody().getResult().getStatus());
-                    assertEquals(1, attendeeApiController.getScannedBadges(context.event.getShortName(), EventUtil.JSON_DATETIME_FORMATTER.format(LocalDateTime.of(1970, 1, 1, 0, 0)), sponsorPrincipal).getBody().size());
+                    assertEquals(CheckInStatus.SUCCESS, attendeeApiController.scanBadge(new AttendeeApiController.SponsorScanRequest(eventName, ticket.getUuid(), "this is a very good lead!", "HOT"), sponsorPrincipal, null).getBody().getResult().getStatus());
+                    var scannedBadges = attendeeApiController.getScannedBadges(context.event.getShortName(), EventUtil.JSON_DATETIME_FORMATTER.format(LocalDateTime.of(1970, 1, 1, 0, 0)), sponsorPrincipal).getBody();
+                    assertEquals(1, requireNonNull(scannedBadges).size());
+                    assertEquals(CheckInStatus.SUCCESS, attendeeApiController.scanBadge(new AttendeeApiController.SponsorScanRequest(eventName, ticket.getUuid(), "this is a very good lead!", "HOT"), sponsorPrincipal, null).getBody().getResult().getStatus());
+                    scannedBadges = attendeeApiController.getScannedBadges(context.event.getShortName(), EventUtil.JSON_DATETIME_FORMATTER.format(LocalDateTime.of(1970, 1, 1, 0, 0)), sponsorPrincipal).getBody();
+                    assertEquals(1, requireNonNull(scannedBadges).size());
                     response = new MockHttpServletResponse();
                     eventApiController.downloadSponsorScanExport(context.event.getShortName(), "csv", response, principal);
-                    response.getContentAsString();
                     csvReader = new CSVReader(new StringReader(response.getContentAsString()));
                     csvSponsorScan = csvReader.readAll();
                     assertEquals(2, csvSponsorScan.size());
@@ -1149,6 +1156,27 @@ public abstract class BaseReservationFlowTest extends BaseIntegrationTest {
                     assertEquals("testmctest@test.com", csvSponsorScan.get(1)[4]);
                     assertEquals("this is a very good lead!", csvSponsorScan.get(1)[8]);
                     assertEquals(SponsorScan.LeadStatus.HOT.name(), csvSponsorScan.get(1)[9]);
+                    assertEquals(AttendeeManager.DEFAULT_OPERATOR_ID, csvSponsorScan.get(1)[10]);
+
+                    // scan from a different operator
+                    response = new MockHttpServletResponse();
+                    assertEquals(CheckInStatus.SUCCESS, attendeeApiController.scanBadge(new AttendeeApiController.SponsorScanRequest(eventName, ticketwc.getUuid(), null, null), sponsorPrincipal, "OP2").getBody().getResult().getStatus());
+                    eventApiController.downloadSponsorScanExport(context.event.getShortName(), "csv", response, principal);
+                    csvReader = new CSVReader(new StringReader(response.getContentAsString()));
+                    csvSponsorScan = csvReader.readAll();
+                    assertEquals(3, csvSponsorScan.size());
+                    assertEquals("sponsor", csvSponsorScan.get(1)[0]);
+                    assertEquals("Test Testson", csvSponsorScan.get(1)[3]);
+                    assertEquals("testmctest@test.com", csvSponsorScan.get(1)[4]);
+                    assertEquals("this is a very good lead!", csvSponsorScan.get(1)[8]);
+                    assertEquals(SponsorScan.LeadStatus.HOT.name(), csvSponsorScan.get(1)[9]);
+                    assertEquals(AttendeeManager.DEFAULT_OPERATOR_ID, csvSponsorScan.get(1)[10]);
+
+                    assertEquals("sponsor", csvSponsorScan.get(2)[0]);
+                    assertEquals("Test Testson", csvSponsorScan.get(2)[3]);
+                    assertEquals("testmctest@test.com", csvSponsorScan.get(2)[4]);
+                    assertEquals("", csvSponsorScan.get(2)[8]);
+                    assertEquals("OP2", csvSponsorScan.get(2)[10]);
 
                     // #742 - test multiple check-ins
 


### PR DESCRIPTION
During an event, it is possible that the same person gets scanned multiple times by different members of the sponsor staff.
The current strategy is to update the record to show data from the last scan. 
This has proven to be not very "user friendly" in different occasions.

This PR will add a "unique scan per operator" constraint, giving more flexibility to sponsors, and less opportunity to loose valuable data