### PR TITLE
case insensitive qr code

### DIFF
--- a/src/main/java/alfio/controller/OnlineCheckInController.java
+++ b/src/main/java/alfio/controller/OnlineCheckInController.java
@@ -52,7 +52,7 @@ public class OnlineCheckInController {
             .flatMap(data -> {
                 var ticket = data.getTicket();
                 var event = data.getEventWithCheckInInfo();
-                String ticketCode = ticket.ticketCode(event.getPrivateKey());
+                String ticketCode = ticket.ticketCode(event.getPrivateKey(), event.supportsQRCodeCaseInsensitive());
                 if(MessageDigest.isEqual(DigestUtils.sha256Hex(ticketCode).getBytes(StandardCharsets.UTF_8), ticketCodeHash.getBytes(StandardCharsets.UTF_8))) {
                     log.debug("code successfully validated for ticket {}", ticketUUID);
                     // check-in can be done. Let's check if there is a redirection URL

--- a/src/main/java/alfio/controller/api/v2/user/TicketApiV2Controller.java
+++ b/src/main/java/alfio/controller/api/v2/user/TicketApiV2Controller.java
@@ -16,12 +16,12 @@
  */
 package alfio.controller.api.v2.user;
 
+import alfio.controller.api.support.BookingInfoTicketLoader;
 import alfio.controller.api.support.TicketHelper;
 import alfio.controller.api.v2.model.DatesWithTimeZoneOffset;
 import alfio.controller.api.v2.model.OnlineCheckInInfo;
 import alfio.controller.api.v2.model.ReservationInfo;
 import alfio.controller.api.v2.model.TicketInfo;
-import alfio.controller.api.support.BookingInfoTicketLoader;
 import alfio.controller.form.UpdateTicketOwnerForm;
 import alfio.controller.support.Formatters;
 import alfio.controller.support.TemplateProcessor;
@@ -95,7 +95,7 @@ public class TicketApiV2Controller {
         var event = oData.get().getLeft();
         var ticket = oData.get().getRight();
 
-        String qrCodeText = ticket.ticketCode(event.getPrivateKey());
+        String qrCodeText = ticket.ticketCode(event.getPrivateKey(), event.supportsQRCodeCaseInsensitive());
 
         response.setContentType("image/png");
 
@@ -288,7 +288,7 @@ public class TicketApiV2Controller {
                 var ticket = info.getTicket();
                 var event = info.getEventWithCheckInInfo();
                 var messageSource = messageSourceManager.getMessageSourceFor(event.getOrganizationId(), event.getId());
-                String ticketCode = ticket.ticketCode(event.getPrivateKey());
+                String ticketCode = ticket.ticketCode(event.getPrivateKey(), event.supportsQRCodeCaseInsensitive());
                 if(MessageDigest.isEqual(DigestUtils.sha256Hex(ticketCode).getBytes(StandardCharsets.UTF_8), checkInCode.getBytes(StandardCharsets.UTF_8))) {
                     var categoryConfiguration = info.getCategoryMetadata().getOnlineConfiguration();
                     var eventConfiguration = event.getMetadata().getOnlineConfiguration();

--- a/src/main/java/alfio/manager/PassKitManager.java
+++ b/src/main/java/alfio/manager/PassKitManager.java
@@ -173,7 +173,7 @@ public class PassKitManager {
             .relevantDate(Date.from(ticketValidityStart.toInstant()))
             .expirationDate(Date.from(Optional.ofNullable(category.getTicketValidityEnd(event.getZoneId())).orElse(event.getEnd()).toInstant()))
 
-            .barcode(new Barcode(BarcodeFormat.QR, ticket.ticketCode(event.getPrivateKey())))
+            .barcode(new Barcode(BarcodeFormat.QR, ticket.ticketCode(event.getPrivateKey(), event.supportsQRCodeCaseInsensitive())))
             .labelColor(Color.BLACK)
             .foregroundColor(Color.BLACK)
             .backgroundColor(Color.WHITE)

--- a/src/main/java/alfio/manager/wallet/GoogleWalletManager.java
+++ b/src/main/java/alfio/manager/wallet/GoogleWalletManager.java
@@ -202,7 +202,7 @@ public class GoogleWalletManager {
             .classId(eventTicketClass.getId())
             .ticketHolderName(ticket.getFullName())
             .ticketNumber(ticket.getUuid())
-            .barcode(ticket.ticketCode(event.getPrivateKey()))
+            .barcode(ticket.ticketCode(event.getPrivateKey(), event.supportsQRCodeCaseInsensitive()))
             .build();
 
         GoogleCredentials credentials = retrieveCredentials(serviceAccountKey);

--- a/src/main/java/alfio/model/Event.java
+++ b/src/main/java/alfio/model/Event.java
@@ -18,6 +18,7 @@ package alfio.model;
 
 import alfio.model.transaction.PaymentProxy;
 import alfio.util.ClockProvider;
+import alfio.util.EventUtil;
 import alfio.util.MonetaryUtil;
 import ch.digitalfondue.npjt.ConstructorAnnotationRowMapper.Column;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -252,6 +253,10 @@ public class Event extends EventAndOrganizationId implements EventHiddenFieldCon
 
     public boolean mustUseFirstAndLastName() {
         return mustUseFirstAndLastName(this);
+    }
+
+    public boolean supportsQRCodeCaseInsensitive() {
+        return EventUtil.supportsCaseInsensitiveQRCode(version);
     }
 
 

--- a/src/main/java/alfio/model/EventCheckInInfo.java
+++ b/src/main/java/alfio/model/EventCheckInInfo.java
@@ -22,7 +22,7 @@ import java.time.ZonedDateTime;
 
 public interface EventCheckInInfo extends TimeZoneInfo {
 
-    String VERSION_FOR_CODE_CASE_INSENSITIVE = "205.2.0.0.49";
+    String VERSION_FOR_CODE_CASE_INSENSITIVE = "205.2.0.0.50";
 
     int getId();
     String getPrivateKey();

--- a/src/main/java/alfio/model/EventCheckInInfo.java
+++ b/src/main/java/alfio/model/EventCheckInInfo.java
@@ -16,14 +16,21 @@
  */
 package alfio.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import java.time.ZonedDateTime;
 
 public interface EventCheckInInfo extends TimeZoneInfo {
+
+    String VERSION_FOR_CODE_CASE_INSENSITIVE = "205.2.0.0.49";
 
     int getId();
     String getPrivateKey();
     ZonedDateTime getBegin();
     ZonedDateTime getEnd();
     Event.EventFormat getFormat();
+
+    @JsonIgnore
+    boolean supportsQRCodeCaseInsensitive();
 
 }

--- a/src/main/java/alfio/model/Ticket.java
+++ b/src/main/java/alfio/model/Ticket.java
@@ -18,6 +18,7 @@ package alfio.model;
 
 import alfio.model.support.Array;
 import alfio.util.MonetaryUtil;
+import alfio.util.checkin.NameNormalizer;
 import ch.digitalfondue.npjt.ConstructorAnnotationRowMapper.Column;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
@@ -147,7 +148,7 @@ public class Ticket implements TicketInfoContainer {
         var attendeeName = fullName;
         var attendeeEmail = email;
         if (caseInsensitive) {
-            attendeeName = StringUtils.stripAccents(attendeeName).toLowerCase(Locale.ROOT);
+            attendeeName = NameNormalizer.normalize(attendeeName);
             attendeeEmail = email.toLowerCase(Locale.ROOT);
         }
         return hmacSHA256Base64(eventKey, StringUtils.join(new String[]{ticketsReservationId , uuid, attendeeName, attendeeEmail}, '/'));

--- a/src/main/java/alfio/model/Ticket.java
+++ b/src/main/java/alfio/model/Ticket.java
@@ -126,12 +126,12 @@ public class Ticket implements TicketInfoContainer {
      * @param eventKey
      * @return
      */
-    public String ticketCode(String eventKey) {
-        return uuid + '/' + hmacTicketInfo(eventKey);
+    public String ticketCode(String eventKey, boolean caseInsensitive) {
+        return uuid + '/' + hmacTicketInfo(eventKey, caseInsensitive);
     }
 
-    public String hmacTicketInfo(String eventKey) {
-        return hmacSHA256Base64(eventKey, StringUtils.join(new String[]{ticketsReservationId , uuid, getFullName(), email}, '/'));
+    public String hmacTicketInfo(String eventKey, boolean caseInsensitive) {
+        return generateHmacTicketInfo(eventKey, caseInsensitive, getFullName(), email, ticketsReservationId, uuid);
     }
 
     public boolean hasBeenSold() {
@@ -141,6 +141,16 @@ public class Ticket implements TicketInfoContainer {
     @Override
     public boolean isCheckedIn() {
         return status == TicketStatus.CHECKED_IN;
+    }
+
+    static String generateHmacTicketInfo(String eventKey, boolean caseInsensitive, String fullName, String email, String ticketsReservationId, String uuid) {
+        var attendeeName = fullName;
+        var attendeeEmail = email;
+        if (caseInsensitive) {
+            attendeeName = StringUtils.stripAccents(attendeeName).toLowerCase(Locale.ROOT);
+            attendeeEmail = email.toLowerCase(Locale.ROOT);
+        }
+        return hmacSHA256Base64(eventKey, StringUtils.join(new String[]{ticketsReservationId , uuid, attendeeName, attendeeEmail}, '/'));
     }
 
     public static String hmacSHA256Base64(String key, String code) {

--- a/src/main/java/alfio/model/checkin/CheckInFullInfo.java
+++ b/src/main/java/alfio/model/checkin/CheckInFullInfo.java
@@ -138,6 +138,7 @@ public class CheckInFullInfo {
                            @Column("e_org_id") int eventOrgId,
                            @Column("e_metadata") @JSONData AlfioMetadata eventMetadata,
                            @Column("e_locales") int locales,
+                           @Column("e_version") String eventVersion,
 
                            @Column("tai_additional_info") @JSONData Map<String, List<String>> ticketAdditionalInfo
                                  ) {
@@ -155,7 +156,7 @@ public class CheckInFullInfo {
 
         this.categoryMetadata = categoryMetadata;
         this.billingDetails = new BillingDetails(billingAddressCompany, billingAddressLine1, billingAddressLine2, billingAddressZip, billingAddressCity, billingAddressState, vatCountry, vatNr, invoicingAdditionalInfo);
-        this.eventWithCheckInInfo = new EventWithCheckInInfo(eventId, eventFormat, eventShortName, eventDisplayName, eventStartTs, eventEndTs, timezone, eventPrivateKey, eventOrgId, eventMetadata, locales);
+        this.eventWithCheckInInfo = new EventWithCheckInInfo(eventId, eventFormat, eventShortName, eventDisplayName, eventStartTs, eventEndTs, timezone, eventPrivateKey, eventOrgId, eventMetadata, locales, eventVersion);
         this.ticketAdditionalInfo = ticketAdditionalInfo;
     }
 }

--- a/src/main/java/alfio/model/checkin/EventWithCheckInInfo.java
+++ b/src/main/java/alfio/model/checkin/EventWithCheckInInfo.java
@@ -19,6 +19,7 @@ package alfio.model.checkin;
 import alfio.model.*;
 import alfio.model.metadata.AlfioMetadata;
 import alfio.model.support.JSONData;
+import alfio.util.EventUtil;
 import lombok.Getter;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -41,6 +42,7 @@ public class EventWithCheckInInfo extends EventAndOrganizationId implements Even
     private final String privateKey;
     private final AlfioMetadata metadata;
     private final List<ContentLanguage> contentLanguages;
+    private final String version;
 
 
     public EventWithCheckInInfo(@Column("id") int id,
@@ -53,7 +55,8 @@ public class EventWithCheckInInfo extends EventAndOrganizationId implements Even
                                 @Column("private_key") String privateKey,
                                 @Column("org_id") int organizationId,
                                 @Column("metadata") @JSONData AlfioMetadata metadata,
-                                @Column("locales") int locales) {
+                                @Column("locales") int locales,
+                                @Column("version") String version) {
         super(id, organizationId);
         this.zoneId = ZoneId.of(timezone);
         this.format = format;
@@ -64,6 +67,7 @@ public class EventWithCheckInInfo extends EventAndOrganizationId implements Even
         this.privateKey = privateKey;
         this.metadata = metadata;
         this.contentLanguages = ContentLanguage.findAllFor(locales);
+        this.version = version;
     }
 
     public boolean isOnline() {
@@ -93,5 +97,10 @@ public class EventWithCheckInInfo extends EventAndOrganizationId implements Even
     @Override
     public List<ContentLanguage> getContentLanguages() {
         return contentLanguages;
+    }
+
+    @Override
+    public boolean supportsQRCodeCaseInsensitive() {
+        return EventUtil.supportsCaseInsensitiveQRCode(version);
     }
 }

--- a/src/main/java/alfio/util/EventUtil.java
+++ b/src/main/java/alfio/util/EventUtil.java
@@ -36,6 +36,7 @@ import biweekly.property.Status;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.RegExUtils;
+import org.flywaydb.core.api.MigrationVersion;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -53,6 +54,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static alfio.model.EventCheckInInfo.VERSION_FOR_CODE_CASE_INSENSITIVE;
 import static alfio.model.TicketFieldConfiguration.Context.ATTENDEE;
 import static alfio.model.system.ConfigurationKeys.*;
 import static java.time.temporal.ChronoField.*;
@@ -285,5 +287,10 @@ public final class EventUtil {
         }
 
         return messagesByLang.values().stream().findFirst().orElseThrow();
+    }
+
+    public static boolean supportsCaseInsensitiveQRCode(String version) {
+        return version != null
+            && MigrationVersion.fromVersion(version).compareTo(MigrationVersion.fromVersion(VERSION_FOR_CODE_CASE_INSENSITIVE)) >= 0;
     }
 }

--- a/src/main/java/alfio/util/TemplateResource.java
+++ b/src/main/java/alfio/util/TemplateResource.java
@@ -595,7 +595,7 @@ public enum TemplateResource {
                                                              Optional<ImageData> imageData,
                                                              String reservationId,
                                                              Map<String,String> additionalFields) {
-        String qrCodeText = ticketWithMetadata.getTicket().ticketCode(event.getPrivateKey());
+        String qrCodeText = ticketWithMetadata.getTicket().ticketCode(event.getPrivateKey(), event.supportsQRCodeCaseInsensitive());
         //
         Map<String, Object> model = new HashMap<>();
         model.put(TICKET_KEY, ticketWithMetadata.getTicket());

--- a/src/main/java/alfio/util/checkin/NameNormalizer.java
+++ b/src/main/java/alfio/util/checkin/NameNormalizer.java
@@ -1,0 +1,39 @@
+/**
+ * This file is part of alf.io.
+ *
+ * alf.io is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * alf.io is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with alf.io.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package alfio.util.checkin;
+
+// heavily inspired by https://stackoverflow.com/a/5470803
+public class NameNormalizer {
+
+    private static final String[] REPLACEMENT = new String[Character.MAX_VALUE+1];
+    static {
+        for(int i=Character.MIN_VALUE; i<=Character.MAX_VALUE; i++) {
+            REPLACEMENT[i] = Character.toString(Character.toLowerCase((char) i));
+        }
+        REPLACEMENT['ı'] = "i"; // special case: we render the turkish ı as i since its uppercase is represented as Latin I
+        REPLACEMENT['Σ'] = "σς";
+    }
+    private NameNormalizer() {}
+
+    public static String normalize(String input) {
+        StringBuilder sb = new StringBuilder(input.length());
+        for(int i=0;i<input.length();i++) {
+            sb.append(REPLACEMENT[input.charAt(i)]);
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/alfio/util/checkin/NameNormalizer.java
+++ b/src/main/java/alfio/util/checkin/NameNormalizer.java
@@ -19,21 +19,24 @@ package alfio.util.checkin;
 // heavily inspired by https://stackoverflow.com/a/5470803
 public class NameNormalizer {
 
-    private static final String[] REPLACEMENT = new String[Character.MAX_VALUE+1];
-    static {
-        for(int i=Character.MIN_VALUE; i<=Character.MAX_VALUE; i++) {
-            REPLACEMENT[i] = Character.toString(Character.toLowerCase((char) i));
-        }
-        REPLACEMENT['ı'] = "i"; // special case: we render the turkish ı as i since its uppercase is represented as Latin I
-        REPLACEMENT['Σ'] = "σς";
-    }
     private NameNormalizer() {}
 
     public static String normalize(String input) {
         StringBuilder sb = new StringBuilder(input.length());
-        for(int i=0;i<input.length();i++) {
-            sb.append(REPLACEMENT[input.charAt(i)]);
+        for (int i=0; i < input.length(); i++) {
+            sb.append(replaceCharIfNotSupported(input.charAt(i)));
         }
         return sb.toString();
+    }
+
+    private static String replaceCharIfNotSupported(char in) {
+        if (in == 'Σ') {
+            return "σς";
+        }
+        char lowercase = Character.toLowerCase(in);
+        if (lowercase == 'ı') {
+            return "i"; // special case: we render the turkish ı as i since its uppercase is represented as Latin I
+        }
+        return Character.toString(lowercase);
     }
 }

--- a/src/main/java/alfio/util/checkin/TicketCheckInUtil.java
+++ b/src/main/java/alfio/util/checkin/TicketCheckInUtil.java
@@ -39,7 +39,7 @@ public class TicketCheckInUtil {
     public static final String CUSTOM_CHECK_IN_URL_DESCRIPTION = "customCheckInUrlDescription";
 
     public static String ticketOnlineCheckInUrl(Event event, Ticket ticket, String baseUrl) {
-        var ticketCode = DigestUtils.sha256Hex(ticket.ticketCode(event.getPrivateKey()));
+        var ticketCode = DigestUtils.sha256Hex(ticket.ticketCode(event.getPrivateKey(), event.supportsQRCodeCaseInsensitive()));
         return StringUtils.removeEnd(baseUrl, "/")
             + "/event/" + event.getShortName() + "/ticket/" + ticket.getUuid() + "/check-in/"+ticketCode;
     }

--- a/src/main/resources/alfio/db/PGSQL/V205_2.0.0.50__QR_CASE_INSENSITIVE_MARKER.sql
+++ b/src/main/resources/alfio/db/PGSQL/V205_2.0.0.50__QR_CASE_INSENSITIVE_MARKER.sql
@@ -1,0 +1,18 @@
+--
+-- This file is part of alf.io.
+--
+-- alf.io is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- alf.io is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with alf.io.  If not, see <http://www.gnu.org/licenses/>.
+--
+
+-- this is only meant to be a marker and act as a baseline for applying the new "case insensitive" QR Code generation

--- a/src/main/resources/alfio/db/PGSQL/afterMigrate__009_VIEW_checkin_ticket_event_and_category_info.sql
+++ b/src/main/resources/alfio/db/PGSQL/afterMigrate__009_VIEW_checkin_ticket_event_and_category_info.sql
@@ -121,6 +121,7 @@ create view checkin_ticket_event_and_category_info as
         e.metadata                          e_metadata,
         e.org_id                            e_org_id,
         e.locales                           e_locales,
+        e.version                           e_version,
         (select jsonb_object_agg(tfc.field_name, case tfc.field_type when 'checkbox' then tfv.field_value::jsonb else jsonb_build_array(tfv.field_value) end) as additional_info
             from ticket_field_value tfv
                 inner join ticket_field_configuration tfc on tfv.ticket_field_configuration_id_fk = tfc.id

--- a/src/test/java/alfio/controller/api/v2/user/reservation/BaseReservationFlowTest.java
+++ b/src/test/java/alfio/controller/api/v2/user/reservation/BaseReservationFlowTest.java
@@ -39,7 +39,6 @@ import alfio.extension.ExtensionService;
 import alfio.manager.*;
 import alfio.manager.support.CheckInStatus;
 import alfio.manager.support.IncompatibleStateException;
-import alfio.manager.support.SponsorAttendeeData;
 import alfio.manager.support.TicketAndCheckInResult;
 import alfio.manager.support.extension.ExtensionEvent;
 import alfio.model.*;
@@ -948,7 +947,7 @@ public abstract class BaseReservationFlowTest extends BaseIntegrationTest {
             var fullTicketInfo = ticketRepository.findByUUID(ticket.getUuid());
             var qrCodeReader = new QRCodeReader();
             var qrCodeRead = qrCodeReader.decode(new BinaryBitmap(new HybridBinarizer(new BufferedImageLuminanceSource(ImageIO.read(new ByteArrayInputStream(ticketQRCodeResp.getContentAsByteArray()))))), Map.of(DecodeHintType.PURE_BARCODE, Boolean.TRUE));
-            assertEquals(fullTicketInfo.ticketCode(context.event.getPrivateKey()), qrCodeRead.getText());
+            assertEquals(fullTicketInfo.ticketCode(context.event.getPrivateKey(), context.event.supportsQRCodeCaseInsensitive()), qrCodeRead.getText());
 
             //can only be done for free tickets
             var releaseTicketFailure = ticketApiV2Controller.releaseTicket(context.event.getShortName(), ticket.getUuid());
@@ -997,7 +996,7 @@ public abstract class BaseReservationFlowTest extends BaseIntegrationTest {
                         break;
                 }
 
-                String ticketCode = fullTicketInfo.ticketCode(context.event.getPrivateKey());
+                String ticketCode = fullTicketInfo.ticketCode(context.event.getPrivateKey(), context.event.supportsQRCodeCaseInsensitive());
                 TicketAndCheckInResult ticketAndCheckInResult = checkInApiController.findTicketWithUUID(context.event.getId(), ticketIdentifier, ticketCode);
                 assertEquals(CheckInStatus.OK_READY_TO_BE_CHECKED_IN, ticketAndCheckInResult.getResult().getStatus());
                 CheckInApiController.TicketCode tc = new CheckInApiController.TicketCode();
@@ -1367,7 +1366,8 @@ public abstract class BaseReservationFlowTest extends BaseIntegrationTest {
         Map<String, String> payload = checkInApiController.getOfflineEncryptedInfo(context.event.getShortName(), Collections.emptyList(), offlineIdentifiers, principal);
         assertEquals(1, payload.size());
         TicketWithCategory ticketwc = ticketAndcheckInResult.getTicket();
-        String ticketKey = ticketwc.hmacTicketInfo(context.event.getPrivateKey());
+        String ticketKey = ticketwc.hmacTicketInfo(context.event.getPrivateKey(), true);
+        assertNotEquals(ticketKey, ticketwc.hmacTicketInfo(context.event.getPrivateKey(), false));
         String hashedTicketKey = DigestUtils.sha256Hex(ticketKey);
         String encJson = payload.get(hashedTicketKey);
         assertNotNull(encJson);

--- a/src/test/java/alfio/model/TicketTest.java
+++ b/src/test/java/alfio/model/TicketTest.java
@@ -1,0 +1,19 @@
+package alfio.model;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TicketTest {
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void ticketCode(boolean caseInsensitive) {
+        var fullName = "Full Name";
+        var email = "email@example.org";
+        var regularCase = Ticket.generateHmacTicketInfo("eventKey", caseInsensitive, fullName, email, "id", "uuid");
+        var modifiedCase = Ticket.generateHmacTicketInfo("eventKey", caseInsensitive, fullName.toUpperCase(), email.toUpperCase(), "id", "uuid");
+        assertEquals(caseInsensitive, regularCase.equals(modifiedCase));
+    }
+}

--- a/src/test/java/alfio/model/TicketTest.java
+++ b/src/test/java/alfio/model/TicketTest.java
@@ -16,8 +16,11 @@
  */
 package alfio.model;
 
+import alfio.util.checkin.NameNormalizer;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -34,10 +37,38 @@ class TicketTest {
     }
 
     @ParameterizedTest
+    @ValueSource(strings = {
+        // format: UPPERCASE/lowercase,UPPERCASE/lowercase...
+        "A/a,B/b,C/c,D/d,E/e,F/f,G/g,H/h,I/i,J/j,K/k,L/l,M/m,N/n,O/o,P/p,Q/q,R/r,S/s,T/t,U/u,V/v,W/w,X/x,Y/y,Z/z",
+        "Α/α,Β/β,Γ/γ,Δ/δ,Ε/ε,Ζ/ζ,Η/η,Θ/θ,Ι/ι,Κ/κ,Λ/λ,Μ/μ,Ν/ν,Ξ/ξ,Ο/ο,Π/π,Ρ/ρ,Σ/σς,Τ/τ,Υ/υ,Φ/φ,Χ/χ,Ψ/ψ,Ω/ω", //greek, https://en.wikipedia.org/wiki/Greek_alphabet
+        "Ç/ç,Ğ/ğ,I/i,İ/i,J/j,Ö/ö,Ş/ş,Ü/ü", // turkish https://en.wikipedia.org/wiki/Turkish_alphabet, except character ı, see NameNormalizer
+        "А/а,Б/б,В/в,Г/г,Д/д,Е/е,Ж/ж,З/з,И/и,Й/й,К/к,Л/л,М/м,Н/н,О/о,П/п,Р/р,С/с,Т/т,У/у,Ф/ф,Х/х,Ц/ц,Ч/ч,Ш/ш,Щ/щ,Ъ/ъ,Ь/ь,Ю/ю,Я/я", // bulgarian, https://en.wikipedia.org/wiki/Bulgarian_alphabet
+        "Å/å,Ä/ä,Ö/ö", // Swedish https://en.wikipedia.org/wiki/Swedish_alphabet
+        "Ă/ă,Â/â,I/i,Î/î,Ș/ș,Ț/ț", // Romanian https://en.wikipedia.org/wiki/Romanian_alphabet
+        "Ä/ä,Ö/ö,Ü/ü,ẞ/ß", // German https://en.wikipedia.org/wiki/German_orthography
+        "Æ/æ,Ø/ø,Å/å", //Danish / Norwegian https://en.wikipedia.org/wiki/Danish_and_Norwegian_alphabet
+        "Ą/ą,Ć/ć,Ę/ę,Ł/ł,Ń/ń,Ó/ó,Ś/ś,Ź/ź,Ż/ż", // Polish https://en.wikipedia.org/wiki/Polish_alphabet
+        "À/à,È/è,É/é,Ì/ì,Ò/ò,Ù/ù" // Italian / French vowels
+    })
+    void validateCase(String letters) {
+        var uppercase = new StringBuilder();
+        var lowercase = new StringBuilder();
+        Arrays.stream(letters.split(",")).forEach(str -> {
+            var split = str.split("/");
+            uppercase.append(split[0]);
+            lowercase.append(split[1]);
+        });
+        assertEquals(lowercase.toString(), NameNormalizer.normalize(uppercase.toString()));
+        var unmodifiedLowercase = Ticket.generateHmacTicketInfo("eventKey", false, lowercase.toString(), "mail@example.org", "id", "uuid");
+        var processedUppercase = Ticket.generateHmacTicketInfo("eventKey", true, uppercase.toString(), "mail@example.org", "id", "uuid");
+        assertEquals(unmodifiedLowercase, processedUppercase);
+    }
+
+    @ParameterizedTest
     @ValueSource(booleans = {true, false})
     void ticketCodeUTF8Chars(boolean caseInsensitive) {
-        var fullName = "çÇĞğIıİiÖöŞşÜü";
-        var fullNameSwappedCase = "ÇçğĞıIiİöÖşŞüÜ";
+        var fullName = "çÇĞğIıİiÖöŞşÜüΑ";
+        var fullNameSwappedCase = "ÇçğĞıIiİöÖşŞüÜα";
         var email = "email@example.org";
         var regularCase = Ticket.generateHmacTicketInfo("eventKey", caseInsensitive, fullName, email, "id", "uuid");
         var modifiedCase = Ticket.generateHmacTicketInfo("eventKey", caseInsensitive, fullNameSwappedCase, email.toUpperCase(), "id", "uuid");

--- a/src/test/java/alfio/model/TicketTest.java
+++ b/src/test/java/alfio/model/TicketTest.java
@@ -32,4 +32,15 @@ class TicketTest {
         var modifiedCase = Ticket.generateHmacTicketInfo("eventKey", caseInsensitive, fullName.toUpperCase(), email.toUpperCase(), "id", "uuid");
         assertEquals(caseInsensitive, regularCase.equals(modifiedCase));
     }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void ticketCodeUTF8Chars(boolean caseInsensitive) {
+        var fullName = "çÇĞğIıİiÖöŞşÜü";
+        var fullNameSwappedCase = "ÇçğĞıIiİöÖşŞüÜ";
+        var email = "email@example.org";
+        var regularCase = Ticket.generateHmacTicketInfo("eventKey", caseInsensitive, fullName, email, "id", "uuid");
+        var modifiedCase = Ticket.generateHmacTicketInfo("eventKey", caseInsensitive, fullNameSwappedCase, email.toUpperCase(), "id", "uuid");
+        assertEquals(caseInsensitive, regularCase.equals(modifiedCase));
+    }
 }

--- a/src/test/java/alfio/model/TicketTest.java
+++ b/src/test/java/alfio/model/TicketTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of alf.io.
+ *
+ * alf.io is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * alf.io is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with alf.io.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package alfio.model;
 
 import org.junit.jupiter.params.ParameterizedTest;

--- a/src/test/java/alfio/model/TicketTest.java
+++ b/src/test/java/alfio/model/TicketTest.java
@@ -48,7 +48,9 @@ class TicketTest {
         "Ä/ä,Ö/ö,Ü/ü,ẞ/ß", // German https://en.wikipedia.org/wiki/German_orthography
         "Æ/æ,Ø/ø,Å/å", //Danish / Norwegian https://en.wikipedia.org/wiki/Danish_and_Norwegian_alphabet
         "Ą/ą,Ć/ć,Ę/ę,Ł/ł,Ń/ń,Ó/ó,Ś/ś,Ź/ź,Ż/ż", // Polish https://en.wikipedia.org/wiki/Polish_alphabet
-        "À/à,È/è,É/é,Ì/ì,Ò/ò,Ù/ù" // Italian / French vowels
+        "À/à,È/è,É/é,Ì/ì,Ò/ò,Ù/ù", // Italian / French vowels
+        "万/万,丈/丈,三/三,上/上", // some random characters with no support for lowerCase
+        "❤/❤,✅/✅" // emojis
     })
     void validateCase(String letters) {
         var uppercase = new StringBuilder();

--- a/src/test/java/alfio/test/util/IntegrationTestUtil.java
+++ b/src/test/java/alfio/test/util/IntegrationTestUtil.java
@@ -139,6 +139,8 @@ public class IntegrationTestUtil {
         eventManager.createEvent(em, username);
         Event event = eventManager.getSingleEvent(eventName, username);
         Assertions.assertEquals(AVAILABLE_SEATS, eventRepository.countExistingTickets(event.getId()).intValue());
+        Assertions.assertTrue(event.mustUseFirstAndLastName());
+        Assertions.assertTrue(event.supportsQRCodeCaseInsensitive());
         return Pair.of(event, username);
     }
 

--- a/src/test/java/alfio/util/EventUtilTest.java
+++ b/src/test/java/alfio/util/EventUtilTest.java
@@ -44,7 +44,7 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class EventUtilTest {
+class EventUtilTest {
 
     private Event event;
     private SaleableTicketCategory first;

--- a/src/test/java/alfio/util/TemplateResourceTest.java
+++ b/src/test/java/alfio/util/TemplateResourceTest.java
@@ -30,8 +30,7 @@ import java.util.Optional;
 
 import static alfio.test.util.TestUtil.clockProvider;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -65,7 +64,7 @@ class TemplateResourceTest {
     @Test
     void buildModelForTicketPDF() {
         Pair<ZonedDateTime, ZonedDateTime> dates = getDates();
-        when(ticket.ticketCode(anyString())).thenReturn("abcd");
+        when(ticket.ticketCode(anyString(), anyBoolean())).thenReturn("abcd");
         when(event.getPrivateKey()).thenReturn("key");
         Map<String, Object> model = TemplateResource.buildModelForTicketPDF(organization, event, ticketReservation, ticketCategory, ticketWithMetadata, Optional.empty(), "abcd", Collections.emptyMap());
         assertEquals(dates.getLeft(), model.get("validityStart"));
@@ -81,7 +80,7 @@ class TemplateResourceTest {
         when(event.getZoneId()).thenReturn(ZoneId.systemDefault());
         when(event.getEnd()).thenReturn(eventEnd);
         when(ticketCategory.getTicketValidityStart(eq(ZoneId.systemDefault()))).thenReturn(validityStart);
-        when(ticket.ticketCode(anyString())).thenReturn("abcd");
+        when(ticket.ticketCode(anyString(), anyBoolean())).thenReturn("abcd");
         return Pair.of(validityStart, eventEnd);
     }
 


### PR DESCRIPTION
We should allow attendees to change case on their name (e.g. HOmer -> Homer) without causing troubles at the check-in.
This PR will generate case-insensitive QR Codes for events created with the new code.