### PR TITLE
Improve file handling with if-none-match

### DIFF
--- a/src/main/java/alfio/manager/FileBlobCacheManager.java
+++ b/src/main/java/alfio/manager/FileBlobCacheManager.java
@@ -51,6 +51,12 @@ public class FileBlobCacheManager {
         Assert.isTrue(childPath.startsWith(parentPath), () -> "Resource path " + childPath + "must be inside the blob path " + parentPath);
     }
 
+    public boolean fileExists(String section, String id) {
+        var resourcePath = getBlobDir(section).resolve(id);
+        checkPath(resourcePath, section);
+        return Files.exists(resourcePath);
+    }
+
     public File getFile(String section, String id, Supplier<File> supplier) {
         var resourcePath = getBlobDir(section).resolve(id);
         checkPath(resourcePath, section);

--- a/src/main/java/alfio/manager/FileUploadManager.java
+++ b/src/main/java/alfio/manager/FileUploadManager.java
@@ -64,6 +64,11 @@ public class FileUploadManager {
         return repository.findById(id);
     }
 
+    public boolean hasCached(String digest) {
+        Assert.isTrue(IS_HEX.matcher(digest).matches(), "id must be an hex value");
+        return fileBlobCacheManager.fileExists(FILE_SECTION, digest);
+    }
+
     private static final Pattern IS_HEX = Pattern.compile("^\\p{XDigit}+$");
 
     public void outputFile(String id, OutputStream out) {


### PR DESCRIPTION
if we have the cached file and the user use if-none-match, we can bypass the db connection to fetch the metadata and return NOT_MODIFIED directly.