### PR TITLE
Expose JoinLink and TicketMetadata to enable CUSTOM_ONLINE_JOIN_URL

### DIFF
--- a/src/main/java/alfio/extension/ScriptingExecutionService.java
+++ b/src/main/java/alfio/extension/ScriptingExecutionService.java
@@ -181,7 +181,12 @@ public class ScriptingExecutionService {
             scope.put("console", scope, new ConsoleLogger(extensionLogger));
 
             // retrocompatibility
-            scope.put("Java", scope, new JavaClassInterop(Map.of("alfio.model.CustomerName", alfio.model.CustomerName.class), scope));
+            scope.put("Java", scope, new JavaClassInterop(
+                Map.of("alfio.model.CustomerName", alfio.model.CustomerName.class,
+                    "alfio.model.metadata.TicketMetadata", alfio.model.metadata.TicketMetadata.class,
+                    "alfio.model.metadata.JoinLink", alfio.model.metadata.JoinLink.class
+                ), 
+                scope));
 
             scope.put("returnClass", scope, clazz);
 


### PR DESCRIPTION
For custom events, the CUSTOM_ONLINE_JOIN_URL event type requires returning a type of TicketMetadata which contains a type of JoinLink.  Currently the JavaClassInterop configured in ScriptingExecutionService only permits construction of type CustomerName.  This makes it impossible to satisfy the return type required for the CUSTOM_ONLINE_JOIN_URL event type.

This PR adds JoinLink and TicketMeta to the JavaClassInterop map permitting the join URL to be successfully customized.