### PR TITLE
Link subscriptions with categories

### DIFF
--- a/src/main/java/alfio/controller/api/v1/admin/EventApiV1Controller.java
+++ b/src/main/java/alfio/controller/api/v1/admin/EventApiV1Controller.java
@@ -30,7 +30,7 @@ import alfio.model.ExtensionSupport.ExtensionMetadataValue;
 import alfio.model.PromoCodeDiscount;
 import alfio.model.api.v1.admin.CheckInLogEntry;
 import alfio.model.api.v1.admin.EventCreationRequest;
-import alfio.model.api.v1.admin.LinkedSubscriptions;
+import alfio.model.api.v1.admin.LinkedSubscription;
 import alfio.model.group.Group;
 import alfio.model.modification.EventModification;
 import alfio.model.modification.LinkedGroupModification;
@@ -38,6 +38,8 @@ import alfio.model.modification.TicketCategoryModification;
 import alfio.model.result.ErrorCode;
 import alfio.model.result.Result;
 import alfio.model.result.ValidationResult;
+import alfio.model.subscription.EventSubscriptionLink;
+import alfio.model.subscription.LinkSubscriptionsToEventRequest;
 import alfio.model.system.ConfigurationKeys;
 import alfio.model.user.Organization;
 import alfio.repository.ExtensionRepository;
@@ -184,15 +186,15 @@ public class EventApiV1Controller {
     }
 
     @GetMapping("/{slug}/subscriptions")
