### PR TITLE
Fix logging statement

### DIFF
--- a/src/main/java/alfio/manager/NotificationManager.java
+++ b/src/main/java/alfio/manager/NotificationManager.java
@@ -167,7 +167,7 @@ public class NotificationManager {
                     TemplateProcessor.getSubscriptionDetailsModelForTicket(ticket, subscriptionRepository::findDescriptorBySubscriptionId, locale),
                     additionalServiceHelper.findForTicket(ticket, event));
             } catch (IOException e) {
-                log.warn("was not able to generate ticket pdf for ticket with id" + ticket.getId(), e);
+                log.warn("Failed to generate ticket pdf for ticket with id" + ticket.getId(), e);
             }
             return baos.toByteArray();
         };
@@ -257,7 +257,7 @@ public class NotificationManager {
             reservationEmailModel.put("event", purchaseContext);
 
             if(receipt.isEmpty()) {
-                log.warn("was not able to generate the receipt for reservation id " + reservationId + " for locale " + language);
+                log.warn("Failed to generate the receipt for reservation id " + reservationId + " for locale " + language);
             }
             return receipt.orElse(null);
         };
@@ -561,7 +561,7 @@ public class NotificationManager {
                     extensionManager,
                     purchaseContextFieldManager);
             } catch (IOException e) {
-                log.warn("was not able to generate subscription pdf for " + subscription.getId(), e);
+                log.warn("Failed to generate subscription pdf for " + subscription.getId(), e);
             }
             return baos.toByteArray();
         };


### PR DESCRIPTION
#### Description:

This is an incremental change for the logging statement.
This PR updates the logging statement within the `generateSubscriptionPDF` function to improve clarity. The new logging statement provides a more straightforward description of the error.

#### Changes:

1. **Updated Logging Statement**:
    - Changed the logging statement from:
      ```java
      log.warn("was not able to generate subscription pdf for " + subscription.getId(), e);
      ```
      to:
      ```java
      log.warn("Failed to generate subscription pdf for " + subscription.getId(), e);
      ```

same as the other two code change.
---
