### PR TITLE
refactor file upload manager

### DIFF
--- a/src/main/java/alfio/manager/FileUploadManager.java
+++ b/src/main/java/alfio/manager/FileUploadManager.java
@@ -23,8 +23,6 @@ import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.RemovalCause;
 import com.github.benmanes.caffeine.cache.RemovalListener;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
@@ -43,10 +41,13 @@ import java.nio.file.Files;
 import java.time.Duration;
 import java.util.*;
 
+// FIXME: remove @Transactiona
+// FIXME: new strategy: we cache on the FS, without any in memory cache reference, ideally, a file read should not trigger a transaction in the happy path
 @Component
 @Transactional
-@RequiredArgsConstructor
 public class FileUploadManager {
+
+
 
     static final int IMAGE_THUMB_MAX_WIDTH_PX = 300;
     static final int IMAGE_THUMB_MAX_HEIGHT_PX = 200;
@@ -63,6 +64,10 @@ public class FileUploadManager {
         .removalListener(removalListener())
         .build();
 
+    public FileUploadManager(FileUploadRepository repository) {
+        this.repository = repository;
+    }
+
     private static RemovalListener<String, File> removalListener() {
         return (String key, File value, RemovalCause cause) -> {
             if (value != null) {
@@ -76,6 +81,7 @@ public class FileUploadManager {
         };
     }
 
+    @Transactional(readOnly = true)
     public Optional<FileBlobMetadata> findMetadata(String id) {
         return repository.findById(id);
     }

--- a/src/main/java/alfio/repository/FileUploadRepository.java
+++ b/src/main/java/alfio/repository/FileUploadRepository.java
@@ -40,8 +40,8 @@ import java.util.Optional;
 @QueryRepository
 public interface FileUploadRepository {
 
-    @Query("select count(id) from file_blob where id = :id")
-    Integer isPresent(@Bind("id") String id);
+    @Query("select exists (select 1 from file_blob where id = :id)")
+    boolean isPresent(@Bind("id") String id);
 
     @Query("select id, name, content_size, content_type, attributes from file_blob where id = :id")
     Optional<FileBlobMetadata> findById(@Bind("id") String id);
@@ -79,7 +79,6 @@ public interface FileUploadRepository {
     default File file(String id) {
         try {
             File cachedFile = File.createTempFile("fileupload-cache", ".tmp");
-            cachedFile.deleteOnExit();
             SqlParameterSource param = new MapSqlParameterSource("id", id);
             getNamedParameterJdbcTemplate().query("select content from file_blob where id = :id", param, rs -> {
                 try (InputStream is = rs.getBinaryStream("content"); OutputStream os = new FileOutputStream(cachedFile)) {


### PR DESCRIPTION
We know cache more aggressively, first on upload and also on "read", where we don't keep a timer of 20 minutes for the files.

Ideally the temporary directory + "alfio-blob" could also be a shared volume.