### PR TITLE
Add reservation email to attendee exports

### DIFF
--- a/src/main/java/alfio/controller/api/admin/EventApiController.java
+++ b/src/main/java/alfio/controller/api/admin/EventApiController.java
@@ -436,7 +436,8 @@ public class EventApiController {
 
     private static final String PAYMENT_METHOD = "Payment Method";
     private static final String EXTERNAL_REFERENCE = "External Reference";
-    static final List<String> FIXED_FIELDS = Arrays.asList("ID", "Category", "Event", "Status", "OriginalPrice", "PaidPrice", "Discount", "VAT", "ReservationID", "Full Name", "First Name", "Last Name", "E-Mail", "Locked", "Language", "Confirmation", "Billing Address", "Country Code", "Promo Code","Payment ID", PAYMENT_METHOD, EXTERNAL_REFERENCE);
+    private static final String RESERVATION_EMAIL_ADDRESS = "Reservation Email address";
+    static final List<String> FIXED_FIELDS = Arrays.asList("ID", "Category", "Event", "Status", "OriginalPrice", "PaidPrice", "Discount", "VAT", "ReservationID", RESERVATION_EMAIL_ADDRESS, "Full Name", "First Name", "Last Name", "E-Mail", "Locked", "Language", "Confirmation", "Billing Address", "Country Code", "Promo Code","Payment ID", PAYMENT_METHOD, EXTERNAL_REFERENCE);
     private static final List<SerializablePair<String, String>> FIXED_PAIRS = FIXED_FIELDS.stream().map(f -> SerializablePair.of(f, f)).collect(toList());
     private static final String FISCAL_CODE = "Fiscal Code";
     private static final String REFERENCE_TYPE = "Reference Type";
@@ -499,6 +500,7 @@ public class EventApiController {
             if(fields.contains("Discount")) {line.add(MonetaryUtil.centsToUnit(t.getDiscountCts(), currencyCode).toString());}
             if(fields.contains("VAT")) {line.add(MonetaryUtil.centsToUnit(t.getVatCts(), currencyCode).toString());}
             if(fields.contains("ReservationID")) {line.add(t.getTicketsReservationId());}
+            if(fields.contains(RESERVATION_EMAIL_ADDRESS)) {line.add(reservation.getEmail());}
             if(fields.contains("Full Name")) {line.add(t.getFullName());}
             if(fields.contains("First Name")) {line.add(t.getFirstName());}
             if(fields.contains("Last Name")) {line.add(t.getLastName());}

--- a/src/main/java/alfio/controller/api/v1/admin/EventApiV1Controller.java
+++ b/src/main/java/alfio/controller/api/v1/admin/EventApiV1Controller.java
@@ -209,6 +209,7 @@ public class EventApiV1Controller {
                         return new DownloadedAttendeeData(ticket.getFirstName(),
                             ticket.getLastName(),
                             ticket.getEmail(),
+                            t.getTicketReservation().getEmail(),
                             ticket.getUserLanguage(),
                             Map.of(),
                             additional,

--- a/src/main/java/alfio/model/api/v1/admin/DownloadedAttendeeData.java
+++ b/src/main/java/alfio/model/api/v1/admin/DownloadedAttendeeData.java
@@ -27,6 +27,7 @@ public record DownloadedAttendeeData(
     @JsonProperty("firstName") String firstName,
     @JsonProperty("lastName") String lastName,
     @JsonProperty("email") String email,
+    @JsonProperty("reservationEmail") String reservationEmail,
     @JsonProperty("userLanguage") String userLanguage,
     @JsonProperty("metadata") Map<String, String> metadata,
     @JsonProperty("additional") Map<String, List<String>> additional,

--- a/src/test/java/alfio/controller/api/admin/EventApiControllerIntegrationTest.java
+++ b/src/test/java/alfio/controller/api/admin/EventApiControllerIntegrationTest.java
@@ -113,6 +113,7 @@ class EventApiControllerIntegrationTest {
     private static final String TEST_ATTENDEE_FIRST_NAME = "Attendee";
     private static final String TEST_ATTENDEE_LAST_NAME = "Test";
     private static final String TEST_ATTENDEE_EMAIL = "attendee@test.com";
+    private static final String TEST_RESERVATION_EMAIL = "integration-test@test.ch";
 
     @Test
     void getAllEventsForExternalInPerson() {
@@ -191,7 +192,7 @@ class EventApiControllerIntegrationTest {
         mockRequest.addParameter("fields", FIXED_FIELDS.toArray(new String[0]));
         MockHttpServletResponse mockResponse = new MockHttpServletResponse();
         this.eventApiController.downloadAllTicketsCSV(event.getShortName(), "csv", mockRequest, mockResponse, principal);
-        String expectedTestAttendeeCsvLine = "\""+foundTicket.getUuid()+"\""+",default,"+"\""+event.getShortName()+"\""+",ACQUIRED,0,0,0,0,"+"\""+foundTicket.getTicketsReservationId()+"\""+",\""+TEST_ATTENDEE_FIRST_NAME+" "+TEST_ATTENDEE_LAST_NAME+"\","+TEST_ATTENDEE_FIRST_NAME+","+TEST_ATTENDEE_LAST_NAME+","+TEST_ATTENDEE_EMAIL+",false,"+TEST_ATTENDEE_USER_LANGUAGE;
+        String expectedTestAttendeeCsvLine = "\""+foundTicket.getUuid()+"\""+",default,"+"\""+event.getShortName()+"\""+",ACQUIRED,0,0,0,0,"+"\""+foundTicket.getTicketsReservationId()+"\","+TEST_RESERVATION_EMAIL+",\""+TEST_ATTENDEE_FIRST_NAME+" "+TEST_ATTENDEE_LAST_NAME+"\","+TEST_ATTENDEE_FIRST_NAME+","+TEST_ATTENDEE_LAST_NAME+","+TEST_ATTENDEE_EMAIL+",false,"+TEST_ATTENDEE_USER_LANGUAGE;
         String returnedCsvContent = mockResponse.getContentAsString().trim().replace("\uFEFF", ""); // remove BOM
         assertTrue(returnedCsvContent.startsWith(getExpectedHeaderCsvLine() + "\n" + expectedTestAttendeeCsvLine));
         assertTrue(returnedCsvContent.endsWith("\"Billing Address\",,"+TEST_PROMO_CODE+",,," + TEST_ATTENDEE_EXTERNAL_REFERENCE));
@@ -315,7 +316,7 @@ class EventApiControllerIntegrationTest {
 
     private AdminReservationModification getTestAdminReservationModification() {
         DateTimeModification expiration = DateTimeModification.fromZonedDateTime(ZonedDateTime.now(ClockProvider.clock()).plusDays(1));
-        AdminReservationModification.CustomerData customerData = new AdminReservationModification.CustomerData("Integration", "Test", "integration-test@test.ch", "Billing Address", "reference", "en", "1234", "CH", null);
+        AdminReservationModification.CustomerData customerData = new AdminReservationModification.CustomerData("Integration", "Test", TEST_RESERVATION_EMAIL, "Billing Address", "reference", "en", "1234", "CH", null);
         var ticketCategoryList = this.ticketCategoryRepository.findAllTicketCategories(event.getId());
         AdminReservationModification.Category category = new AdminReservationModification.Category(ticketCategoryList.get(0).getId(), "name", new BigDecimal("100.00"), null);
         List<AdminReservationModification.TicketsInfo> ticketsInfoList = Collections.singletonList(new AdminReservationModification.TicketsInfo(category, Collections.singletonList(generateTestAttendee()), true, false));
@@ -339,6 +340,7 @@ class EventApiControllerIntegrationTest {
         expectedHeaderCsvLine = expectedHeaderCsvLine.replaceAll("Full Name", "\"Full Name\"");
         expectedHeaderCsvLine = expectedHeaderCsvLine.replaceAll("First Name", "\"First Name\"");
         expectedHeaderCsvLine = expectedHeaderCsvLine.replaceAll("Last Name", "\"Last Name\"");
+        expectedHeaderCsvLine = expectedHeaderCsvLine.replaceAll("Reservation Email address", "\"Reservation Email address\"");
         expectedHeaderCsvLine = expectedHeaderCsvLine.replaceAll("Billing Address", "\"Billing Address\"");
         expectedHeaderCsvLine = expectedHeaderCsvLine.replaceAll("Country Code", "\"Country Code\"");
         expectedHeaderCsvLine = expectedHeaderCsvLine.replaceAll("Promo Code", "\"Promo Code\"");


### PR DESCRIPTION
Fixes #1518

## Summary
- add a selectable `Reservation Email address` field to the event attendee CSV/Excel export
- populate the new export column from the ticket reservation email
- include `reservationEmail` in the v1 download-attendees payload
- update the attendee export integration-test expectation for the new column

## Verification
- `git diff --check`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home PATH=/opt/homebrew/opt/openjdk@17/bin:$PATH ./gradlew classes testClasses`

I also attempted `./gradlew test --tests alfio.controller.api.admin.EventApiControllerIntegrationTest`, but the local run could not start because Testcontainers could not find a running Docker daemon. The project compiled successfully and test classes compiled successfully.
