### PR TITLE
Custom Offline Payments

### DIFF
--- a/frontend/admin/src/configuration/confirmation-dialog.ts
+++ b/frontend/admin/src/configuration/confirmation-dialog.ts
@@ -1,0 +1,60 @@
+import { html, LitElement, type TemplateResult } from "lit";
+import { customElement, property, query } from "lit/decorators.js";
+import { dialog, row } from "../styles";
+import type { SlDialog } from "@shoelace-style/shoelace";
+
+/**
+ * Basic confirm/cancel helper dialog for prompting
+ * a user to inform of a dangerous action with
+ * potential consequences.
+ */
+@customElement('confirmation-dialog')
+export class ConfirmationDialog extends LitElement {
+    static styles = [row, dialog];
+
+    @property({attribute: "dialog-title", type: String})
+    dialogTitle?: string;
+
+    @property({attribute: "dialog-description", type: String})
+    dialogDescription?: string;
+
+    @property({attribute: "confirm-text", type: String})
+    confirmText?: string;
+
+    @property({attribute: "cancel-text", type: String})
+    cancelText?: string;
+
+    @property({attribute: "confirm-variant", type: String})
+    confirmVariant?: string;
+
+    @query("sl-dialog")
+    dialog?: SlDialog;
+
+    protected render(): TemplateResult {
+        return html`
+            <sl-dialog label=${this.dialogTitle} class="dialog">
+                ${this.dialogDescription}
+                <span slot="footer">
+                    <sl-button variant=${this.confirmVariant} @click=${() => this.handleConfirmPressed()}>
+                        ${this.confirmText}
+                    </sl-button>
+                    <sl-button variant="neutral" @click=${() => this.closeDialog()}>${this.cancelText}</sl-button>
+                </span>
+            </sl-dialog>
+        `;
+    }
+
+    protected handleConfirmPressed() {
+        this.closeDialog();
+        this.dispatchEvent(new CustomEvent("confirmActionButtonPressed"));
+    }
+
+    openDialog() {
+        this.dialog?.show();
+    }
+
+    closeDialog() {
+        this.dialog?.hide();
+    }
+}
+