-    public ResponseEntity<LinkedSubscriptions> getLinkedSubscriptions(@PathVariable String slug, Principal user) {
+    public ResponseEntity<LinkedSubscription> getLinkedSubscriptions(@PathVariable String slug, Principal user) {
         var event = accessService.checkEventOwnership(user, slug);
         return ResponseEntity.ok(retrieveLinkedSubscriptionsForEvent(slug, event.getId(), event.getOrganizationId()));
     }
 
     @PutMapping("/{slug}/subscriptions")
-    public ResponseEntity<LinkedSubscriptions> updateLinkedSubscriptions(@PathVariable String slug,
-                                                                         @RequestBody List<UUID> subscriptions,
-                                                                         Principal user) {
+    public ResponseEntity<LinkedSubscription> updateLinkedSubscriptions(@PathVariable String slug,
+                                                                        @RequestBody List<LinkSubscriptionsToEventRequest> subscriptions,
+                                                                        Principal user) {
         var eventAndOrgId = accessService.checkDescriptorsLinkRequest(user, slug, subscriptions);
         eventManager.updateLinkedSubscriptions(subscriptions, eventAndOrgId.getId(), eventAndOrgId.getOrganizationId());
         return ResponseEntity.ok(retrieveLinkedSubscriptionsForEvent(slug, eventAndOrgId.getId(), eventAndOrgId.getOrganizationId()));
@@ -222,9 +224,11 @@ public class EventApiV1Controller {
         }
     }
 
-    private LinkedSubscriptions retrieveLinkedSubscriptionsForEvent(String slug, int id, int organizationId) {
-        var subscriptionIds = eventManager.getLinkedSubscriptionIds(id, organizationId);
-        return new LinkedSubscriptions(slug, subscriptionIds);
+    private LinkedSubscription retrieveLinkedSubscriptionsForEvent(String slug, int id, int organizationId) {
+        var subscriptions = eventManager.getLinkedSubscriptions(id, organizationId);
+        return new LinkedSubscription(slug,
+            subscriptions.stream().collect(Collectors.toMap(EventSubscriptionLink::getSubscriptionDescriptorId, EventSubscriptionLink::getCompatibleCategories))
+        );
     }
 
     private Optional<Event> updateEvent(String slug, EventCreationRequest request, Principal user, String imageRef) {

--- a/src/main/java/alfio/job/executor/AssignTicketToSubscriberJobExecutor.java
+++ b/src/main/java/alfio/job/executor/AssignTicketToSubscriberJobExecutor.java
@@ -32,7 +32,7 @@ import alfio.repository.PurchaseContextFieldRepository;
 import alfio.repository.SubscriptionRepository;
 import alfio.repository.TicketCategoryRepository;
 import alfio.util.ClockProvider;
-import lombok.extern.log4j.Log4j2;
+import org.apache.commons.collections4.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -41,7 +41,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
-import java.time.temporal.ChronoUnit;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
@@ -108,13 +107,12 @@ public class AssignTicketToSubscriberJobExecutor implements AdminJobExecutor {
                     .getValueAsBooleanOrDefault();
                 if (generationEnabled) {
                     var subscriptions = subscriptionsByEvent.get(event.getId());
-                    var optionalCategory = ticketCategoryRepository.findFirstWithAvailableTickets(event.getId());
-                    if (optionalCategory.isPresent()) {
-                        var category = optionalCategory.get();
+                    var availableCategories = ticketCategoryRepository.findAllWithAvailableTickets(event.getId());
+                    if (CollectionUtils.isNotEmpty(availableCategories)) {
                         // 3. create reservation import request for the subscribers. ID is "AUTO_${eventShortName}_${now_ISO}"
                         var requestId = String.format("AUTO_%s_%s", event.getShortName(), LocalDateTime.now(clockProvider.getClock()).format(DateTimeFormatter.ISO_DATE_TIME));
                         requestManager.insertRequest(requestId,
-                            buildBody(event, subscriptions, category, fieldsByEventId.getOrDefault(event.getId(), Set.of())),
+                            buildBody(event, subscriptions, availableCategories, fieldsByEventId.getOrDefault(event.getId(), Set.of())),
                             event,
                             false,
                             "admin");
@@ -132,18 +130,34 @@ public class AssignTicketToSubscriberJobExecutor implements AdminJobExecutor {
 
     private AdminReservationModification buildBody(Event event,
                                                    List<AvailableSubscriptionsByEvent> subscriptions,
-                                                   TicketCategory category,
+                                                   List<TicketCategory> availableCategories,
                                                    Set<String> fieldsForEvent) {
         var clock = clockProvider.getClock();
+        var subscriptionsByDescriptor = subscriptions.stream().collect(Collectors.groupingBy(AvailableSubscriptionsByEvent::getDescriptorId));
+        var tickets = subscriptionsByDescriptor.values().stream().flatMap(availableSubscriptionsByEvents -> {
+            var firstValue = availableSubscriptionsByEvents.get(0);
+            var categoryOptional = availableCategories.stream()
+                .filter(c -> CollectionUtils.isEmpty(firstValue.getCompatibleCategoryIds()) || firstValue.getCompatibleCategoryIds().contains(c.getId()))
+                .findFirst();
+
+            if (categoryOptional.isEmpty()) {
+                var categoriesIds = availableCategories.stream().map(TicketCategory::getId).collect(Collectors.toSet());
+                log.warn("Skipping descriptor {}. No compatible category found (wanted: one of {}, available: {})", firstValue.getDescriptorId(), firstValue.getCompatibleCategoryIds(), categoriesIds);
+            }
+
+            return categoryOptional.stream()
+                .map(category -> new TicketsInfo(
+                    new Category(category.getId(), category.getName(), category.getPrice(), category.getTicketAccessType()),
+                    toAttendees(availableSubscriptionsByEvents, fieldsForEvent),
+                    false,
+                    false
+                ));
+        }).collect(Collectors.toList());
+
         return new AdminReservationModification(
-            new DateTimeModification(LocalDate.now(clock), LocalTime.now(clock).plus(5L, ChronoUnit.MINUTES)),
+            new DateTimeModification(LocalDate.now(clock), LocalTime.now(clock).plusMinutes(5L)),
             new CustomerData("", "", "", null, "", null, null, null, null),
-            List.of(new TicketsInfo(
-                new Category(category.getId(), category.getName(), category.getPrice(), category.getTicketAccessType()),
-                toAttendees(subscriptions, fieldsForEvent),
-                false,
-                false
-            )),
+            tickets,
             event.getContentLanguages().get(0).getLanguage(),
             false,
             false,

--- a/src/main/java/alfio/manager/EventManager.java
+++ b/src/main/java/alfio/manager/EventManager.java
@@ -34,6 +34,8 @@ import alfio.model.modification.PromoCodeDiscountWithFormattedTimeAndAmount;
 import alfio.model.modification.TicketCategoryModification;
 import alfio.model.result.ErrorCode;
 import alfio.model.result.Result;
+import alfio.model.subscription.EventSubscriptionLink;
+import alfio.model.subscription.LinkSubscriptionsToEventRequest;
 import alfio.model.support.CheckInOutputColorConfiguration;
 import alfio.model.support.CheckInOutputColorConfiguration.ColorConfiguration;
 import alfio.model.system.ConfigurationKeys;
@@ -210,7 +212,7 @@ public class EventManager {
         createAdditionalFields(event, em);
         createCategoriesForEvent(em, event, srcEvent);
         createAllTicketsForEvent(event, em);
-        createSubscriptionLinks(eventId, organization.getId(), em.getLinkedSubscriptions());
+        createSubscriptionLinks(eventId, organization.getId(), toSubscriptionLinkRequests(em.getLinkedSubscriptions()));
         srcEvent.ifPresent(eventAndOrganizationId -> copySettings(event, eventAndOrganizationId));
         extensionManager.handleEventCreation(event);
         var eventMetadata = extensionManager.handleMetadataUpdate(event, organization, AlfioMetadata.empty());
@@ -238,13 +240,15 @@ public class EventManager {
         log.info("copied {} settings from source event", count);
     }
 
-    private void createSubscriptionLinks(int eventId, int organizationId, List<UUID> linkedSubscriptions) {
+    private void createSubscriptionLinks(int eventId, int organizationId, List<LinkSubscriptionsToEventRequest> linkedSubscriptions) {
         if(CollectionUtils.isNotEmpty(linkedSubscriptions)) {
             var parameters = linkedSubscriptions.stream()
-                .map(id -> new MapSqlParameterSource("eventId", eventId)
-                    .addValue("subscriptionId", id)
+                .map(s -> new MapSqlParameterSource("eventId", eventId)
+                    .addValue("subscriptionId", s.getDescriptorId())
                     .addValue("pricePerTicket", 0)
-                    .addValue("organizationId", organizationId))
+                    .addValue("organizationId", organizationId)
+                    .addValue("compatibleCategories", Json.toJson(s.getCategories()))
+                )
                 .toArray(MapSqlParameterSource[]::new);
             var result = jdbcTemplate.batchUpdate(SubscriptionRepository.INSERT_SUBSCRIPTION_LINK, parameters);
             Validate.isTrue(Arrays.stream(result).allMatch(r -> r == 1), "Cannot link subscription");
@@ -365,14 +369,22 @@ public class EventManager {
                 Validate.isTrue(ids.size() == invalidatedTickets, "error during ticket invalidation: expected %d, got %d".formatted(ids.size(), invalidatedTickets));
             }
         }
-        if (updateSubscriptions) {
-            updateLinkedSubscriptions(em.getLinkedSubscriptions(), eventId, original.getOrganizationId());
+        if (updateSubscriptions && em.getLinkedSubscriptions() != null) {
+            var requests = toSubscriptionLinkRequests(em.getLinkedSubscriptions());
+            updateLinkedSubscriptions(requests, eventId, original.getOrganizationId());
         }
     }
 
-    public void updateLinkedSubscriptions(List<UUID> linkedSubscriptions, int eventId, int organizationId) {
+    // temporary until we support full subscription link on the admin UI
+    private static List<LinkSubscriptionsToEventRequest> toSubscriptionLinkRequests(List<UUID> subscriptionIds) {
+        return requireNonNullElse(subscriptionIds, List.<UUID>of()).stream()
+            .map(s -> new LinkSubscriptionsToEventRequest(s, List.of())).collect(Collectors.toList());
+    }
+
+    public void updateLinkedSubscriptions(List<LinkSubscriptionsToEventRequest> linkedSubscriptions, int eventId, int organizationId) {
         if(CollectionUtils.isNotEmpty(linkedSubscriptions)) {
-            int removed = subscriptionRepository.removeStaleSubscriptions(eventId, organizationId, linkedSubscriptions);
+            var descriptorIds = linkedSubscriptions.stream().map(LinkSubscriptionsToEventRequest::getDescriptorId).collect(Collectors.toList());
+            int removed = subscriptionRepository.removeStaleSubscriptions(eventId, organizationId, descriptorIds);
             log.trace("removed {} subscription links", removed);
             createSubscriptionLinks(eventId, organizationId, linkedSubscriptions);
         } else if (linkedSubscriptions != null) {
@@ -1090,6 +1102,10 @@ public class EventManager {
 
     public List<UUID> getLinkedSubscriptionIds(int eventId, int organizationId) {
         return subscriptionRepository.findLinkedSubscriptionIds(eventId, organizationId);
+    }
+
+    public List<EventSubscriptionLink> getLinkedSubscriptions(int eventId, int organizationId) {
+        return subscriptionRepository.findLinkedSubscriptions(eventId, organizationId);
     }
 
     public int getEventsCount() {

--- a/src/main/java/alfio/model/api/v1/admin/LinkedEvent.java
+++ b/src/main/java/alfio/model/api/v1/admin/LinkedEvent.java
@@ -1,0 +1,38 @@
+/**
+ * This file is part of alf.io.
+ *
+ * alf.io is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * alf.io is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with alf.io.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package alfio.model.api.v1.admin;
+
+import java.util.List;
+
+public class LinkedEvent {
+
+    private final String slug;
+    private final List<Integer> enabledCategories;
+
+    public LinkedEvent(String slug, List<Integer> enabledCategories) {
+        this.slug = slug;
+        this.enabledCategories = enabledCategories;
+    }
+
+    public String getSlug() {
+        return slug;
+    }
+
+    public List<Integer> getEnabledCategories() {
+        return enabledCategories;
+    }
+}

--- a/src/main/java/alfio/model/api/v1/admin/LinkedSubscription.java
+++ b/src/main/java/alfio/model/api/v1/admin/LinkedSubscription.java
@@ -17,14 +17,16 @@
 package alfio.model.api.v1.admin;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 
-public class LinkedSubscriptions {
+public class LinkedSubscription {
     private final String eventSlug;
-    private final List<UUID> subscriptions;
+    private final Map<UUID, List<Integer>> subscriptions;
 
-    public LinkedSubscriptions(String eventSlug, List<UUID> subscriptions) {
+    public LinkedSubscription(String eventSlug,
+                              Map<UUID, List<Integer>> subscriptions) {
         this.eventSlug = eventSlug;
         this.subscriptions = subscriptions;
     }
@@ -33,7 +35,7 @@ public class LinkedSubscriptions {
         return eventSlug;
     }
 
-    public List<UUID> getSubscriptions() {
-        return Objects.requireNonNullElse(subscriptions, List.of());
+    public Map<UUID, List<Integer>> getSubscriptions() {
+        return Objects.requireNonNullElse(subscriptions, Map.of());
     }
 }

--- a/src/main/java/alfio/model/subscription/AvailableSubscriptionsByEvent.java
+++ b/src/main/java/alfio/model/subscription/AvailableSubscriptionsByEvent.java
@@ -21,34 +21,37 @@ import alfio.util.Json;
 import ch.digitalfondue.npjt.ConstructorAnnotationRowMapper.Column;
 import com.fasterxml.jackson.core.type.TypeReference;
 
-import java.lang.reflect.Type;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 
 public class AvailableSubscriptionsByEvent {
     private final int eventId;
     private final int organizationId;
     private final UUID subscriptionId;
+    private final UUID descriptorId;
     private final String emailAddress;
     private final String firstName;
     private final String lastName;
     private final String userLanguage;
     private final String reservationEmail;
     private final List<FieldNameAndValue> additionalFields;
+    private final List<Integer> compatibleCategoryIds;
 
     public AvailableSubscriptionsByEvent(@Column("event_id") int eventId,
                                          @Column("organization_id") int organizationId,
                                          @Column("subscription_id") UUID subscriptionId,
+                                         @Column("descriptor_id") UUID descriptorId,
                                          @Column("email_address") String emailAddress,
                                          @Column("first_name") String firstName,
                                          @Column("last_name") String lastName,
                                          @Column("user_language") String userLanguage,
                                          @Column("reservation_email") String reservationEmail,
-                                         @Column("additional_fields") String additionalFieldsAsString) {
+                                         @Column("additional_fields") String additionalFieldsAsString,
+                                         @Column("compatible_categories") String compatibleCategories) {
         this.eventId = eventId;
         this.organizationId = organizationId;
         this.subscriptionId = subscriptionId;
+        this.descriptorId = descriptorId;
         this.emailAddress = emailAddress;
         this.firstName = firstName;
         this.lastName = lastName;
@@ -59,6 +62,7 @@ public class AvailableSubscriptionsByEvent {
         } else {
             this.additionalFields = List.of();
         }
+        this.compatibleCategoryIds = compatibleCategories != null ? Json.fromJson(compatibleCategories, new TypeReference<>() {}) : List.of();
     }
 
     public int getEventId() {
@@ -67,6 +71,10 @@ public class AvailableSubscriptionsByEvent {
 
     public UUID getSubscriptionId() {
         return subscriptionId;
+    }
+
+    public UUID getDescriptorId() {
+        return descriptorId;
     }
 
     public String getEmailAddress() {
@@ -95,5 +103,9 @@ public class AvailableSubscriptionsByEvent {
 
     public List<FieldNameAndValue> getAdditionalFields() {
         return additionalFields;
+    }
+
+    public List<Integer> getCompatibleCategoryIds() {
+        return compatibleCategoryIds;
     }
 }

--- a/src/main/java/alfio/model/subscription/EventSubscriptionLink.java
+++ b/src/main/java/alfio/model/subscription/EventSubscriptionLink.java
@@ -17,12 +17,16 @@
 package alfio.model.subscription;
 
 import alfio.model.support.JSONData;
+import alfio.util.Json;
 import alfio.util.MonetaryUtil;
 import ch.digitalfondue.npjt.ConstructorAnnotationRowMapper.Column;
+import com.fasterxml.jackson.core.type.TypeReference;
 import lombok.Getter;
 
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 
 @Getter
@@ -34,6 +38,7 @@ public class EventSubscriptionLink {
     private final String eventDisplayName;
     private final int pricePerTicket;
     private final String eventCurrency;
+    private final List<Integer> compatibleCategories;
 
 
     public EventSubscriptionLink(@Column("subscription_descriptor_id") UUID subscriptionDescriptorId,
@@ -42,7 +47,8 @@ public class EventSubscriptionLink {
                                  @Column("event_short_name") String eventShortName,
                                  @Column("event_display_name") String eventDisplayName,
                                  @Column("event_currency") String eventCurrency,
-                                 @Column("price_per_ticket") int pricePerTicket) {
+                                 @Column("price_per_ticket") int pricePerTicket,
+                                 @Column("compatible_categories") String compatibleCategories) {
         this.subscriptionDescriptorId = subscriptionDescriptorId;
         this.subscriptionDescriptorTitle = subscriptionDescriptorTitle;
         this.eventId = eventId;
@@ -50,6 +56,7 @@ public class EventSubscriptionLink {
         this.eventCurrency = eventCurrency;
         this.eventDisplayName = eventDisplayName;
         this.pricePerTicket = pricePerTicket;
+        this.compatibleCategories = Json.fromJson(Objects.requireNonNullElse(compatibleCategories, "[]"), new TypeReference<>() {});
     }
 
     public BigDecimal getFormattedPricePerTicket() {

--- a/src/main/java/alfio/model/subscription/LinkEventsToSubscriptionRequest.java
+++ b/src/main/java/alfio/model/subscription/LinkEventsToSubscriptionRequest.java
@@ -1,0 +1,43 @@
+/**
+ * This file is part of alf.io.
+ *
+ * alf.io is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * alf.io is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with alf.io.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package alfio.model.subscription;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Objects;
+
+public class LinkEventsToSubscriptionRequest {
+    private final String slug;
+    private final List<Integer> categories;
+
+    @JsonCreator
+    public LinkEventsToSubscriptionRequest(@JsonProperty("slug") String slug,
+                                           @JsonProperty("categories") List<Integer> categories) {
+        this.slug = slug;
+        this.categories = categories;
+    }
+
+    public String getSlug() {
+        return slug;
+    }
+
+    public List<Integer> getCategories() {
+        return Objects.requireNonNullElse(categories, List.of());
+    }
+}

--- a/src/main/java/alfio/model/subscription/LinkSubscriptionsToEventRequest.java
+++ b/src/main/java/alfio/model/subscription/LinkSubscriptionsToEventRequest.java
@@ -1,0 +1,45 @@
+/**
+ * This file is part of alf.io.
+ *
+ * alf.io is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * alf.io is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with alf.io.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package alfio.model.subscription;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+public class LinkSubscriptionsToEventRequest {
+
+    private final UUID descriptorId;
+    private final List<Integer> categories;
+
+    @JsonCreator
+    public LinkSubscriptionsToEventRequest(@JsonProperty("descriptorId") UUID descriptorId,
+                                           @JsonProperty("categories") List<Integer> categories) {
+        this.descriptorId = descriptorId;
+        this.categories = categories;
+    }
+
+    public UUID getDescriptorId() {
+        return descriptorId;
+    }
+
+    public List<Integer> getCategories() {
+        return Objects.requireNonNullElse(categories, List.of());
+    }
+}

--- a/src/main/java/alfio/repository/EventRepository.java
+++ b/src/main/java/alfio/repository/EventRepository.java
@@ -190,6 +190,9 @@ public interface EventRepository {
     @Query("select count(*) from event where org_id = :organizationId and short_name in (:eventShortNames)")
     Integer countEventsInOrganization(@Bind("organizationId") int organizationId, @Bind("eventShortNames") Collection<String> shortNames);
 
+    @Query("select * from event where org_id = :organizationId and short_name in (:eventShortNames)")
+    List<Event> findEventsByShortNames(@Bind("organizationId") int organizationId, @Bind("eventShortNames") Collection<String> shortNames);
+
     @Query(value = "update event set status = 'DISABLED' where org_id in (select org_id from j_user_organization where user_id in (:userIds)) returning id", type = QueryType.MODIFYING_WITH_RETURN)
     List<Integer> disableEventsForUsers(@Bind("userIds") Collection<Integer> userIds);
     @Query(value = "update event set status = 'DISABLED' where org_id = :orgId returning id", type = QueryType.MODIFYING_WITH_RETURN)

--- a/src/main/java/alfio/repository/SubscriptionRepository.java
+++ b/src/main/java/alfio/repository/SubscriptionRepository.java
@@ -51,7 +51,7 @@ public interface SubscriptionRepository {
 
     String INSERT_SUBSCRIPTION_LINK = """
         insert into subscription_event(event_id_fk, subscription_descriptor_id_fk, price_per_ticket, organization_id_fk, compatible_categories) \
-        values(:eventId, :subscriptionId, :pricePerTicket, :organizationId, :compatibleCategories::json) on conflict(subscription_descriptor_id_fk, event_id_fk) do update set price_per_ticket = excluded.price_per_ticket
+        values(:eventId, :subscriptionId, :pricePerTicket, :organizationId, :compatibleCategories::json) on conflict(subscription_descriptor_id_fk, event_id_fk) do update set price_per_ticket = excluded.price_per_ticket, compatible_categories = excluded.compatible_categories
         """;
 
     String INSERT_SUBSCRIPTION = """

--- a/src/main/java/alfio/repository/TicketCategoryRepository.java
+++ b/src/main/java/alfio/repository/TicketCategoryRepository.java
@@ -32,6 +32,15 @@ import java.util.stream.Collectors;
 public interface TicketCategoryRepository {
 
     String CHECK_ACTIVE = "event_id = :eventId and tc_status = 'ACTIVE'";
+    String FIND_ALL_AVAILABLE = """
+        select tc.* from ticket_category_with_currency tc
+                    join ticket_category_statistics tcs on tc.id = tcs.ticket_category_id
+                    where tc.event_id = :eventId
+                    and tcs.is_expired is FALSE
+                    and tcs.access_restricted is FALSE
+                    and (tcs.bounded is FALSE or tcs.not_sold_tickets > 0)
+                 order by tc.inception, tc.expiration, tc.id
+        """;
 
     @Query("""
             insert into ticket_category(inception, expiration, name, max_tickets, price_cts, src_price_cts, access_restricted, tc_status, event_id, bounded, category_code, valid_checkin_from, valid_checkin_to, ticket_validity_start, ticket_validity_end, ordinal, ticket_checkin_strategy, metadata, ticket_access_type) \
@@ -92,17 +101,11 @@ public interface TicketCategoryRepository {
     @Query("select * from ticket_category_with_currency where event_id = :eventId  and tc_status = 'ACTIVE' order by ordinal asc, inception asc, expiration asc, id asc")
     List<TicketCategory> findAllTicketCategories(@Bind("eventId") int eventId);
 
-    @Query("""
-        select tc.* from ticket_category_with_currency tc\
-            join ticket_category_statistics tcs on tc.id = tcs.ticket_category_id\
-            where tc.event_id = :eventId\
-            and tcs.is_expired is FALSE\
-            and tcs.access_restricted is FALSE\
-            and (tcs.bounded is FALSE or tcs.not_sold_tickets > 0)\
-         order by tc.inception, tc.expiration, tc.id\
-         limit 1\
-        """)
+    @Query(FIND_ALL_AVAILABLE + " limit 1")
     Optional<TicketCategory> findFirstWithAvailableTickets(@Bind("eventId") int eventId);
+
+    @Query(FIND_ALL_AVAILABLE)
+    List<TicketCategory> findAllWithAvailableTickets(@Bind("eventId") int eventId);
 
     default Map<Integer, TicketCategory> findByEventIdAsMap(int eventId) {
         return findAllTicketCategories(eventId).stream().collect(Collectors.toMap(TicketCategory::getId, Function.identity()));
@@ -200,4 +203,7 @@ public interface TicketCategoryRepository {
 
     @Query("select count(*) from ticket_category where event_id = :eventId and id in (:categoryIds)")
     int countCategoryForEvent(@Bind("categoryIds") Set<Integer> categoryIds, @Bind("eventId") int eventId);
+
+    @Query("select count(*) from ticket_category tc join event e on tc.event_id = e.id where e.short_name = :shortName and tc.id in (:categoryIds)")
+    int countCategoryForEvent(@Bind("categoryIds") Set<Integer> categoryIds, @Bind("shortName") String eventShortName);
 }

--- a/src/main/java/alfio/repository/TicketRepository.java
+++ b/src/main/java/alfio/repository/TicketRepository.java
@@ -491,6 +491,16 @@ public interface TicketRepository {
                                                 @Bind("subscriptionId") UUID subscriptionId,
                                                 @Bind("limit") int limit);
 
+    @Query("""
+        update ticket set subscription_id_fk = :subscriptionId from \
+         (select id from ticket where tickets_reservation_id = :reservationId and category_id in (:categories) order by final_price_cts limit :limit) t\
+         where ticket.id = t.id\
+        """)
+    int applySubscriptionToTicketsInReservation(@Bind("reservationId") String reservationId,
+                                                @Bind("subscriptionId") UUID subscriptionId,
+                                                @Bind("categories") Collection<Integer> categories,
+                                                @Bind("limit") int limit);
+
     @Query("update ticket set subscription_id_fk = null where tickets_reservation_id = :reservationId")
     int removeSubscriptionFromTicketsInReservation(@Bind("reservationId") String reservationId);
 

--- a/src/main/resources/alfio/db/PGSQL/V205_2.0.0.55__SUBSCRIPTION_LINKED_TO_CATEGORY.sql
+++ b/src/main/resources/alfio/db/PGSQL/V205_2.0.0.55__SUBSCRIPTION_LINKED_TO_CATEGORY.sql
@@ -1,0 +1,19 @@
+--
+-- This file is part of alf.io.
+--
+-- alf.io is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- alf.io is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with alf.io.  If not, see <http://www.gnu.org/licenses/>.
+--
+
+-- add support for enabling a subscription only for one or more categories.
+alter table subscription_event add column compatible_categories jsonb;

--- a/src/test/java/alfio/controller/api/v1/SubscriptionApiV1IntegrationTest.java
+++ b/src/test/java/alfio/controller/api/v1/SubscriptionApiV1IntegrationTest.java
@@ -29,6 +29,7 @@ import alfio.model.api.v1.admin.DescriptionRequest;
 import alfio.model.api.v1.admin.SubscriptionDescriptorModificationRequest;
 import alfio.model.api.v1.admin.subscription.StandardPeriodTerm;
 import alfio.model.modification.OrganizationModification;
+import alfio.model.subscription.LinkEventsToSubscriptionRequest;
 import alfio.model.subscription.SubscriptionDescriptor;
 import alfio.model.subscription.SubscriptionDescriptor.SubscriptionUsageType;
 import alfio.model.transaction.PaymentProxy;
@@ -138,10 +139,15 @@ class SubscriptionApiV1IntegrationTest {
         var response = controller.getLinkedEvents(descriptorId, principal);
         assertTrue(response.getStatusCode().is2xxSuccessful());
         assertTrue(requireNonNull(response.getBody()).isEmpty());
-        controller.updateLinkedEvents(descriptorId, List.of(eventSlug), principal);
+        controller.updateLinkedEvents(descriptorId, List.of(new LinkEventsToSubscriptionRequest(eventSlug, List.of())), principal);
         response = controller.getLinkedEvents(descriptorId, principal);
         assertTrue(response.getStatusCode().is2xxSuccessful());
-        assertEquals(List.of(eventSlug), response.getBody());
+        var body = response.getBody();
+        assertNotNull(body);
+        assertEquals(1, body.size());
+        var linkedEvent = body.get(0);
+        assertEquals(eventSlug, linkedEvent.getSlug());
+        assertTrue(linkedEvent.getEnabledCategories().isEmpty());
     }
 
 

--- a/src/test/java/alfio/controller/api/v2/user/reservation/BaseReservationFlowTest.java
+++ b/src/test/java/alfio/controller/api/v2/user/reservation/BaseReservationFlowTest.java
@@ -1586,10 +1586,8 @@ public abstract class BaseReservationFlowTest extends BaseIntegrationTest {
         assertEquals(1, reservation.getTicketsByCategory().size());
         assertEquals(numberOfTickets, reservation.getTicketsByCategory().get(0).getTickets().size());
 
-        var contactForm = new ContactAndTicketsForm();
-
         // move to overview status
-        contactForm = new ContactAndTicketsForm();
+        var contactForm = new ContactAndTicketsForm();
         contactForm.setEmail("test@test.com");
         contactForm.setBillingAddress("my billing address");
         contactForm.setFirstName("full");

--- a/src/test/java/alfio/controller/api/v2/user/reservation/BaseReservationFlowTest.java
+++ b/src/test/java/alfio/controller/api/v2/user/reservation/BaseReservationFlowTest.java
@@ -1559,14 +1559,19 @@ public abstract class BaseReservationFlowTest extends BaseIntegrationTest {
         return ticketwc;
     }
 
-    protected void testAddSubscription(ReservationFlowContext context, int numberOfTickets) {
+    protected void testAddSubscription(ReservationFlowContext context, int numberOfTickets, String categoryName) {
         var form = new ReservationForm();
         var ticketReservation = new TicketReservationModification();
         ticketReservation.setQuantity(numberOfTickets);
         var categoriesResponse = eventApiV2Controller.getTicketCategories(context.event.getShortName(), null);
         assertTrue(categoriesResponse.getStatusCode().is2xxSuccessful());
         assertNotNull(categoriesResponse.getBody());
-        ticketReservation.setTicketCategoryId(categoriesResponse.getBody().getTicketCategories().get(0).getId());
+        var categoryId = categoriesResponse.getBody().getTicketCategories().stream()
+            .filter(t -> t.getName().equals(categoryName))
+            .findFirst()
+            .orElseThrow()
+            .getId();
+        ticketReservation.setTicketCategoryId(categoryId);
         form.setReservation(Collections.singletonList(ticketReservation));
         var res = eventApiV2Controller.reserveTickets(context.event.getShortName(), "en", form, new BeanPropertyBindingResult(form, "reservation"), new ServletWebRequest(new MockHttpServletRequest(), new MockHttpServletResponse()), null);
         assertEquals(HttpStatus.OK, res.getStatusCode());

--- a/src/test/java/alfio/controller/api/v2/user/reservation/ReservationFlowWithSubscriptionIntegrationTest.java
+++ b/src/test/java/alfio/controller/api/v2/user/reservation/ReservationFlowWithSubscriptionIntegrationTest.java
@@ -210,7 +210,7 @@ class ReservationFlowWithSubscriptionIntegrationTest extends BaseReservationFlow
         var descriptorId = createSubscriptionDescriptor(event.getOrganizationId(), fileUploadManager, subscriptionManager, maxEntries);
         var descriptor = subscriptionRepository.findOne(descriptorId).orElseThrow();
         var subscriptionIdAndPin = confirmAndLinkSubscription(descriptor, event.getOrganizationId(), subscriptionRepository, ticketReservationRepository, maxEntries);
-        this.subscriptionRepository.linkSubscriptionAndEvent(descriptorId, event.getId(), 0, event.getOrganizationId());
+        this.subscriptionRepository.linkSubscriptionAndEvent(descriptorId, event.getId(), 0, event.getOrganizationId(), null);
         var linkedSubscriptions = eventManager.getLinkedSubscriptionIds(event.getId(), event.getOrganizationId());
         assertEquals(List.of(descriptorId), linkedSubscriptions);
         this.context = new ReservationFlowContext(event, owner(eventAndUser.getRight()), subscriptionIdAndPin.getLeft(), subscriptionIdAndPin.getRight());
@@ -340,7 +340,7 @@ class ReservationFlowWithSubscriptionIntegrationTest extends BaseReservationFlow
         desc.put("de", "muh description new");
 
         var descriptorId = createSubscriptionDescriptor(event.getOrganizationId(), fileUploadManager, subscriptionManager, 10);
-        this.subscriptionRepository.linkSubscriptionAndEvent(descriptorId, event.getId(), 0, event.getOrganizationId());
+        this.subscriptionRepository.linkSubscriptionAndEvent(descriptorId, event.getId(), 0, event.getOrganizationId(), null);
         int newOrgId = BaseIntegrationTest.createNewOrg(username, jdbcTemplate);
 
         EventModification em = new EventModification(event.getId(),

--- a/src/test/java/alfio/controller/api/v2/user/reservation/ReservationFlowWithSubscriptionIntegrationTest.java
+++ b/src/test/java/alfio/controller/api/v2/user/reservation/ReservationFlowWithSubscriptionIntegrationTest.java
@@ -83,6 +83,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @ActiveProfiles({Initializer.PROFILE_DEV, Initializer.PROFILE_DISABLE_JOBS, Initializer.PROFILE_INTEGRATION_TEST})
 class ReservationFlowWithSubscriptionIntegrationTest extends BaseReservationFlowTest {
 
+    public static final String DEFAULT_CATEGORY_NAME = "default";
     private final OrganizationRepository organizationRepository;
     private final UserManager userManager;
     private final SubscriptionManager subscriptionManager;
@@ -186,7 +187,7 @@ class ReservationFlowWithSubscriptionIntegrationTest extends BaseReservationFlow
     @BeforeEach
     void createContext() {
         List<TicketCategoryModification> categories = Arrays.asList(
-            new TicketCategoryModification(null, "default", TicketCategory.TicketAccessType.INHERIT, AVAILABLE_SEATS,
+            new TicketCategoryModification(null, DEFAULT_CATEGORY_NAME, TicketCategory.TicketAccessType.INHERIT, AVAILABLE_SEATS,
                 new DateTimeModification(LocalDate.now(clockProvider.getClock()).minusDays(1), LocalTime.now(clockProvider.getClock())),
                 new DateTimeModification(LocalDate.now(clockProvider.getClock()).plusDays(1), LocalTime.now(clockProvider.getClock())),
                 DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()),
@@ -228,7 +229,7 @@ class ReservationFlowWithSubscriptionIntegrationTest extends BaseReservationFlow
     @Test
     void inPersonEventWithSubscriptionUsingID() {
         var modifiedContext = new ReservationFlowContext(context.event, context.userId, context.subscriptionId, null);
-        super.testAddSubscription(modifiedContext, 1);
+        super.testAddSubscription(modifiedContext, 1, DEFAULT_CATEGORY_NAME);
         var eventInfo = eventStatisticsManager.getEventWithAdditionalInfo(context.event.getShortName(), context.userId);
         assertEquals(BigDecimal.ZERO, eventInfo.getGrossIncome());
         assertErrorWhenTransferToAnotherOrg();
@@ -236,13 +237,30 @@ class ReservationFlowWithSubscriptionIntegrationTest extends BaseReservationFlow
 
     @Test
     void inPersonEventWithSubscriptionUsingPin() {
-        super.testAddSubscription(context, 1);
+        super.testAddSubscription(context, 1, DEFAULT_CATEGORY_NAME);
+        assertErrorWhenTransferToAnotherOrg();
+    }
+
+    @Test
+    void limitSubscriptionToSpecificCategory() {
+        var newCategoryName = "new";
+        var categoryRequest = new TicketCategoryModification(null, newCategoryName, TicketCategory.TicketAccessType.INHERIT, AVAILABLE_SEATS,
+            new DateTimeModification(LocalDate.now(clockProvider.getClock()).minusDays(1), LocalTime.now(clockProvider.getClock())),
+            new DateTimeModification(LocalDate.now(clockProvider.getClock()).plusDays(1), LocalTime.now(clockProvider.getClock())),
+            DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty());
+        var categoryResult = eventManager.insertCategory(context.event, categoryRequest, context.userId);
+        assertTrue(categoryResult.isSuccess());
+        int organizationId = context.event.getOrganizationId();
+        var descriptorId = eventManager.getLinkedSubscriptionIds(context.event.getId(), organizationId).get(0);
+        // remap link
+        subscriptionRepository.linkSubscriptionAndEvent(descriptorId, context.event.getId(), 0, organizationId, List.of(categoryResult.getData()));
+        super.testAddSubscription(context, 1, newCategoryName);
         assertErrorWhenTransferToAnotherOrg();
     }
 
     @Test
     void triggerMaxSubscriptionPerEvent() {
-        super.testAddSubscription(context, 1);
+        super.testAddSubscription(context, 1, DEFAULT_CATEGORY_NAME);
         var params = Map.of("subscriptionId", context.subscriptionId, "eventId", context.event.getId());
         assertEquals(1, jdbcTemplate.queryForObject("select count(*) from tickets_reservation where subscription_id_fk = :subscriptionId and event_id_fk = :eventId", params, Integer.class));
         int ticketId = ticketRepository.findFreeByEventId(context.event.getId()).get(0).getId();
@@ -260,7 +278,7 @@ class ReservationFlowWithSubscriptionIntegrationTest extends BaseReservationFlow
     void triggerMaxUsage() {
         assertEquals(2, subscriptionRepository.findSubscriptionById(context.subscriptionId).getMaxEntries());
         jdbcTemplate.update("update subscription set max_entries = 1 where id = :id::uuid", Map.of("id", context.subscriptionId));
-        super.testAddSubscription(context, 1);
+        super.testAddSubscription(context, 1, DEFAULT_CATEGORY_NAME);
         var params = Map.of("subscriptionId", context.subscriptionId, "eventId", context.event.getId());
         assertEquals(1, jdbcTemplate.queryForObject("select count(*) from tickets_reservation where subscription_id_fk = :subscriptionId and event_id_fk = :eventId", params, Integer.class));
         int ticketId = ticketRepository.findFreeByEventId(context.event.getId()).get(0).getId();
@@ -280,7 +298,7 @@ class ReservationFlowWithSubscriptionIntegrationTest extends BaseReservationFlow
         assertEquals(2, subscriptionById.getMaxEntries());
         assertEquals(SubscriptionDescriptor.SubscriptionUsageType.ONCE_PER_EVENT, subscriptionById.getUsageType());
         jdbcTemplate.update("update subscription_descriptor set usage_type = 'UNLIMITED' where id = :id", Map.of("id", subscriptionById.getId()));
-        super.testAddSubscription(context, 2);
+        super.testAddSubscription(context, 2, DEFAULT_CATEGORY_NAME);
         assertErrorWhenTransferToAnotherOrg();
     }
 
@@ -326,7 +344,7 @@ class ReservationFlowWithSubscriptionIntegrationTest extends BaseReservationFlow
     @Test
     void testUpdateEventHeaderError() {
         List<TicketCategoryModification> categories = Collections.singletonList(
-            new TicketCategoryModification(null, "default", TicketCategory.TicketAccessType.INHERIT, 10,
+            new TicketCategoryModification(null, DEFAULT_CATEGORY_NAME, TicketCategory.TicketAccessType.INHERIT, 10,
                 new DateTimeModification(LocalDate.now(clockProvider.getClock()), LocalTime.now(clockProvider.getClock())),
                 new DateTimeModification(LocalDate.now(clockProvider.getClock()), LocalTime.now(clockProvider.getClock())),
                 DESCRIPTION, BigDecimal.TEN, false, "", false, null, null, null, null, null, 0, null, null, AlfioMetadata.empty()));

--- a/src/test/java/alfio/manager/SubscriptionManagerIntegrationTest.java
+++ b/src/test/java/alfio/manager/SubscriptionManagerIntegrationTest.java
@@ -175,7 +175,7 @@ class SubscriptionManagerIntegrationTest {
         assertEquals(1, subscriptionsWithStatistics.size());
         assertEquals(0, subscriptionsWithStatistics.get(0).getSoldCount());
 
-        assertEquals(1, subscriptionManager.linkSubscriptionToEvent(descriptor.getId(), event.getId(), orgId, 0));
+        assertEquals(1, subscriptionManager.linkSubscriptionToEvent(descriptor.getId(), event.getId(), orgId, 0, null));
         var links = subscriptionManager.getLinkedEvents(orgId, descriptor.getId());
         assertFalse(links.isEmpty());
         assertEquals(event.getId(), links.get(0).getEventId());

--- a/src/test/resources/api/descriptor.json
+++ b/src/test/resources/api/descriptor.json
@@ -444,7 +444,7 @@
             "content" : {
               "*/*" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/LinkedSubscriptions"
+                  "$ref" : "#/components/schemas/LinkedSubscription"
                 }
               }
             }
@@ -468,8 +468,7 @@
               "schema" : {
                 "type" : "array",
                 "items" : {
-                  "type" : "string",
-                  "format" : "uuid"
+                  "$ref" : "#/components/schemas/LinkSubscriptionsToEventRequest"
                 }
               }
             }
@@ -522,7 +521,7 @@
             "content" : {
               "*/*" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/LinkedSubscriptions"
+                  "$ref" : "#/components/schemas/LinkedSubscription"
                 }
               }
             }
@@ -4820,7 +4819,7 @@
                 "schema" : {
                   "type" : "array",
                   "items" : {
-                    "type" : "string"
+                    "$ref" : "#/components/schemas/LinkedEvent"
                   }
                 }
               }
@@ -4846,7 +4845,7 @@
               "schema" : {
                 "type" : "array",
                 "items" : {
-                  "type" : "string"
+                  "$ref" : "#/components/schemas/LinkEventsToSubscriptionRequest"
                 }
               }
             }
@@ -4901,7 +4900,7 @@
                 "schema" : {
                   "type" : "array",
                   "items" : {
-                    "type" : "string"
+                    "$ref" : "#/components/schemas/LinkedEvent"
                   }
                 }
               }
@@ -25944,17 +25943,36 @@
           }
         }
       },
-      "LinkedSubscriptions" : {
+      "LinkSubscriptionsToEventRequest" : {
+        "type" : "object",
+        "properties" : {
+          "descriptorId" : {
+            "type" : "string",
+            "format" : "uuid"
+          },
+          "categories" : {
+            "type" : "array",
+            "items" : {
+              "type" : "integer",
+              "format" : "int32"
+            }
+          }
+        }
+      },
+      "LinkedSubscription" : {
         "type" : "object",
         "properties" : {
           "eventSlug" : {
             "type" : "string"
           },
           "subscriptions" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string",
-              "format" : "uuid"
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "array",
+              "items" : {
+                "type" : "integer",
+                "format" : "int32"
+              }
             }
           }
         }
@@ -26085,14 +26103,14 @@
           "location" : {
             "type" : "string"
           },
+          "description" : {
+            "type" : "string"
+          },
           "arguments" : {
             "type" : "array",
             "items" : {
               "type" : "object"
             }
-          },
-          "description" : {
-            "type" : "string"
           },
           "code" : {
             "type" : "string"
@@ -26479,23 +26497,6 @@
           "refundedAmount" : {
             "type" : "string"
           },
-          "notYetPaid" : {
-            "type" : "boolean"
-          },
-          "vatExempt" : {
-            "type" : "boolean"
-          },
-          "priceInCents" : {
-            "type" : "integer",
-            "format" : "int32"
-          },
-          "ticketAmount" : {
-            "type" : "integer",
-            "format" : "int32"
-          },
-          "singleTicketOrder" : {
-            "type" : "boolean"
-          },
           "displayVat" : {
             "type" : "boolean"
           },
@@ -26510,6 +26511,23 @@
           },
           "priceBeforeTaxes" : {
             "type" : "string"
+          },
+          "singleTicketOrder" : {
+            "type" : "boolean"
+          },
+          "ticketAmount" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "notYetPaid" : {
+            "type" : "boolean"
+          },
+          "vatExempt" : {
+            "type" : "boolean"
+          },
+          "priceInCents" : {
+            "type" : "integer",
+            "format" : "int32"
           }
         }
       },
@@ -26768,14 +26786,14 @@
             "type" : "string",
             "enum" : [ "NONE", "INCLUDED", "NOT_INCLUDED", "INCLUDED_EXEMPT", "NOT_INCLUDED_EXEMPT", "CUSTOM_INCLUDED_EXEMPT", "CUSTOM_NOT_INCLUDED_EXEMPT", "INCLUDED_NOT_CHARGED", "NOT_INCLUDED_NOT_CHARGED" ]
           },
-          "discount" : {
-            "type" : "boolean"
-          },
           "taxDetail" : {
             "type" : "boolean"
           },
           "descriptionForPayment" : {
             "type" : "string"
+          },
+          "discount" : {
+            "type" : "boolean"
           }
         }
       },
@@ -26950,11 +26968,11 @@
             "type" : "string",
             "enum" : [ "INHERIT", "IN_PERSON", "ONLINE" ]
           },
-          "price" : {
-            "type" : "number"
-          },
           "free" : {
             "type" : "boolean"
+          },
+          "price" : {
+            "type" : "number"
           }
         }
       },
