### PR TITLE
pdf: register default font for monospace,sans-serif,serif

### DIFF
--- a/src/main/java/alfio/controller/support/TemplateProcessor.java
+++ b/src/main/java/alfio/controller/support/TemplateProcessor.java
@@ -150,6 +150,7 @@ public final class TemplateProcessor {
         builder.useProtocolsStreamImplementation(new AlfioInternalFSStreamFactory(), "alfio-internal");
         builder.useProtocolsStreamImplementation(new InvalidProtocolFSStreamFactory(), "http", "https", "file", "jar");
         builder.useFastMode();
+        builder.usePdfUaAccessibility(true);
         builder.usePdfAConformance(PdfRendererBuilder.PdfAConformance.PDFA_3_U);
 
         var parser = new Parser();

--- a/src/main/java/alfio/controller/support/TemplateProcessor.java
+++ b/src/main/java/alfio/controller/support/TemplateProcessor.java
@@ -150,16 +150,24 @@ public final class TemplateProcessor {
         builder.useProtocolsStreamImplementation(new AlfioInternalFSStreamFactory(), "alfio-internal");
         builder.useProtocolsStreamImplementation(new InvalidProtocolFSStreamFactory(), "http", "https", "file", "jar");
         builder.useFastMode();
-        builder.usePdfUaAccessbility(true);
         builder.usePdfAConformance(PdfRendererBuilder.PdfAConformance.PDFA_3_U);
 
         var parser = new Parser();
 
         builder.withW3cDocument(W3CDom.toW3CDocument(parser.parse(page)), "");
         try (PdfBoxRenderer renderer = builder.buildPdfRenderer()) {
-            File defaultFont = ImageUtil.getDejaVuSansMonoFont(fileUploadManager);
-            if (defaultFont != null) {
-                renderer.getFontResolver().addFont(defaultFont, "DejaVu Sans Mono", null, null, false, PdfBoxFontResolver.FontGroup.MAIN);
+            File monoFont = ImageUtil.getDejaVuSansMonoFont(fileUploadManager);
+            if (monoFont != null) {
+                renderer.getFontResolver().addFont(monoFont, "DejaVu Sans Mono", null, null, false, PdfBoxFontResolver.FontGroup.MAIN);
+                renderer.getFontResolver().addFont(monoFont, "Monospaced", null, null, false, PdfBoxFontResolver.FontGroup.MAIN);
+            }
+            File sansFont = ImageUtil.getDejaVuSansFont(fileUploadManager);
+            if (sansFont != null) {
+                renderer.getFontResolver().addFont(sansFont, "SansSerif", null, null, false, PdfBoxFontResolver.FontGroup.MAIN);
+            }
+            File serifFont = ImageUtil.getDejaVuSerifFont(fileUploadManager);
+            if (serifFont != null) {
+                renderer.getFontResolver().addFont(sansFont, "Serif", null, null, false, PdfBoxFontResolver.FontGroup.MAIN);
             }
             renderer.layout();
             renderer.createPDF();

--- a/src/main/java/alfio/util/ImageUtil.java
+++ b/src/main/java/alfio/util/ImageUtil.java
@@ -42,13 +42,15 @@ public final class ImageUtil {
 
     private static final Logger log = LoggerFactory.getLogger(ImageUtil.class);
 
-    private static final String DEJA_VU_SANS = "/alfio/font/DejaVuSansMono.ttf";
+    private static final String DEJA_VU_SANS_MONO = "/alfio/font/DejaVuSansMono.ttf";
+    private static final String DEJA_VU_SANS = "/alfio/font/DejaVuSans.ttf";
+    private static final String DEJA_VU_SERIF = "/alfio/font/DejaVuSerif.ttf";
     private static final String FONT_SECTION = "font";
 
-    private static File loadDejaVuFont() {
+    private static File loadDejaVuFont(String name) {
         try {
             var cachedFile = File.createTempFile("font-cache", ".tmp");
-            try (InputStream is = new ClassPathResource(DEJA_VU_SANS).getInputStream(); OutputStream tmpOs = new FileOutputStream(cachedFile)) {
+            try (InputStream is = new ClassPathResource(name).getInputStream(); OutputStream tmpOs = new FileOutputStream(cachedFile)) {
                 is.transferTo(tmpOs);
             }
             return cachedFile;
@@ -59,7 +61,15 @@ public final class ImageUtil {
     }
 
     public static File getDejaVuSansMonoFont(FileUploadManager fileUploadManager) {
-        return fileUploadManager.getFile(FONT_SECTION, "DejaVuSansMono", () -> loadDejaVuFont());
+        return fileUploadManager.getFile(FONT_SECTION, "DejaVuSansMono", () -> loadDejaVuFont(DEJA_VU_SANS_MONO));
+    }
+
+    public static File getDejaVuSansFont(FileUploadManager fileUploadManager) {
+        return fileUploadManager.getFile(FONT_SECTION, "DejaVuSans", () -> loadDejaVuFont(DEJA_VU_SANS));
+    }
+
+    public static File getDejaVuSerifFont(FileUploadManager fileUploadManager) {
+        return fileUploadManager.getFile(FONT_SECTION, "DejaVuSerif", () -> loadDejaVuFont(DEJA_VU_SERIF));
     }
 
 


### PR DESCRIPTION
By registering the default fonts, the user don't need to specify the family on the body.

This fix an issue in the receipt pdf.