--- a/frontend/admin/src/configuration/offline-payment-config-block.ts
+++ b/frontend/admin/src/configuration/offline-payment-config-block.ts
@@ -68,7 +68,7 @@ export class OfflinePaymentConfigBlock extends LitElement {
                         <br/>
                         <div style="display: flex; flex-direction: row; justify-content: flex-end;">
                             <sl-icon-button
-                                style="background-color: rgb(153, 95, 13); margin-right: 5px;"
+                                style="color: #E8E0E0; background-color: rgb(153, 95, 13); margin-right: 5px;"
                                 name="pencil-square"
                                 label="Edit"
                                 @click=${() => {
@@ -78,7 +78,7 @@ export class OfflinePaymentConfigBlock extends LitElement {
                             <sl-icon-button
                                 label="Delete"
                                 name="trash"
-                                style="background-color: rgb(148, 35, 32);"
+                                style="color: #E8E0E0; background-color: rgb(148, 35, 32);"
                                 @click=${() => {
                                     this._selectedPaymentMethod = config.paymentName;
                                     this.confirmDialog?.openDialog()

--- a/frontend/admin/src/configuration/offline-payment-config-block.ts
+++ b/frontend/admin/src/configuration/offline-payment-config-block.ts
@@ -1,0 +1,193 @@
+import { customElement, property, query, state } from "lit/decorators.js";
+import { html, LitElement, type TemplateResult } from "lit";
+import { repeat } from "lit/directives/repeat.js";
+
+import type { OfflinePaymentDialog } from "./offline-payment-dialog";
+import { OrganizationConfigurationService } from "../service/configuration";
+import { dispatchFeedback } from "../model/dom-events";
+import type { ConfirmationDialog } from "./confirmation-dialog";
+
+/**
+ * Displays defined custom payment methods for org. Allows
+ * organizers to add new payment methods.
+ */
+@customElement('offline-payment-config-block')
+export class OfflinePaymentConfigBlock extends LitElement {
+    @property({attribute: "organization", type: Number})
+    organization?: number;
+
+    @query("offline-payment-dialog")
+    paymentCreationDialog?: OfflinePaymentDialog;
+    @query("confirmation-dialog")
+    confirmDialog?: ConfirmationDialog;
+
+    @state()
+    protected _selectedPaymentMethod: string | null = null;
+    @state()
+    protected _paymentConfig: CustomOfflinePayment[] = [];
+
+    configService?: OrganizationConfigurationService;
+
+    constructor() {
+        super();
+        this.updateConfigFromServer();
+    }
+
+    async updated(changedProperties: Map<string, unknown>) {
+        if(changedProperties.has("organization") && this.organization) {
+            this.configService = new OrganizationConfigurationService(this.organization);
+            await this.updateConfigFromServer();
+        }
+    }
+
+    protected render(): TemplateResult {
+        return html`
+            <div>
+                <sl-button type="button" variant="success" @click=${() => this.paymentCreationDialog?.openDialog()} size="medium">
+                    <sl-icon name="plus-circle" slot="prefix"></sl-icon>
+                    New Payment Method
+                </sl-button>
+                ${this.renderPaymentMethodDetails()}
+                <offline-payment-dialog
+                    .currentMethods=${this._paymentConfig}
+                    @offlinePaymentDialogSave=${this._saveCustomPaymentMethod}
+                />
+            </div>
+        `;
+    }
+
+    protected renderPaymentMethodDetails() {
+        return html`
+            <div>
+                ${repeat(this._paymentConfig, (config) => config.paymentName, (config) => html`
+                    <sl-details style="margin: 10px 0;" summary="${config.paymentName}">
+                        <h3>Description</h3>
+                        ${config.paymentDescription}
+                        <h3>Instructions</h3>
+                        ${config.paymentInstructions}
+                        <br/>
+                        <div style="display: flex; flex-direction: row; justify-content: flex-end;">
+                            <sl-icon-button
+                                style="background-color: rgb(153, 95, 13); margin-right: 5px;"
+                                name="pencil-square"
+                                label="Edit"
+                                @click=${() => {
+                                    this.paymentCreationDialog?.openDialog(config);
+                                }}
+                            ></sl-icon-button>
+                            <sl-icon-button
+                                label="Delete"
+                                name="trash"
+                                style="background-color: rgb(148, 35, 32);"
+                                @click=${() => {
+                                    this._selectedPaymentMethod = config.paymentName;
+                                    this.confirmDialog?.openDialog()
+                                }}
+                            ></sl-icon-button>
+                        </div>
+                    </sl-details>
+                `)}
+
+                <confirmation-dialog
+                    dialog-title="Delete Payment Method?"
+                    dialog-description="This payment method will be permanently deleted from your organization."
+                    confirm-text="Delete"
+                    cancel-text="Cancel"
+                    confirm-variant="danger"
+                    @confirmActionButtonPressed=${this._handleDeletePaymentMethod}
+                ></confirmation-dialog>
+            </div>
+        `;
+    }
+
+
+    private async _handleDeletePaymentMethod() {
+        await this.updateConfigFromServer();
+
+        const updatedPaymentMethodList = this._paymentConfig.filter(method => method.paymentName !== this._selectedPaymentMethod);
+        const submitResult = await this.configService?.updateConfigurationEntries({
+            PAYMENT_OFFLINE: [
+                {
+                    id: -1,
+                    key: "CUSTOM_OFFLINE_PAYMENTS",
+                    value: JSON.stringify(updatedPaymentMethodList),
+                }
+            ]
+        });
+
+        if (submitResult?.ok) {
+            dispatchFeedback({
+                type: "success",
+                message: "Deleted Offline Payment Method."
+            }, this);
+            this.paymentCreationDialog?.closeDialog();
+            this._paymentConfig = this._paymentConfig.filter(method => method.paymentName !== this._selectedPaymentMethod);
+            this._selectedPaymentMethod = null;
+        } else {
+            dispatchFeedback({
+                type: "danger",
+                message: "Failed to delete offline payment method."
+            }, this);
+        }
+    }
+
+    private async _saveCustomPaymentMethod(event: CustomEvent<{payment: CustomOfflinePayment, oldPayment?: CustomOfflinePayment}>) {
+        const {payment, oldPayment} = event.detail;
+
+        await this.updateConfigFromServer();
+
+        if(oldPayment) {
+            this._paymentConfig = this._paymentConfig.filter(config => config.paymentName !== oldPayment.paymentName);
+        }
+
+        this._paymentConfig = [...this._paymentConfig, {
+            paymentName: payment.paymentName,
+            paymentDescription: payment.paymentDescription,
+            paymentInstructions: payment.paymentInstructions,
+        }];
+        const submitResult = await this.configService?.updateConfigurationEntries(
+            {
+                PAYMENT_OFFLINE: [
+                    {
+                        id: -1,
+                        key: "CUSTOM_OFFLINE_PAYMENTS",
+                        value: JSON.stringify(this._paymentConfig),
+                    }
+                ]
+            }
+        );
+
+        if (submitResult?.ok) {
+            dispatchFeedback({
+                type: "success",
+                message: `${oldPayment ? "Edited" : "Created"} Offline Payment Method.`
+            }, this);
+            this.paymentCreationDialog?.closeDialog();
+        } else {
+            dispatchFeedback({
+                type: "danger",
+                message: `Failed to ${oldPayment ? "edit" : "create"} offline payment method.`
+            }, this);
+        }
+    }
+
+    async updateConfigFromServer() {
+        let curConfigStr: string | undefined;
+
+        try {
+            curConfigStr = await this.configService?.getConfigurationEntry<string>("CUSTOM_OFFLINE_PAYMENTS");
+        } catch(e) {
+            console.warn("Failed to get offline payments config from server", e);
+        }
+
+        if (!curConfigStr) {
+            return;
+        }
+
+        try {
+            this._paymentConfig = JSON.parse(curConfigStr);
+        } catch (e) {
+            console.error("Failed to parse offline payments JSON from DB:", e);
+        }
+    }
+}

--- a/frontend/admin/src/configuration/offline-payment-dialog.ts
+++ b/frontend/admin/src/configuration/offline-payment-dialog.ts
@@ -1,0 +1,247 @@
+import type { SlDialog } from "@shoelace-style/shoelace";
+import { TanStackFormController } from "@tanstack/lit-form";
+import { html, LitElement, type TemplateResult } from "lit";
+import { customElement, property, query, state } from "lit/decorators.js";
+import { dialog, form, row } from "../styles";
+import { classMap } from "lit/directives/class-map.js";
+
+/**
+ * Defines offline payment method form to be filled out
+ * by organizers.
+ */
+@customElement('offline-payment-dialog')
+export class OfflinePaymentDialog extends LitElement {
+    static styles = [row, dialog, form];
+
+    @query("sl-dialog#offlinePaymentDialog")
+    dialog?: SlDialog;
+
+    /**
+     * Used to edit the properties of an existing payment
+     * method object instead of creating a new one.
+     */
+    @state()
+    editObject?: CustomOfflinePayment;
+
+    /**
+     * The current payment methods known by the system.
+     * Used for name colision client-side validation.
+     */
+    @property({type: Array})
+    currentMethods: CustomOfflinePayment[] = [];
+
+
+    #form = new TanStackFormController(this, {
+        defaultValues: {
+            payment: {} as CustomOfflinePayment
+        }
+    });
+
+    protected render(): TemplateResult {
+        return html`
+            <div>
+                <sl-dialog
+                    label="New Payment Method"
+                    id="offlinePaymentDialog"
+                    style="--width: 50vw; --sl-font-size-large: 1.5rem;"
+                    class="dialog"
+                >
+                    ${this.renderPaymentMethodForm()}
+                </sl-dialog>
+            </div>
+        `;
+    }
+
+    renderPaymentMethodForm(): TemplateResult {
+        return html`<form
+            id="form"
+            @submit=${
+                async (e: Event) => {
+                    e.preventDefault();
+                    e.stopImmediatePropagation();
+                    await this.#form.api.handleSubmit();
+                }
+            }
+        >
+            ${this.#form.field(
+                {
+                    name: `payment.paymentName`,
+                    validators: {
+                        onChange: ({ value }: {value: string}) => {
+                            return value.length < 3 ? 'Name is too short.' : undefined;
+                        }
+                    },
+                },
+                (field) => {
+                    return html`
+                    <div>
+                        <sl-input
+                            id="paymentMethodName"
+                            class="${classMap({ error: this._hasError(field.state.meta) })}"
+                            label="Payment Method Name"
+                            required
+                            .value=${field.state.value}
+                            @sl-blur=${() => field.handleBlur()}
+                            @sl-change=${(event: InputEvent) => {
+                                if (event.currentTarget) {
+                                    const newValue = (event.currentTarget as HTMLInputElement).value;
+                                    field.handleChange(newValue);
+                                }
+                            }}
+                        >
+                        </sl-input>
+                    </div>`
+                },
+            )}
+            ${this.#form.field(
+                {
+                    name: `payment.paymentDescription`,
+                    validators: {
+                    onChange: ({ value }: {value: string}) =>
+                        value.length < 3 ? 'Description is too short' : undefined,
+                    },
+                },
+                (field) => {
+                    return html`
+                    <div>
+                        <sl-textarea
+                            label="Payment Method Description"
+                            class="${classMap({ error: this._hasError(field.state.meta) })}"
+                            required
+                            rows="2"
+                            .value=${field.state.value}
+                            @sl-blur=${() => field.handleBlur()}
+                            @sl-change=${(event: InputEvent) => {
+                                if (event.currentTarget) {
+                                    const newValue = (event.currentTarget as HTMLInputElement).value;
+                                    field.handleChange(newValue);
+                                }
+                            }}
+                        >
+                            <div slot="help-text">
+                                <alfio-display-commonmark-preview
+                                    data-button-text="preview"
+                                    .text=${field.state.value}
+                                >
+                                </alfio-display-commonmark-preview>
+                            </div>
+                        </sl-textarea>
+                    </div>`
+                },
+            )}
+            ${this.#form.field(
+                {
+                    name: `payment.paymentInstructions`,
+                    validators: {
+                    onChange: ({ value }: {value: string}) =>
+                        value.length < 3 ? 'Instructions are too short.' : undefined,
+                    },
+                },
+                (field) => {
+                    return html`
+                    <div>
+                        <sl-textarea
+                            label="Payment Method Instructions"
+                            class="${classMap({ error: this._hasError(field.state.meta) })}"
+                            required
+                            rows="2"
+                            .value=${field.state.value}
+                            @sl-blur=${() => field.handleBlur()}
+                            @sl-change=${(event: InputEvent) => {
+                                if (event.currentTarget) {
+                                    const newValue = (event.currentTarget as HTMLInputElement).value;
+                                    field.handleChange(newValue);
+                                }
+                            }}
+                        >
+                            <div slot="help-text">
+                                <alfio-display-commonmark-preview
+                                    data-button-text="preview"
+                                    .text=${field.state.value}
+                                >
+                                </alfio-display-commonmark-preview>
+                            </div>
+                        </sl-textarea>
+                    </div>`
+                },
+            )}
+            <div slot="footer">
+                <sl-divider></sl-divider>
+                <div class="row" style="--alfio-row-cols: 3">
+                    <sl-button variant="default" size="large" @click=${() => this.closeDialog()}>Close</sl-button>
+                    <div></div>
+                    <sl-button
+                        variant="success"
+                        type="submit"
+                        size="large"
+                        .disabled=${!this.#form.api.state.canSubmit}
+                    >
+                        Save
+                    </sl-button>
+                </div>
+            </div>
+        </form>
+        `;
+    }
+
+    async openDialog(editObject?: CustomOfflinePayment) {
+        this.editObject = editObject;
+
+        if(this.dialog) {
+            this.#form.api.update({
+                defaultValues: {
+                    payment: this._buildInitialFormValues(),
+                },
+                onSubmit: async (formResult) => {
+                    this.dispatchEvent(
+                        new CustomEvent("offlinePaymentDialogSave", {
+                            detail: {
+                                payment: formResult.value.payment,
+                                oldPayment: this.editObject
+                            }
+                        })
+                    )
+                },
+                validators: {
+                    onSubmitAsync: async props => {
+                        if(
+                            !this.editObject
+                            && this.currentMethods.some(method => method.paymentName === props.value.payment.paymentName)
+                        ) {
+                            return 'Chosen payment method name matches one already created for this organization. Please choose a different name';
+                        }
+
+                        return undefined;
+                    }
+                }
+            });
+            await this.dialog.show();
+        }
+    }
+
+    async closeDialog() {
+        await this.dialog?.hide();
+        this.#form.api.reset();
+    }
+
+    private _hasError(meta: any) {
+        return (meta.isTouched && meta.errors.length > 0);
+    }
+
+    private _buildInitialFormValues() : CustomOfflinePayment {
+        if(this.editObject) {
+            return {
+                paymentName: this.editObject.paymentName,
+                paymentDescription: this.editObject.paymentDescription,
+                paymentInstructions: this.editObject.paymentInstructions
+            };
+        }
+
+        return {
+            paymentName: "",
+            paymentDescription: "",
+            paymentInstructions: "",
+        }
+    }
+}
+

--- a/frontend/admin/src/configuration/types.ts
+++ b/frontend/admin/src/configuration/types.ts
@@ -1,0 +1,10 @@
+
+/**
+ * Used to identify and describe an organizer-created
+ * offline payment method.
+ */
+type CustomOfflinePayment = {
+    paymentName: string;
+    paymentDescription: string;
+    paymentInstructions: string;
+};

--- a/frontend/admin/src/main.ts
+++ b/frontend/admin/src/main.ts
@@ -10,6 +10,7 @@ import "@shoelace-style/shoelace/dist/components/format-number/format-number.js"
 import "@shoelace-style/shoelace/dist/components/divider/divider.js";
 import "@shoelace-style/shoelace/dist/components/dialog/dialog.js";
 import "@shoelace-style/shoelace/dist/components/button/button.js";
+import "@shoelace-style/shoelace/dist/components/icon-button/icon-button.js";
 import "@shoelace-style/shoelace/dist/components/tab-group/tab-group.js";
 import "@shoelace-style/shoelace/dist/components/tab/tab.js";
 import "@shoelace-style/shoelace/dist/components/tab-panel/tab-panel.js";
@@ -24,6 +25,7 @@ import '@shoelace-style/shoelace/dist/components/textarea/textarea';
 import '@shoelace-style/shoelace/dist/components/select/select';
 import '@shoelace-style/shoelace/dist/components/option/option';
 import '@shoelace-style/shoelace/dist/components/qr-code/qr-code.js';
+import '@shoelace-style/shoelace/dist/components/details/details.js';
 
 
 
@@ -40,3 +42,6 @@ export { AdditionalItemList } from './event/additional-item-list/additional-item
 export { DisplayCommonMarkPreview } from './display-common-mark-preview/display-common-mark-preview';
 export { AdditionalItemEdit } from './event/additional-item-edit/additional-item-edit';
 export { FeedbackVisualizer } from './feedback-visualizer/feedback-visualizer';
+export { OfflinePaymentConfigBlock } from './configuration/offline-payment-config-block';
+export { OfflinePaymentDialog } from './configuration/offline-payment-dialog';
+export { ConfirmationDialog } from './configuration/confirmation-dialog';

--- a/frontend/admin/src/service/configuration.ts
+++ b/frontend/admin/src/service/configuration.ts
@@ -1,8 +1,31 @@
-import { postJson } from "./helpers";
+import { fetchJson, postJson } from "./helpers";
 
 export class ConfigurationService {
 
     static update(kv: { key: string, value: string }): Promise<Response> {
         return postJson('/admin/api/configuration/update', kv);
+    }
+
+}
+
+export class OrganizationConfigurationService {
+    organizationId: number;
+
+    constructor(organizationId: number) {
+        this.organizationId = organizationId;
+    }
+
+    async getConfigurationEntry<T>(key: string): Promise<T> {
+        const result: T = await fetchJson(`/admin/api/configuration/organizations/${this.organizationId}/single/${key}`);
+        return result;
+    }
+
+    async updateConfigurationEntries(kv: {[key: string]: {id: number, key: string, value: string}[]}) {
+        const result = await postJson(`/admin/api/configuration/organizations/${this.organizationId}/update`, kv);
+        return result;
+    }
+
+    getConfiguration() {
+        fetchJson(`/admin/api/configuration/update`)
     }
 }

--- a/src/main/java/alfio/model/system/ConfigurationKeys.java
+++ b/src/main/java/alfio/model/system/ConfigurationKeys.java
@@ -150,6 +150,7 @@ public enum ConfigurationKeys {
     OFFLINE_PAYMENT_DAYS("Maximum number of days allowed to pay an offline ticket", false, SettingCategory.PAYMENT_OFFLINE, ComponentType.TEXT, false, EnumSet.of(SYSTEM, ORGANIZATION, PURCHASE_CONTEXT)),
     OFFLINE_REMINDER_HOURS("How many hours before expiration should be sent a reminder e-mail for offline payments?", false, SettingCategory.PAYMENT_OFFLINE, ComponentType.TEXT, false, EnumSet.of(SYSTEM, ORGANIZATION, PURCHASE_CONTEXT)),
 
+    CUSTOM_OFFLINE_PAYMENTS("Defines custom payment methods defined by organizers", true, SettingCategory.PAYMENT_OFFLINE, ComponentType.TEXT, false, EnumSet.of(ORGANIZATION)),
 
     ENABLE_CAPTCHA_FOR_OFFLINE_PAYMENTS("Enable captcha for offline payments / free of charge tickets (default false)", false, SettingCategory.PAYMENT_OFFLINE, ComponentType.BOOLEAN, false, EnumSet.of(SYSTEM), BooleanUtils.FALSE),
     BANK_ACCOUNT_NR("Bank Account number", false, SettingCategory.PAYMENT_OFFLINE, ComponentType.TEXT, false, EnumSet.of(SYSTEM, ORGANIZATION, PURCHASE_CONTEXT)),

--- a/src/main/webapp/alfio-admin-v1/angular-templates/admin/partials/configuration/organization.html
+++ b/src/main/webapp/alfio-admin-v1/angular-templates/admin/partials/configuration/organization.html
@@ -252,6 +252,15 @@
                     </div>
                 </div>
 
+                <div class="panel panel-default">
+                    <div class="panel-heading">
+                        <div class="panel-title"><i class="fa fa-money"></i> Custom Offline Payments</div>
+                    </div>
+                    <div class="panel-body">
+                        <offline-payment-config-block ng-attr-organization="{{organizationConf.organizationId}}"></offline-payment-config-block>
+                    </div>
+                </div>
+
                 <div class="page-header" id="SUBSCRIPTIONS">
                     <h2>Subscriptions</h2>
                 </div>


### PR DESCRIPTION
This is a work in progress PR to address issue #1415.

## High Level Goals
Add a method for organizers to configure and manage custom offline payments for their organization.

Instead of Alf.io implementing every provider possible, organizers can define the payment methods they need with custom descriptions and instructions for their users to follow to complete payments.

## Components
- [ ] **WIP** Create web component within configuration interface for organizers to perform CRUD operations on payment methods
- [x] Persist created, modified, and deleted payment methods to database using custom configuration key with a JSON value
- [ ] Modification of / Integration with: existing payment system (Providers, Proxies, Methods, etc.) to support dynamic payment methods

## Showcase
#### Creation Dialog
![2024-11-26_05](https://github.com/user-attachments/assets/44c88aac-8207-4411-abd6-90ea786c2c86)
#### Organization Payment Method List
![2024-11-26_06](https://github.com/user-attachments/assets/0402aa6a-fee5-45ce-a9b9-3288ca448834)

#### Payment Method Details
![2024-11-26_07](https://github.com/user-attachments/assets/cd421556-17f4-464c-bc7e-6f669ee842ba)