@@ -27199,6 +27217,10 @@
           "currencyCode" : {
             "type" : "string"
           },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "PENDING", "IN_PAYMENT", "EXTERNAL_PROCESSING_PAYMENT", "WAITING_EXTERNAL_CONFIRMATION", "OFFLINE_PAYMENT", "DEFERRED_OFFLINE_PAYMENT", "FINALIZING", "OFFLINE_FINALIZING", "COMPLETE", "STUCK", "CANCELLED", "CREDIT_NOTE_ISSUED" ]
+          },
           "stuck" : {
             "type" : "boolean"
           },
@@ -27225,9 +27247,8 @@
             "type" : "string",
             "format" : "date-time"
           },
-          "status" : {
-            "type" : "string",
-            "enum" : [ "PENDING", "IN_PAYMENT", "EXTERNAL_PROCESSING_PAYMENT", "WAITING_EXTERNAL_CONFIRMATION", "OFFLINE_PAYMENT", "DEFERRED_OFFLINE_PAYMENT", "FINALIZING", "OFFLINE_FINALIZING", "COMPLETE", "STUCK", "CANCELLED", "CREDIT_NOTE_ISSUED" ]
+          "customerReference" : {
+            "type" : "string"
           },
           "hasInvoiceNumber" : {
             "type" : "boolean"
@@ -27247,19 +27268,6 @@
           },
           "userLanguage" : {
             "type" : "string"
-          },
-          "email" : {
-            "type" : "string"
-          },
-          "vatStatus" : {
-            "type" : "string",
-            "enum" : [ "NONE", "INCLUDED", "NOT_INCLUDED", "INCLUDED_EXEMPT", "NOT_INCLUDED_EXEMPT", "CUSTOM_INCLUDED_EXEMPT", "CUSTOM_NOT_INCLUDED_EXEMPT", "INCLUDED_NOT_CHARGED", "NOT_INCLUDED_NOT_CHARGED" ]
-          },
-          "vat" : {
-            "type" : "number"
-          },
-          "discount" : {
-            "$ref" : "#/components/schemas/PromoCodeDiscount"
           },
           "srcPriceCts" : {
             "type" : "integer",
@@ -27292,6 +27300,22 @@
           "invoiceRequested" : {
             "type" : "boolean"
           },
+          "email" : {
+            "type" : "string"
+          },
+          "vatStatus" : {
+            "type" : "string",
+            "enum" : [ "NONE", "INCLUDED", "NOT_INCLUDED", "INCLUDED_EXEMPT", "NOT_INCLUDED_EXEMPT", "CUSTOM_INCLUDED_EXEMPT", "CUSTOM_NOT_INCLUDED_EXEMPT", "INCLUDED_NOT_CHARGED", "NOT_INCLUDED_NOT_CHARGED" ]
+          },
+          "vat" : {
+            "type" : "number"
+          },
+          "discount" : {
+            "$ref" : "#/components/schemas/PromoCodeDiscount"
+          },
+          "pendingOfflinePayment" : {
+            "type" : "boolean"
+          },
           "promoCodeDiscountId" : {
             "type" : "integer",
             "format" : "int32"
@@ -27302,17 +27326,11 @@
           "netPrice" : {
             "type" : "number"
           },
-          "pendingOfflinePayment" : {
-            "type" : "boolean"
-          },
           "validity" : {
             "type" : "string",
             "format" : "date-time"
           },
           "billingAddress" : {
-            "type" : "string"
-          },
-          "customerReference" : {
             "type" : "string"
           },
           "registrationTimestamp" : {
@@ -28691,6 +28709,36 @@
           }
         }
       },
+      "LinkEventsToSubscriptionRequest" : {
+        "type" : "object",
+        "properties" : {
+          "slug" : {
+            "type" : "string"
+          },
+          "categories" : {
+            "type" : "array",
+            "items" : {
+              "type" : "integer",
+              "format" : "int32"
+            }
+          }
+        }
+      },
+      "LinkedEvent" : {
+        "type" : "object",
+        "properties" : {
+          "slug" : {
+            "type" : "string"
+          },
+          "enabledCategories" : {
+            "type" : "array",
+            "items" : {
+              "type" : "integer",
+              "format" : "int32"
+            }
+          }
+        }
+      },
       "Owner" : {
         "type" : "object",
         "properties" : {
@@ -29215,15 +29263,15 @@
           "currencyCode" : {
             "type" : "string"
           },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "FREE", "PENDING", "TO_BE_PAID", "ACQUIRED", "CANCELLED", "CHECKED_IN", "EXPIRED", "INVALIDATED", "RELEASED", "PRE_RESERVED" ]
+          },
           "formattedNetPrice" : {
             "type" : "string"
           },
           "extReference" : {
             "type" : "string"
-          },
-          "status" : {
-            "type" : "string",
-            "enum" : [ "FREE", "PENDING", "TO_BE_PAID", "ACQUIRED", "CANCELLED", "CHECKED_IN", "EXPIRED", "INVALIDATED", "RELEASED", "PRE_RESERVED" ]
           },
           "tags" : {
             "type" : "array",
@@ -29255,16 +29303,6 @@
             "type" : "string",
             "format" : "uuid"
           },
-          "email" : {
-            "type" : "string"
-          },
-          "ticketsReservationId" : {
-            "type" : "string"
-          },
-          "vatStatus" : {
-            "type" : "string",
-            "enum" : [ "NONE", "INCLUDED", "NOT_INCLUDED", "INCLUDED_EXEMPT", "NOT_INCLUDED_EXEMPT", "CUSTOM_INCLUDED_EXEMPT", "CUSTOM_NOT_INCLUDED_EXEMPT", "INCLUDED_NOT_CHARGED", "NOT_INCLUDED_NOT_CHARGED" ]
-          },
           "srcPriceCts" : {
             "type" : "integer",
             "format" : "int32"
@@ -29280,6 +29318,16 @@
           "discountCts" : {
             "type" : "integer",
             "format" : "int32"
+          },
+          "email" : {
+            "type" : "string"
+          },
+          "ticketsReservationId" : {
+            "type" : "string"
+          },
+          "vatStatus" : {
+            "type" : "string",
+            "enum" : [ "NONE", "INCLUDED", "NOT_INCLUDED", "INCLUDED_EXEMPT", "NOT_INCLUDED_EXEMPT", "CUSTOM_INCLUDED_EXEMPT", "CUSTOM_NOT_INCLUDED_EXEMPT", "INCLUDED_NOT_CHARGED", "NOT_INCLUDED_NOT_CHARGED" ]
           },
           "uuid" : {
             "type" : "string"
@@ -30520,15 +30568,15 @@
           "currencyCode" : {
             "type" : "string"
           },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "FREE", "PENDING", "TO_BE_PAID", "ACQUIRED", "CANCELLED", "CHECKED_IN", "EXPIRED", "INVALIDATED", "RELEASED", "PRE_RESERVED" ]
+          },
           "formattedNetPrice" : {
             "type" : "string"
           },
           "extReference" : {
             "type" : "string"
-          },
-          "status" : {
-            "type" : "string",
-            "enum" : [ "FREE", "PENDING", "TO_BE_PAID", "ACQUIRED", "CANCELLED", "CHECKED_IN", "EXPIRED", "INVALIDATED", "RELEASED", "PRE_RESERVED" ]
           },
           "tags" : {
             "type" : "array",
@@ -30560,16 +30608,6 @@
             "type" : "string",
             "format" : "uuid"
           },
-          "email" : {
-            "type" : "string"
-          },
-          "ticketsReservationId" : {
-            "type" : "string"
-          },
-          "vatStatus" : {
-            "type" : "string",
-            "enum" : [ "NONE", "INCLUDED", "NOT_INCLUDED", "INCLUDED_EXEMPT", "NOT_INCLUDED_EXEMPT", "CUSTOM_INCLUDED_EXEMPT", "CUSTOM_NOT_INCLUDED_EXEMPT", "INCLUDED_NOT_CHARGED", "NOT_INCLUDED_NOT_CHARGED" ]
-          },
           "srcPriceCts" : {
             "type" : "integer",
             "format" : "int32"
@@ -30585,6 +30623,16 @@
           "discountCts" : {
             "type" : "integer",
             "format" : "int32"
+          },
+          "email" : {
+            "type" : "string"
+          },
+          "ticketsReservationId" : {
+            "type" : "string"
+          },
+          "vatStatus" : {
+            "type" : "string",
+            "enum" : [ "NONE", "INCLUDED", "NOT_INCLUDED", "INCLUDED_EXEMPT", "NOT_INCLUDED_EXEMPT", "CUSTOM_INCLUDED_EXEMPT", "CUSTOM_NOT_INCLUDED_EXEMPT", "INCLUDED_NOT_CHARGED", "NOT_INCLUDED_NOT_CHARGED" ]
           },
           "uuid" : {
             "type" : "string"
@@ -31500,14 +31548,14 @@
           "currency" : {
             "type" : "string"
           },
-          "formattedPrice" : {
-            "type" : "string"
-          },
           "description" : {
             "type" : "object",
             "additionalProperties" : {
               "type" : "string"
             }
+          },
+          "formattedPrice" : {
+            "type" : "string"
           },
           "title" : {
             "type" : "object",
@@ -31517,13 +31565,6 @@
           },
           "vat" : {
             "type" : "string"
-          },
-          "maxEntries" : {
-            "type" : "integer",
-            "format" : "int32"
-          },
-          "vatIncluded" : {
-            "type" : "boolean"
           },
           "termsAndConditionsUrl" : {
             "type" : "string"
@@ -31538,6 +31579,13 @@
           "validityTimeUnit" : {
             "type" : "string",
             "enum" : [ "DAYS", "MONTHS", "YEARS" ]
+          },
+          "maxEntries" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "vatIncluded" : {
+            "type" : "boolean"
           },
           "usageType" : {
             "type" : "string",
@@ -32209,11 +32257,11 @@
               "type" : "string"
             }
           },
-          "publicIdentifier" : {
-            "type" : "string"
-          },
           "free" : {
             "type" : "boolean"
+          },
+          "publicIdentifier" : {
+            "type" : "string"
           },
           "contentLanguages" : {
             "type" : "array",
@@ -32221,11 +32269,11 @@
               "$ref" : "#/components/schemas/ContentLanguage"
             }
           },
-          "regularPrice" : {
-            "type" : "number"
-          },
           "freeOfCharge" : {
             "type" : "boolean"
+          },
+          "regularPrice" : {
+            "type" : "number"
           },
           "sameDay" : {
             "type" : "boolean"
@@ -32387,14 +32435,14 @@
           "vat" : {
             "type" : "string"
           },
-          "vatIncluded" : {
-            "type" : "boolean"
-          },
           "termsAndConditionsUrl" : {
             "type" : "string"
           },
           "privacyPolicyUrl" : {
             "type" : "string"
+          },
+          "vatIncluded" : {
+            "type" : "boolean"
           },
           "free" : {
             "type" : "boolean"
@@ -32992,18 +33040,18 @@
           "currencyCode" : {
             "type" : "string"
           },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "FREE", "PENDING", "TO_BE_PAID", "ACQUIRED", "CANCELLED", "CHECKED_IN", "EXPIRED", "INVALIDATED", "RELEASED", "PRE_RESERVED" ]
+          },
+          "stuck" : {
+            "type" : "boolean"
+          },
           "formattedNetPrice" : {
             "type" : "string"
           },
           "extReference" : {
             "type" : "string"
-          },
-          "stuck" : {
-            "type" : "boolean"
-          },
-          "status" : {
-            "type" : "string",
-            "enum" : [ "FREE", "PENDING", "TO_BE_PAID", "ACQUIRED", "CANCELLED", "CHECKED_IN", "EXPIRED", "INVALIDATED", "RELEASED", "PRE_RESERVED" ]
           },
           "tags" : {
             "type" : "array",
@@ -33038,16 +33086,6 @@
             "type" : "string",
             "format" : "uuid"
           },
-          "email" : {
-            "type" : "string"
-          },
-          "ticketsReservationId" : {
-            "type" : "string"
-          },
-          "vatStatus" : {
-            "type" : "string",
-            "enum" : [ "NONE", "INCLUDED", "NOT_INCLUDED", "INCLUDED_EXEMPT", "NOT_INCLUDED_EXEMPT", "CUSTOM_INCLUDED_EXEMPT", "CUSTOM_NOT_INCLUDED_EXEMPT", "INCLUDED_NOT_CHARGED", "NOT_INCLUDED_NOT_CHARGED" ]
-          },
           "srcPriceCts" : {
             "type" : "integer",
             "format" : "int32"
@@ -33066,6 +33104,16 @@
           "discountCts" : {
             "type" : "integer",
             "format" : "int32"
+          },
+          "email" : {
+            "type" : "string"
+          },
+          "ticketsReservationId" : {
+            "type" : "string"
+          },
+          "vatStatus" : {
+            "type" : "string",
+            "enum" : [ "NONE", "INCLUDED", "NOT_INCLUDED", "INCLUDED_EXEMPT", "NOT_INCLUDED_EXEMPT", "CUSTOM_INCLUDED_EXEMPT", "CUSTOM_NOT_INCLUDED_EXEMPT", "INCLUDED_NOT_CHARGED", "NOT_INCLUDED_NOT_CHARGED" ]
           },
           "transactionTimestamp" : {
             "type" : "string",
@@ -33247,15 +33295,15 @@
           "currencyCode" : {
             "type" : "string"
           },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "FREE", "PENDING", "TO_BE_PAID", "ACQUIRED", "CANCELLED", "CHECKED_IN", "EXPIRED", "INVALIDATED", "RELEASED", "PRE_RESERVED" ]
+          },
           "formattedNetPrice" : {
             "type" : "string"
           },
           "extReference" : {
             "type" : "string"
-          },
-          "status" : {
-            "type" : "string",
-            "enum" : [ "FREE", "PENDING", "TO_BE_PAID", "ACQUIRED", "CANCELLED", "CHECKED_IN", "EXPIRED", "INVALIDATED", "RELEASED", "PRE_RESERVED" ]
           },
           "tags" : {
             "type" : "array",
@@ -33287,16 +33335,6 @@
             "type" : "string",
             "format" : "uuid"
           },
-          "email" : {
-            "type" : "string"
-          },
-          "ticketsReservationId" : {
-            "type" : "string"
-          },
-          "vatStatus" : {
-            "type" : "string",
-            "enum" : [ "NONE", "INCLUDED", "NOT_INCLUDED", "INCLUDED_EXEMPT", "NOT_INCLUDED_EXEMPT", "CUSTOM_INCLUDED_EXEMPT", "CUSTOM_NOT_INCLUDED_EXEMPT", "INCLUDED_NOT_CHARGED", "NOT_INCLUDED_NOT_CHARGED" ]
-          },
           "srcPriceCts" : {
             "type" : "integer",
             "format" : "int32"
@@ -33312,6 +33350,16 @@
           "discountCts" : {
             "type" : "integer",
             "format" : "int32"
+          },
+          "email" : {
+            "type" : "string"
+          },
+          "ticketsReservationId" : {
+            "type" : "string"
+          },
+          "vatStatus" : {
+            "type" : "string",
+            "enum" : [ "NONE", "INCLUDED", "NOT_INCLUDED", "INCLUDED_EXEMPT", "NOT_INCLUDED_EXEMPT", "CUSTOM_INCLUDED_EXEMPT", "CUSTOM_NOT_INCLUDED_EXEMPT", "INCLUDED_NOT_CHARGED", "NOT_INCLUDED_NOT_CHARGED" ]
           },
           "additionalFields" : {
             "type" : "object",
@@ -33609,11 +33657,11 @@
             "type" : "string",
             "enum" : [ "WAITING", "RETRY", "IN_PROCESS", "SENT", "ERROR" ]
           },
-          "eventId" : {
+          "organizationId" : {
             "type" : "integer",
             "format" : "int32"
           },
-          "organizationId" : {
+          "eventId" : {
             "type" : "integer",
             "format" : "int32"
           },
@@ -33708,9 +33756,6 @@
             "type" : "integer",
             "format" : "int32"
           },
-          "inputType" : {
-            "type" : "string"
-          },
           "inputField" : {
             "type" : "boolean"
           },
@@ -33749,6 +33794,9 @@
           },
           "required" : {
             "type" : "boolean"
+          },
+          "inputType" : {
+            "type" : "string"
           },
           "eventId" : {
             "type" : "integer",
@@ -33865,9 +33913,6 @@
             "type" : "integer",
             "format" : "int32"
           },
-          "inputType" : {
-            "type" : "string"
-          },
           "inputField" : {
             "type" : "boolean"
           },
@@ -33891,6 +33936,9 @@
           },
           "textField" : {
             "type" : "boolean"
+          },
+          "inputType" : {
+            "type" : "string"
           },
           "dateOfBirth" : {
             "type" : "boolean"
@@ -34003,14 +34051,14 @@
               "$ref" : "#/components/schemas/PollOptionStatistics"
             }
           },
+          "participationPercentage" : {
+            "type" : "string"
+          },
           "optionStatistics" : {
             "type" : "array",
             "items" : {
               "$ref" : "#/components/schemas/StatisticDetail"
             }
-          },
-          "participationPercentage" : {
-            "type" : "string"
           }
         }
       },
