### PR TITLE
Fix user-defined donation prices being saved with zero value

### DIFF
--- a/src/main/java/alfio/manager/AdditionalServiceManager.java
+++ b/src/main/java/alfio/manager/AdditionalServiceManager.java
@@ -239,7 +239,7 @@ public class AdditionalServiceManager {
                     .addValue("additionalServiceId", as.getId())
                     .addValue("status", AdditionalServiceItem.AdditionalServiceItemStatus.PENDING.name())
                     .addValue("id", ids.get(i))
-                    .addValue("srcPriceCts", as.getSrcPriceCts())
+                    .addValue("srcPriceCts", pc.getSrcPriceCts())
                     .addValue("finalPriceCts", unitToCents(pc.getFinalPrice(), currencyCode))
                     .addValue("vatCts", unitToCents(pc.getVAT(), currencyCode))
                     .addValue("discountCts", unitToCents(pc.getAppliedDiscount(), currencyCode))
@@ -253,7 +253,7 @@ public class AdditionalServiceManager {
                     reservationId,
                     AdditionalServiceItem.AdditionalServiceItemStatus.PENDING,
                     event,
-                    as.getSrcPriceCts(),
+                    pc.getSrcPriceCts(),
                     unitToCents(pc.getFinalPrice(), currencyCode),
                     unitToCents(pc.getVAT(), currencyCode),
                     unitToCents(pc.getAppliedDiscount(), currencyCode)

--- a/src/test/java/alfio/manager/AdditionalServiceManagerTest.java
+++ b/src/test/java/alfio/manager/AdditionalServiceManagerTest.java
@@ -1,0 +1,118 @@
+/**
+ * This file is part of alf.io.
+ *
+ * alf.io is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * alf.io is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with alf.io.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package alfio.manager;
+
+import alfio.model.AdditionalService;
+import alfio.model.Event;
+import alfio.model.PromoCodeDiscount;
+import alfio.repository.AdditionalServiceItemRepository;
+import alfio.repository.AdditionalServiceRepository;
+import alfio.repository.AdditionalServiceTextRepository;
+import alfio.repository.PurchaseContextFieldRepository;
+import alfio.repository.TicketRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.ArgumentCaptor;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+
+import static org.mockito.Mockito.*;
+
+public class AdditionalServiceManagerTest {
+    private static final String EVENT_CURRENCY = "CAD";
+
+    private AdditionalService additionalService;
+    private AdditionalServiceItemRepository additionalServiceItemRepository;
+    private AdditionalServiceRepository additionalServiceRepository;
+    private AdditionalServiceTextRepository additionalServiceTextRepository;
+    private Event event;
+    private NamedParameterJdbcTemplate jdbcTemplate;
+    private TicketRepository ticketRepository;
+    private PurchaseContextFieldRepository purchaseContextFieldRepository;
+
+    @BeforeEach
+    void init() {
+        event = mock(Event.class);
+        when(event.getCurrency()).thenReturn(EVENT_CURRENCY);
+
+        additionalService = mock(AdditionalService.class);
+        additionalServiceItemRepository = mock(AdditionalServiceItemRepository.class);
+        additionalServiceRepository = mock(AdditionalServiceRepository.class);
+        additionalServiceTextRepository = mock(AdditionalServiceTextRepository.class);
+        jdbcTemplate = mock(NamedParameterJdbcTemplate.class);
+        purchaseContextFieldRepository = mock(PurchaseContextFieldRepository.class);
+        ticketRepository = mock(TicketRepository.class);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "-1",
+        "1",
+        "5"
+    })
+    public void testNonFixedPriceCommited(int availQuantity) {
+        final PromoCodeDiscount DISCOUNT = null;
+        final String RESERVATION_ID = "7ddadb25-18e8-4c72-9727-11f0bdfdb698";
+        final int REQUESTED_QUANTITY = 1;
+        final BigDecimal AMOUNT = new BigDecimal(5.74);
+        final boolean IS_FIXED_PRICE = false;
+
+        when(additionalService.getAvailableQuantity()).thenReturn(availQuantity);
+        when(additionalService.isFixPrice()).thenReturn(IS_FIXED_PRICE);
+        when(jdbcTemplate.batchUpdate(any(), any(SqlParameterSource[].class))).thenReturn(new int[]{1});
+
+        final ArrayList<Integer> FREE_SERVICE_ITEMS = new ArrayList<>();
+        FREE_SERVICE_ITEMS.add(1);
+        when(additionalServiceItemRepository.lockExistingItems(anyInt(), anyInt())).thenReturn(FREE_SERVICE_ITEMS);
+
+        AdditionalServiceManager additionalServiceManager = new AdditionalServiceManager(
+            additionalServiceRepository,
+            additionalServiceTextRepository,
+            additionalServiceItemRepository,
+            jdbcTemplate,
+            ticketRepository,
+            purchaseContextFieldRepository
+        );
+
+        additionalServiceManager.bookAdditionalServiceItems(
+            REQUESTED_QUANTITY,
+            AMOUNT,
+            additionalService,
+            event,
+            DISCOUNT,
+            RESERVATION_ID
+        );
+
+        ArgumentCaptor<String> templateCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<SqlParameterSource[]> paramsCaptor = ArgumentCaptor.forClass(SqlParameterSource[].class);
+
+        verify(jdbcTemplate).batchUpdate(templateCaptor.capture(), paramsCaptor.capture());
+
+        SqlParameterSource[] paramList = paramsCaptor.getValue();
+        var srcPriceVal = paramList[0].getValue("srcPriceCts");
+
+        Assertions.assertEquals(paramList.length, REQUESTED_QUANTITY, "Number of Sql parameter sets should match number of services requested to book");
+
+        // Price is inserted into DB as fixed-point integer (E.g, 3.74 -> 374)
+        Assertions.assertEquals(srcPriceVal, AMOUNT.multiply(new BigDecimal("100")).intValue(), "Value of input amount should match commited srcPriceCts");
+    }
+}


### PR DESCRIPTION
Hi,

After updating my alf.io instance from `2.0-M4-2304` to `2.0-M4-2402-3` I noticed donation fields with user-defined pricing no longer work properly.

Here is an example of a ticket which costs $5.50 with an attached donation of $7.00:
![2024-06-09_01](https://github.com/alfio-event/alf.io/assets/9297219/3e8446a4-bad8-442a-8dbe-98cee7b88aa8)

When I reach the summary screen you can see the donation value in the table is $0.00:
![2024-06-09_02](https://github.com/alfio-event/alf.io/assets/9297219/441a403d-9025-464e-8c08-aca354fe6e1a)

Upon investigating I found this is being caused by the incorrect field being inserted into additional_service_item.src_price_cts. When the `event/{eventName}/reserve-tickets` endpoint is called, eventually we get to the 'AdditionalServiceManager.bookAdditionalServiceItems' method where we are inserting the additional_service_item rows to the database. For the src_price_cts column we are inserting as.getSrcPriceCts() which when the price is NOT fixed has a value of 0. When calling 'AdditionalServicePriceContainer.getSrcPriceCts' it already has it's own method of dealing with this issue by checking whether the price is fixed:
```java
    @Override
    public int getSrcPriceCts() {
        if(additionalService.isFixPrice()) {
            return additionalService.getSrcPriceCts();
        }
        return Optional.ofNullable(customAmount).map(a -> MonetaryUtil.unitToCents(a, currencyCode)).orElse(0);
    }
```

Because of this it seemed appropriate to just substitute the call to as.getSrcPriceCts() with pc.getSrcPriceCts(). If you could please let me know if this is something you would be interested in merging. I am not very familiar with the codebase but would be happy to look at implementing further required changes if necessary.

Thank you.