@@ -34639,6 +34687,13 @@
           "eventCurrency" : {
             "type" : "string"
           },
+          "compatibleCategories" : {
+            "type" : "array",
+            "items" : {
+              "type" : "integer",
+              "format" : "int32"
+            }
+          },
           "formattedPricePerTicket" : {
             "type" : "number"
           }
@@ -34660,11 +34715,20 @@
           "description" : {
             "type" : "string"
           },
-          "eventId" : {
+          "formattedStart" : {
+            "type" : "string"
+          },
+          "formattedEnd" : {
+            "type" : "string"
+          },
+          "formattedDiscountAmount" : {
+            "type" : "string"
+          },
+          "organizationId" : {
             "type" : "integer",
             "format" : "int32"
           },
-          "organizationId" : {
+          "eventId" : {
             "type" : "integer",
             "format" : "int32"
           },
@@ -34718,15 +34782,6 @@
           },
           "fixedAmount" : {
             "type" : "boolean"
-          },
-          "formattedStart" : {
-            "type" : "string"
-          },
-          "formattedEnd" : {
-            "type" : "string"
-          },
-          "formattedDiscountAmount" : {
-            "type" : "string"
           }
         }
       },
@@ -35036,6 +35091,9 @@
           "shortName" : {
             "type" : "string"
           },
+          "formattedEnd" : {
+            "type" : "string"
+          },
           "organizationId" : {
             "type" : "integer",
             "format" : "int32"
@@ -35065,17 +35123,14 @@
           "expired" : {
             "type" : "boolean"
           },
-          "formattedEnd" : {
-            "type" : "string"
-          },
           "warningNeeded" : {
-            "type" : "boolean"
-          },
-          "visibleForCurrentUser" : {
             "type" : "boolean"
           },
           "formattedBegin" : {
             "type" : "string"
+          },
+          "visibleForCurrentUser" : {
+            "type" : "boolean"
           },
           "displayStatistics" : {
             "type" : "boolean"


### PR DESCRIPTION
This feature will enable organizers to limit usage of a given subscription to specific ticket categories.
This will be initially possible only through API.

Sponsored by [eventplane](https://eventplane.it) 